### PR TITLE
NPC Dialogue Trees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(bundle exec rubocop*)",
+      "Bash(bundle install*)",
+      "Bash(PARALLEL_WORKERS=1 bin/rails test*)",
+      "Bash(bin/rails test*)",
+      "Bash(bin/rails db:*)",
+      "Bash(bin/rails routes*)",
+      "Bash(mv specs/*)",
+      "Bash(mkdir -p .claude/skills/*)"
+    ]
+  }
+}

--- a/.claude/skills/build-feature/SKILL.md
+++ b/.claude/skills/build-feature/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: build-feature
+description: Full pipeline — ingest a spec, plan the implementation, implement it, and mark the PR ready for review. No human checkpoints.
+argument-hint: [spec-filename (optional)]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *)
+context: fork
+---
+
+# Build Feature (Full Pipeline)
+
+Runs the complete feature factory pipeline on a spec file:
+
+1. **Ingest** — create branch, draft PR, rename spec file
+2. **Plan** — explore codebase, write implementation plan into spec
+3. **Implement** — tests first, then code, full suite + RuboCop
+4. **Ship** — mark PR ready for review
+
+No human checkpoints. The first human touchpoint is the PR ready for review.
+
+On any failure, stop immediately and leave the repo in a clean state.
+Print what failed and what the human needs to do to unblock.
+
+> **Important:** Every shell command must be a single, simple call — no `$()`,
+> no `&&` chains. Use separate tool calls and carry values between them.
+
+---
+
+## Phase 1: Find and validate the spec
+
+If `$ARGUMENTS` names a specific file, use that.
+
+Otherwise:
+1. List all files in `specs/` using Glob.
+2. Find unprocessed files: no `pr-` prefix.
+3. If none: print "No unprocessed specs found." and stop.
+4. If exactly one: proceed.
+5. If multiple: print "Multiple unprocessed specs — pass a filename:" followed by the list, then stop.
+
+Validate the chosen spec:
+- Has a top-level `#` heading
+- Has a non-empty `## Acceptance criteria` section
+
+On failure: print what is missing and stop.
+
+---
+
+## Phase 2: Ingest
+
+Run each command as a separate tool call:
+
+1. `git checkout main`
+2. `git pull`
+3. Derive branch name: strip `.md`, replace `_` with `-`, prefix `feature/`
+4. `git checkout -b <branch-name>`
+5. `git push -u origin <branch-name>`
+6. `git commit --allow-empty -m "chore: initialize <branch-name>"`
+7. `git push`
+8. `gh pr create --draft --title "<# heading>" --body "<2-3 sentence summary>\n\nSpec: specs/pr-{number}-{filename}"`
+   Parse the PR number from the URL printed by this command — do not run another command to fetch it.
+9. Use the Edit tool to prepend `> PR: https://github.com/Fishy49/supertextadventure/pull/{number}\n\n` to the spec file
+10. `git mv specs/{filename} specs/pr-{number}-{filename}`
+11. `git add specs/`
+12. `git commit -m "chore: link spec to PR #{number}"`
+13. `git push`
+
+---
+
+## Phase 3: Plan
+
+Read each file individually using the Read tool (no shell commands for file reading):
+- The full spec file (especially `## Acceptance criteria`)
+- `app/lib/classic_game/base_handler.rb`
+- `app/lib/classic_game/command_parser.rb`
+- `app/lib/classic_game/engine.rb`
+- All files in `app/lib/classic_game/handlers/`
+- `test/support/classic_game_helper.rb`
+- All files in `test/lib/classic_game/`
+
+Use Grep to find existing code related to the feature.
+
+Write an implementation plan with these five sections:
+
+**1. Files to create** — full path + one-line purpose for each
+**2. Files to modify** — full path + specific changes (name the methods/constants)
+**3. Implementation steps** — ordered, atomic; include exact location and reasoning
+**4. Test plan** — for each acceptance criterion: test name, setup, input, expected output
+**5. Gotchas and constraints** — RuboCop rules, FakeGame methods, edge cases
+
+Use the Edit tool to append to the end of the spec file:
+```
+---
+
+## Implementation plan
+
+> Generated {date}
+
+{plan}
+```
+
+Then run each command as a separate tool call:
+1. `git add specs/`
+2. `git commit -m "chore: add implementation plan to PR #{number}"`
+3. `git push`
+
+Update the PR body:
+1. `gh pr view {number} --json body -q .body` — capture the result as `current_body`
+2. `gh pr edit {number} --body "{current_body}\n\n**Implementation plan added** — see spec file."`
+
+---
+
+## Phase 4: Implement
+
+Using only the implementation plan (no additional codebase exploration):
+
+**Tests first:**
+1. Create test file(s) per the test plan using the Write tool.
+2. `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/` — confirm tests fail.
+
+**Implement:**
+3. Work through implementation steps in order using Edit/Write tools.
+4. After each logical unit: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
+5. Do not proceed until current tests pass.
+
+**Full validation — run each as a separate tool call:**
+6. `PARALLEL_WORKERS=1 bin/rails test`
+7. `bundle exec rubocop --parallel`
+8. Fix all failures before continuing.
+
+---
+
+## Phase 5: Ship
+
+Run each command as a separate tool call:
+
+1. `git add -A`
+2. `git commit -m "feat: <feature title>"`
+3. `git push`
+4. `gh pr view {number} --json body -q .body` — capture as `current_body`
+5. `gh pr edit {number} --body "{current_body}\n\n## Summary\n\n<2-3 sentences on what was built>"`
+6. `gh pr ready {number}`
+
+Print:
+```
+✓ PR #{number} is ready for review: https://github.com/Fishy49/supertextadventure/pull/{number}
+```
+
+And the final test count.

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: implement-feature
+description: Read an ingested, planned spec file and implement the feature — tests first, then code, then mark the PR ready for review.
+argument-hint: [pr-X-spec-filename]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *)
+context: fork
+---
+
+# Implement Feature
+
+Execute the implementation plan from a spec file. Writes tests first, then
+implements, then marks the PR ready for review.
+
+**Requires a `pr-X-` prefixed spec filename with an `## Implementation plan` section.**
+
+> **Important:** Every shell command must be a single, simple call — no `$()`,
+> no `&&` chains. Use separate tool calls and carry values between them.
+
+---
+
+## Phase 1: Find the spec
+
+If `$ARGUMENTS` names a specific file, use that.
+
+Otherwise:
+1. List all files in `specs/` using Glob.
+2. Find files with a `pr-` prefix that contain `## Implementation plan` but whose PR is still a draft.
+3. If none: print "No specs ready to implement." and stop.
+4. If exactly one: proceed with it.
+5. If multiple: print "Multiple specs ready — pass a filename:" followed by the list, then stop.
+
+## Phase 2: Check preconditions
+
+1. File must have `## Implementation plan`. If not, print "Run /plan-feature first." and stop.
+2. Extract PR number from the `> PR:` line at the top of the file.
+3. Run `gh pr view {number} --json state,isDraft` — if merged or closed, print the state and stop.
+4. Derive branch name from filename: strip `pr-X-` prefix, strip `.md`, replace `_` with `-`, prefix `feature/`
+5. `git checkout <branch-name>`
+
+## Phase 3: Read the plan
+
+Read the full spec file using the Read tool. The `## Implementation plan` section is the authoritative source — do not re-explore the codebase beyond what the plan references.
+
+## Phase 4: Write tests first
+
+1. Create the test file(s) described in the plan's **Test plan** section.
+2. Follow the exact patterns in `test/lib/classic_game/handlers/` — use `ClassicGameTestHelper`, `FakeGame`, `build_world`, `build_game`, `player_state_in`.
+3. Run: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
+4. Confirm the tests **fail**. If they pass already, stop and report — something is wrong.
+
+## Phase 5: Implement
+
+Work through the **Implementation steps** from the plan in order:
+
+1. Make each change as described using the Edit or Write tools.
+2. After each logical unit of work, run: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
+3. Do not move to the next step until the current tests pass.
+
+## Phase 6: Full suite + RuboCop
+
+Once all engine tests pass, run each command as a separate tool call:
+
+1. `PARALLEL_WORKERS=1 bin/rails test`
+2. `bundle exec rubocop --parallel`
+
+Fix all failures and offenses before continuing. Do not suppress RuboCop rules unless `.rubocop.yml` already disables that cop.
+
+## Phase 7: Commit and mark ready
+
+Run each command as a separate tool call:
+
+1. `git add -A`
+2. `git commit -m "feat: <feature title from spec>"`
+3. `git push`
+4. Run `gh pr view {number} --json body -q .body` — capture the output as the current body
+5. Run `gh pr edit {number} --body "{current body}\n\n## Summary\n\n<2-3 sentences on what was implemented>"`
+   where `{current body}` is the literal text returned in step 4
+6. `gh pr ready {number}`
+
+## Output
+
+Print:
+```
+✓ PR #{number} is ready for review: https://github.com/Fishy49/supertextadventure/pull/{number}
+```
+
+Then print the test count (runs/assertions/failures/errors) from the final test run.

--- a/.claude/skills/ingest-feature/SKILL.md
+++ b/.claude/skills/ingest-feature/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: ingest-feature
+description: Ingest a feature spec from specs/, create a branch and draft PR, rename the spec file with the PR number, and add a PR link to the top of the file.
+argument-hint: [spec-filename]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *)
+context: fork
+---
+
+# Ingest Feature Spec
+
+Register a spec file in `specs/` by creating a branch, opening a draft PR,
+and linking the two together. Does not implement anything — that is a separate step.
+
+**When called with no argument:** auto-selects if exactly one unprocessed spec
+exists, otherwise fails with a list of candidates.
+**When called with a `pr-X-` prefixed file:** reports current PR state and exits.
+
+> **Important:** Every shell command must be a single, simple call — no `$()`,
+> no `&&` chains. Use separate tool calls and carry values between them.
+
+---
+
+## Phase 1: Find the spec
+
+If `$ARGUMENTS` names a specific file, use that.
+
+Otherwise:
+1. List all files in `specs/` using Glob.
+2. Identify unprocessed files: filename does NOT start with `pr-`.
+3. If none: print "No unprocessed specs found in specs/" and stop.
+4. If exactly one: proceed with it.
+5. If multiple: print "Multiple unprocessed specs found — pass a filename as an argument:" followed by the list, then stop.
+6. If `$ARGUMENTS` names a `pr-X-` file: run `gh pr view {number} --json state,isDraft,title` and report the result, then stop.
+
+## Phase 2: Validate the spec
+
+Read the spec file and verify:
+- It has a top-level `#` heading
+- It has an `## Acceptance criteria` section with content
+
+On failure: print exactly what is missing and stop. Do not create anything.
+
+## Phase 3: Set up the branch and draft PR
+
+Run each command as a separate tool call:
+
+1. `git checkout main`
+2. `git pull`
+3. Derive branch name from filename: strip `.md`, replace `_` with `-`, prefix `feature/`
+   e.g. `npc_dialogue_trees.md` → `feature/npc-dialogue-trees`
+4. `git checkout -b <branch-name>`
+5. `git push -u origin <branch-name>`
+6. `git commit --allow-empty -m "chore: initialize <branch-name>"`
+7. `git push`
+8. Run `gh pr create --draft --title "<# heading from spec>" --body "<body>"` where the body is:
+   ```
+   <2-3 sentence summary of what the feature does, written for a reviewer>
+
+   Spec: specs/pr-{number}-{original_filename}
+   ```
+   The PR URL is printed by `gh pr create` — parse the PR number from that URL directly.
+   Do not run a second command to fetch the PR number.
+
+## Phase 4: Rename the spec file and add PR link
+
+1. Use the Edit tool to prepend the following to the top of the spec file (above the `#` heading):
+   ```
+   > PR: https://github.com/Fishy49/supertextadventure/pull/{number}
+
+   ```
+2. Use the Bash tool to rename the file:
+   `git mv specs/{original_filename} specs/pr-{number}-{original_filename}`
+3. `git add specs/`
+4. `git commit -m "chore: link spec to PR #{number}"`
+5. `git push`
+
+## Output
+
+Print a single summary line:
+```
+✓ PR #{number} created: https://github.com/Fishy49/supertextadventure/pull/{number} — specs/pr-{number}-{filename}
+```

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: plan-feature
+description: Read an ingested spec file, explore the codebase, write a detailed implementation plan, and append it to the spec file and PR.
+argument-hint: [pr-X-spec-filename]
+allowed-tools: Read, Glob, Grep, Bash(git *), Bash(gh *), Edit
+context: fork
+---
+
+# Plan Feature Implementation
+
+Read an ingested spec and produce a detailed implementation plan that a
+separate agent can execute without further codebase exploration.
+
+**Requires a `pr-X-` prefixed spec filename as argument.**
+**When called with no argument:** auto-selects if exactly one ingested-but-unplanned
+spec exists, otherwise fails with a list of candidates.
+
+> **Important:** Every shell command must be a single, simple call — no `$()`,
+> no `&&` chains. Use separate tool calls and carry values between them.
+
+---
+
+## Phase 1: Find the spec
+
+If `$ARGUMENTS` names a specific file, use that.
+
+Otherwise:
+1. List all files in `specs/` using Glob.
+2. Find files with a `pr-` prefix that do NOT already contain `## Implementation plan`.
+3. If none: print "No specs awaiting a plan." and stop.
+4. If exactly one: proceed with it.
+5. If multiple: print "Multiple specs awaiting a plan — pass a filename:" followed by the list, then stop.
+
+## Phase 2: Check preconditions
+
+1. File must have a `pr-X-` prefix. If not, print "Run /ingest-feature first." and stop.
+2. Extract the PR number by reading the `> PR: ...` line at the top of the file.
+3. Run `gh pr view {number} --json state,isDraft` — if merged or closed, print the state and stop.
+4. If `## Implementation plan` already exists in the file, print "Plan already exists for PR #{number}." and stop.
+
+## Phase 3: Explore the codebase
+
+Read each file individually using the Read tool (not shell commands):
+
+- The full spec file (especially `## Acceptance criteria`)
+- `app/lib/classic_game/base_handler.rb`
+- `app/lib/classic_game/command_parser.rb`
+- `app/lib/classic_game/engine.rb`
+- All files in `app/lib/classic_game/handlers/`
+- `test/support/classic_game_helper.rb`
+- All files in `test/lib/classic_game/`
+
+Use Grep to find existing code related to the feature.
+
+## Phase 4: Write the implementation plan
+
+The plan must be detailed enough that an implementer needs **zero additional
+codebase exploration**. Include all five sections:
+
+### 1. Files to create
+Each new file: full path + one-line purpose.
+
+### 2. Files to modify
+Each changed file: full path + specific changes (name the methods/constants
+being added or changed, not just "update this file").
+
+### 3. Implementation steps
+Ordered, atomic steps. For each:
+- What to write/change
+- Exact location (file + class/method)
+- Why, if non-obvious
+
+### 4. Test plan
+For each acceptance criterion, one test case:
+- **Test name**
+- **Setup**: world hash, player state, flags, inventory
+- **Input**: the command string
+- **Expected output**: exact text or pattern to assert
+
+### 5. Gotchas and constraints
+- Patterns from existing handlers that must be followed
+- Active RuboCop rules (MethodLength max 60, double-quoted strings, etc.)
+- FakeGame methods available in tests
+- Edge cases implied by the spec but not stated
+
+## Phase 5: Append the plan to the spec file
+
+Use the Edit tool to append to the end of the spec file:
+
+```
+---
+
+## Implementation plan
+
+> Generated {date}
+
+{plan from Phase 4}
+```
+
+Then run each git command as a separate tool call:
+1. `git add specs/`
+2. `git commit -m "chore: add implementation plan to PR #{number}"`
+3. `git push`
+
+Then update the PR body:
+1. Run `gh pr view {number} --json body -q .body` — capture the output as the current body
+2. Run `gh pr edit {number} --body "{current body}\n\n**Implementation plan added** — see spec file."`
+   where `{current body}` is the literal text returned in step 1
+
+## Output
+
+Print a single summary line:
+```
+✓ Implementation plan written for PR #{number} — ready to implement.
+```
+
+Then print any open questions or ambiguities the implementer should be aware of.

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -6,7 +6,7 @@ module ClassicGame
       def handle(command)
         case command[:verb]
         when :talk
-          handle_talk(command[:target])
+          handle_talk(command[:target], command[:modifier])
         when :give
           handle_give(command[:target], command[:modifier])
         when :attack
@@ -18,23 +18,102 @@ module ClassicGame
 
       private
 
-        def handle_talk(target)
-          return failure("Talk to whom?") unless target
+        def handle_talk(target, modifier)
+          # modifier holds "npc_name" or "npc_name about topic_words"
+          raw = modifier.presence || target.presence
+          return failure("Talk to whom?") unless raw
 
-          # Find the NPC
-          npc_id, npc_def = find_npc(target)
+          # split on " about " to separate npc from topic
+          parts = raw.split(/\s+about\s+/, 2)
+          npc_input   = parts[0].strip
+          topic_input = parts[1]&.strip
+
+          npc_id, npc_def = find_npc(npc_input)
           return failure("You don't see anyone like that here.") unless npc_def
           return failure("You don't see anyone like that here.") unless npc_in_room?(npc_id)
 
-          # Get dialogue
           dialogue = npc_def["dialogue"]
           return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue
 
-          # For now, return default dialogue
-          # Future: could implement conversation trees, quest states, etc.
-          response = dialogue["default"] || "#{npc_def['name']} nods at you."
+          return handle_greeting(npc_def) unless topic_input
 
-          success("#{npc_def['name']} says: \"#{response}\"")
+          handle_topic(npc_id, npc_def, topic_input)
+        end
+
+        def handle_greeting(npc_def)
+          greeting = npc_def.dig("dialogue", "greeting") ||
+                     npc_def.dig("dialogue", "default") ||
+                     "#{npc_def['name']} nods at you."
+          npc_says(npc_def, greeting)
+        end
+
+        def handle_topic(npc_id, npc_def, topic_input)
+          dialogue = npc_def["dialogue"]
+          topics   = dialogue["topics"] || {}
+          words    = topic_input.downcase.split
+
+          matched_id, matched_def = topics.find do |_tid, tdef|
+            keywords = (tdef["keywords"] || []).map(&:downcase)
+            words.any? { |w| keywords.include?(w) }
+          end
+
+          unless matched_def
+            default_text = dialogue["default"] || "#{npc_def['name']} shrugs."
+            return npc_says(npc_def, default_text)
+          end
+
+          unless topic_unlocked?(npc_id, matched_id, matched_def, topics)
+            locked = matched_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+            return npc_says(npc_def, locked)
+          end
+
+          locked_response = locked_response_for(npc_def, matched_def, dialogue)
+          return locked_response if locked_response
+
+          game.set_flag(matched_def["sets_flag"], true) if matched_def["sets_flag"]
+          record_leads_to_unlocks(npc_id, matched_def)
+          npc_says(npc_def, matched_def["text"])
+        end
+
+        def locked_response_for(npc_def, topic_def, dialogue)
+          if (req_flag = topic_def["requires_flag"]) && !game.get_flag(req_flag)
+            locked = topic_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+            return npc_says(npc_def, locked)
+          end
+
+          if (req_item = topic_def["requires_item"]) && !item?(req_item)
+            locked = topic_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+            return npc_says(npc_def, locked)
+          end
+
+          nil
+        end
+
+        def topic_unlocked?(npc_id, topic_id, _topic_def, all_topics)
+          gated = all_topics.any? do |_tid, tdef|
+            (tdef["leads_to"] || []).include?(topic_id)
+          end
+          return true unless gated
+
+          unlocked = player_state.dig("dialogue_unlocked", npc_id) || []
+          unlocked.include?(topic_id)
+        end
+
+        def record_leads_to_unlocks(npc_id, topic_def)
+          leads_to = topic_def["leads_to"]
+          return unless leads_to&.any?
+
+          new_state = player_state.dup
+          new_state["dialogue_unlocked"] = (player_state["dialogue_unlocked"] || {}).dup
+          new_state["dialogue_unlocked"][npc_id] ||= []
+          new_state["dialogue_unlocked"][npc_id] = (
+            new_state["dialogue_unlocked"][npc_id] + leads_to
+          ).uniq
+          update_player_state(new_state)
+        end
+
+        def npc_says(npc_def, text)
+          success("#{npc_def['name']} says: \"#{text}\"")
         end
 
         def handle_give(item_target, npc_target)

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -62,7 +62,7 @@ class Game < ApplicationRecord
 
   def current_token_count
     # Approximate token count: ~4 characters per token for GPT models
-    text = messages_for_ai.map { |m| m[:content] }.join
+    text = messages_for_ai.pluck(:content).join
     (text.length / 4.0).ceil
   end
 

--- a/specs/pr-27-npc_dialogue_trees.md
+++ b/specs/pr-27-npc_dialogue_trees.md
@@ -134,3 +134,428 @@ Guard doesn't seem interested in talking.
 - NPC-initiated dialogue
 - Dialogue affecting combat
 - Items given through dialogue (use the existing `give` command instead)
+
+---
+
+## Implementation plan
+
+> Generated 2026-03-23
+
+### 1. Files to create
+
+| File | Purpose |
+|------|---------|
+| `test/lib/classic_game/handlers/interact_handler_test.rb` | Minitest suite covering all dialogue-tree acceptance criteria via FakeGame |
+
+No new production files are needed; all logic lives inside the existing `InteractHandler`.
+
+---
+
+### 2. Files to modify
+
+**`app/lib/classic_game/handlers/interact_handler.rb`**
+
+Replace the stub `handle_talk` private method (lines 21-38) with a full
+implementation. Specific methods to add/change inside the `private` section:
+
+- `handle_talk(target, modifier)` — rewrite signature + body; replaces the
+  existing stub. Parses `modifier` to extract NPC name and optional topic,
+  then delegates to `handle_greeting` or `handle_topic`.
+- `handle_greeting(npc_def)` — new method; returns `dialogue["greeting"]`
+  wrapped in the standard NPC-says format.
+- `handle_topic(npc_id, npc_def, topic_input)` — new method; matches
+  `topic_input` words against every topic's `keywords`, applies gate checks,
+  sets flags, records `leads_to` unlocks, and returns the appropriate text.
+- `topic_unlocked?(npc_id, topic_id, topic_def)` — new method; returns `true`
+  when the topic has no parent that gates it (i.e. it is not referenced by any
+  other topic's `leads_to`), OR when the player's `dialogue_unlocked` state
+  already contains it.
+- `record_leads_to_unlocks(npc_id, topic_def)` — new method; appends
+  `topic_def["leads_to"]` entries to `player_state["dialogue_unlocked"][npc_id]`
+  and calls `update_player_state`.
+- `npc_says(npc_def, text)` — new helper; returns
+  `success("#{npc_def['name']} says: \"#{text}\"")` to avoid repetition.
+
+Also update the public `handle` method's `:talk` branch to pass both
+`command[:target]` and `command[:modifier]` to `handle_talk`.
+
+**`test/support/classic_game_helper.rb`**
+No changes needed — `FakeGame#set_flag`, `FakeGame#get_flag`, and
+`build_game`/`player_state_in`/`build_world` are already sufficient.
+
+---
+
+### 3. Implementation steps
+
+#### Step 1 — Fix the `handle` dispatch for `:talk`
+
+In `ClassicGame::Handlers::InteractHandler#handle`, change:
+
+```ruby
+when :talk
+  handle_talk(command[:target])
+```
+
+to:
+
+```ruby
+when :talk
+  handle_talk(command[:target], command[:modifier])
+```
+
+**Why:** The CommandParser puts the NPC name in `command[:modifier]` (not
+`target`) for `talk to X` because it splits on the word `"to"`. For
+`"talk to innkeeper"`, `target = ""` and `modifier = "innkeeper"`. For
+`"talk to innkeeper about town"`, `modifier = "innkeeper about town"`.
+
+#### Step 2 — Rewrite `handle_talk`
+
+Replace the existing `handle_talk(target)` body with:
+
+```ruby
+def handle_talk(target, modifier)
+  # Modifier holds "npc_name" or "npc_name about topic_words"
+  raw = modifier.presence || target.presence
+  return failure("Talk to whom?") unless raw
+
+  # Split on " about " to separate npc from topic
+  parts = raw.split(/\s+about\s+/, 2)
+  npc_input  = parts[0].strip
+  topic_input = parts[1]&.strip
+
+  npc_id, npc_def = find_npc(npc_input)
+  return failure("You don't see anyone like that here.") unless npc_def
+  return failure("You don't see anyone like that here.") unless npc_in_room?(npc_id)
+
+  dialogue = npc_def["dialogue"]
+  return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue
+
+  return handle_greeting(npc_def) unless topic_input
+
+  handle_topic(npc_id, npc_def, topic_input)
+end
+```
+
+#### Step 3 — Add `handle_greeting`
+
+```ruby
+def handle_greeting(npc_def)
+  greeting = npc_def.dig("dialogue", "greeting") ||
+             npc_def.dig("dialogue", "default") ||
+             "#{npc_def['name']} nods at you."
+  npc_says(npc_def, greeting)
+end
+```
+
+#### Step 4 — Add `handle_topic`
+
+```ruby
+def handle_topic(npc_id, npc_def, topic_input)
+  dialogue = npc_def["dialogue"]
+  topics   = dialogue["topics"] || {}
+  words    = topic_input.downcase.split
+
+  # Find matching topic by keyword intersection
+  matched_id, matched_def = topics.find do |_tid, tdef|
+    keywords = (tdef["keywords"] || []).map(&:downcase)
+    words.any? { |w| keywords.include?(w) }
+  end
+
+  # No keyword match
+  unless matched_def
+    default_text = dialogue["default"] || "#{npc_def['name']} shrugs."
+    return npc_says(npc_def, default_text)
+  end
+
+  # Gate: topic only reachable via leads_to and not yet unlocked
+  unless topic_unlocked?(npc_id, matched_id, matched_def, topics)
+    locked = matched_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+    return npc_says(npc_def, locked)
+  end
+
+  # Gate: requires_flag
+  if (req_flag = matched_def["requires_flag"])
+    unless game.get_flag(req_flag)
+      locked = matched_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+      return npc_says(npc_def, locked)
+    end
+  end
+
+  # Gate: requires_item
+  if (req_item = matched_def["requires_item"])
+    unless item?(req_item)
+      locked = matched_def["locked_text"] || dialogue["default"] || "#{npc_def['name']} shrugs."
+      return npc_says(npc_def, locked)
+    end
+  end
+
+  # Success path: set flag if specified
+  game.set_flag(matched_def["sets_flag"], true) if matched_def["sets_flag"]
+
+  # Unlock any leads_to subtopics
+  record_leads_to_unlocks(npc_id, matched_def)
+
+  npc_says(npc_def, matched_def["text"])
+end
+```
+
+#### Step 5 — Add `topic_unlocked?`
+
+A topic is gated (requires unlocking via `leads_to`) if and only if some other
+topic lists it in its own `leads_to` array. If no topic references it, it is
+freely accessible.
+
+```ruby
+def topic_unlocked?(npc_id, topic_id, _topic_def, all_topics)
+  # Is this topic listed as a child in any other topic's leads_to?
+  gated = all_topics.any? do |_tid, tdef|
+    (tdef["leads_to"] || []).include?(topic_id)
+  end
+  return true unless gated
+
+  # Check player's session-level unlocks
+  unlocked = player_state.dig("dialogue_unlocked", npc_id) || []
+  unlocked.include?(topic_id)
+end
+```
+
+#### Step 6 — Add `record_leads_to_unlocks`
+
+```ruby
+def record_leads_to_unlocks(npc_id, topic_def)
+  leads_to = topic_def["leads_to"]
+  return unless leads_to&.any?
+
+  new_state = player_state.dup
+  new_state["dialogue_unlocked"] ||= {}
+  new_state["dialogue_unlocked"][npc_id] ||= []
+  new_state["dialogue_unlocked"][npc_id] = (
+    new_state["dialogue_unlocked"][npc_id] + leads_to
+  ).uniq
+  update_player_state(new_state)
+end
+```
+
+#### Step 7 — Add `npc_says` helper
+
+```ruby
+def npc_says(npc_def, text)
+  success("#{npc_def['name']} says: \"#{text}\"")
+end
+```
+
+#### Step 8 — Create the test file
+
+Create `test/lib/classic_game/handlers/interact_handler_test.rb` with all test
+cases described in the test plan below (section 4). Mirror the structure of
+`combat_handler_test.rb`: `include ClassicGameTestHelper`, define `USER_ID = 1`,
+a `setup` block building a world with the innkeeper NPC from the spec, a private
+`execute(input)` helper, and tests grouped by feature with banner comments.
+
+---
+
+### 4. Test plan
+
+Shared setup world for all tests (define in `setup`):
+
+```ruby
+INNKEEPER_NPC = {
+  "name"     => "Innkeeper",
+  "keywords" => ["innkeeper"],
+  "dialogue" => {
+    "greeting" => "Welcome, traveller. What brings you to these parts?",
+    "default"  => "I wouldn't know anything about that.",
+    "topics"   => {
+      "town" => {
+        "keywords" => ["town", "village", "quiet"],
+        "text"     => "The town's been quiet since the mine closed. Folk are scared.",
+        "leads_to" => ["mine"]
+      },
+      "mine" => {
+        "keywords"    => ["mine", "collapse", "closed"],
+        "text"        => "Nobody's been down there since the collapse.",
+        "locked_text" => "I'm not sure what you mean."
+      },
+      "work" => {
+        "keywords"  => ["work", "job", "help"],
+        "text"      => "I need someone to clear the rats from my cellar.",
+        "sets_flag" => "rat_quest_started"
+      },
+      "reward" => {
+        "keywords"      => ["reward", "payment", "done"],
+        "requires_flag" => "rats_cleared",
+        "text"          => "You did it! Here's what I promised.",
+        "locked_text"   => "Bring me proof the rats are gone first."
+      },
+      "appraisal" => {
+        "keywords"      => ["appraise", "appraisal", "worth"],
+        "requires_item" => "sword",
+        "text"          => "Fine craftsmanship. That blade is worth 50 gold.",
+        "locked_text"   => "Bring me something worth appraising."
+      }
+    }
+  }
+}.freeze
+
+SILENT_GUARD = {
+  "name"     => "Guard",
+  "keywords" => ["guard"]
+  # no "dialogue" key
+}.freeze
+```
+
+World: one room `"tavern"` with `npcs: ["innkeeper", "guard"]`.
+
+---
+
+**Test: greeting with no topic**
+- **Test name:** `"talk to npc with no topic returns greeting"`
+- **Setup:** default world, player in "tavern", no flags/inventory
+- **Input:** `"talk to innkeeper"`
+- **Expected:** `result[:success]` is true; `result[:response]` includes `"Welcome, traveller"`
+
+**Test: greeting with no topic — response format**
+- **Test name:** `"talk response wraps text in npc-says format"`
+- **Input:** `"talk to innkeeper"`
+- **Expected:** `result[:response]` matches `'Innkeeper says: "'`
+
+**Test: topic matched by keyword**
+- **Test name:** `"talk about topic matches by keyword"`
+- **Input:** `"talk to innkeeper about town"`
+- **Expected:** `result[:success]` true; response includes `"mine closed"`
+
+**Test: topic matched by alternate keyword**
+- **Test name:** `"talk about topic matches alternate keyword in topic"`
+- **Input:** `"talk to innkeeper about village"`
+- **Expected:** response includes `"mine closed"` (same town topic matched by `"village"`)
+
+**Test: leads_to — blocked before parent**
+- **Test name:** `"subtopic locked before parent topic accessed"`
+- **Setup:** no prior dialogue; player has not talked about town
+- **Input:** `"talk to innkeeper about mine"`
+- **Expected:** `result[:success]` true; response includes `"I'm not sure what you mean"`
+
+**Test: leads_to — unlocked after parent**
+- **Test name:** `"subtopic accessible after parent topic accessed"`
+- **Setup:** execute `"talk to innkeeper about town"` first (which records leads_to), then:
+- **Input:** `"talk to innkeeper about mine"`
+- **Expected:** response includes `"Nobody's been down there"`
+
+**Test: leads_to records unlock in player state**
+- **Test name:** `"accessing parent topic records subtopic in player dialogue_unlocked"`
+- **Input:** `"talk to innkeeper about town"`
+- **Expected:** `game.player_state(USER_ID).dig("dialogue_unlocked", "innkeeper")` includes `"mine"`
+
+**Test: requires_flag — locked**
+- **Test name:** `"topic with requires_flag returns locked_text when flag not set"`
+- **Setup:** no flags set
+- **Input:** `"talk to innkeeper about reward"`
+- **Expected:** response includes `"Bring me proof"`
+
+**Test: requires_flag — unlocked**
+- **Test name:** `"topic with requires_flag returns text when flag is set"`
+- **Setup:** `game.set_flag("rats_cleared", true)` before executing
+- **Input:** `"talk to innkeeper about reward"`
+- **Expected:** response includes `"You did it"`
+
+**Test: requires_item — locked**
+- **Test name:** `"topic with requires_item returns locked_text when item not in inventory"`
+- **Setup:** player inventory = `[]`
+- **Input:** `"talk to innkeeper about appraisal"`
+- **Expected:** response includes `"Bring me something worth appraising"`
+
+**Test: requires_item — unlocked**
+- **Test name:** `"topic with requires_item returns text when item in inventory"`
+- **Setup:** player inventory = `["sword"]`; sword defined in world items
+- **Input:** `"talk to innkeeper about appraisal"`
+- **Expected:** response includes `"Fine craftsmanship"`
+
+**Test: sets_flag**
+- **Test name:** `"accessing topic with sets_flag sets the flag"`
+- **Input:** `"talk to innkeeper about work"`
+- **Expected:** `game.get_flag("rat_quest_started")` is truthy after call
+
+**Test: no keyword match returns default**
+- **Test name:** `"talk about unrecognized topic returns default response"`
+- **Input:** `"talk to innkeeper about dragons"`
+- **Expected:** `result[:success]` true; response includes `"I wouldn't know anything about that"`
+
+**Test: NPC has no dialogue**
+- **Test name:** `"talk to npc with no dialogue returns not interested message"`
+- **Input:** `"talk to guard"`
+- **Expected:** `result[:success]` false; response includes `"Guard doesn't seem interested in talking"`
+
+**Test: NPC has dialogue but no topics — greeting only**
+- **Test name:** `"talk to npc with dialogue but no topics returns greeting"`
+- **Setup:** add NPC `"shopkeeper"` to world with `dialogue: { "greeting" => "Hello there." }` and no `topics` key; place in room
+- **Input:** `"talk to shopkeeper"`
+- **Expected:** response includes `"Hello there."`
+
+**Test: NPC not in room**
+- **Test name:** `"talk to npc not in current room fails"`
+- **Setup:** innkeeper not in `current_room_state["npcs"]`
+- **Input:** `"talk to innkeeper"`
+- **Expected:** `result[:success]` false; response includes `"don't see anyone"`
+
+**Test: no target**
+- **Test name:** `"talk with no target fails"`
+- **Input:** `"talk"`
+- **Expected:** `result[:success]` false; response includes `"whom"`
+
+---
+
+### 5. Gotchas and constraints
+
+**CommandParser target/modifier split for `talk`:**
+`"talk to innkeeper"` → `target: ""`, `modifier: "innkeeper"`.
+`"talk to innkeeper about town"` → `target: ""`, `modifier: "innkeeper about town"`.
+`"talk innkeeper"` (no "to") → `target: "innkeeper"`, `modifier: nil`.
+The handler must merge `modifier.presence || target.presence` before splitting on `" about "`.
+
+**`leads_to` gating is session-scoped, not global:**
+The spec says persistent per-NPC conversation state is out of scope, but the
+`leads_to` requirement IS in scope. Store unlocks in
+`player_state["dialogue_unlocked"][npc_id]` (a plain array of topic IDs). This
+is per-user, per-game-session, and is reset when the game restarts (because
+`game_state["player_states"]` is cleared on restart in `engine.rb`).
+
+**`sets_flag` uses `game.set_flag`, not player_state flags:**
+All flag operations in the codebase (`item_handler.rb`, `interact_handler.rb`
+give handler, `movement_handler.rb`) use `game.set_flag` / `game.get_flag`,
+which writes to `game_state["global_flags"]`. Do NOT write into
+`player_state["flags"]` — the `requires_flag` gate must use `game.get_flag`.
+
+**RuboCop MethodLength (max 60 lines):**
+`handle_topic` is the longest method; keep each branch terse. Extract the
+three lock-check branches into a single `locked_response_for(npc_def, topic_def, dialogue)` helper if needed to stay under 60 lines.
+
+**Double-quoted strings:**
+All string literals in production Ruby files in this repo use double quotes
+(RuboCop enforces `Style/StringLiterals: double_quotes`). Do not use single-quoted
+strings in the handler file.
+
+**`success` / `failure` return shape:**
+`success(message)` returns `{ success: true, response: message, state_changes: {} }`.
+`failure(message)` returns `{ success: false, response: message, state_changes: {} }`.
+The dialogue handler returns `success` for all dialogue outputs (including
+locked/default), per the spec examples — only "NPC has no dialogue" and guard
+clauses (NPC not found, no target) return `failure`.
+
+**`find_npc` is fuzzy but not room-scoped:**
+`find_npc` searches the entire world `npcs` hash. The separate `npc_in_room?`
+check is required to confirm presence. Always check both (as the existing stub
+already does).
+
+**Topic keyword matching — case:**
+`topic_input` arrives already downcased (CommandParser normalizes to lowercase).
+Topic keywords in world data may be any case; downcase them before comparing.
+
+**`player_state.dup` is shallow:**
+When mutating nested hashes (e.g. `dialogue_unlocked`), do a deep enough dup:
+`new_state["dialogue_unlocked"] = player_state["dialogue_unlocked"].dup || {}` before
+modifying, to avoid mutating the cached `@player_state` in-place.
+
+**`topic_unlocked?` signature change:**
+The `all_topics` parameter is needed to check whether any topic references
+`topic_id` in its `leads_to`. Pass `topics` (local variable in `handle_topic`)
+as the fourth argument; do not call `npc_def.dig(...)` again inside the method.

--- a/specs/pr-27-npc_dialogue_trees.md
+++ b/specs/pr-27-npc_dialogue_trees.md
@@ -1,0 +1,136 @@
+> PR: https://github.com/Fishy49/supertextadventure/pull/27
+
+# NPC Dialogue Trees
+
+Players can have free-text conversations with NPCs that branch based on
+topic, and optionally on world state (flags/inventory).
+
+---
+
+## Player-facing behaviour
+
+### Talk with no topic — shows greeting
+```
+> talk to innkeeper
+Innkeeper says: "Welcome, traveller. What brings you to these parts?"
+```
+
+### Talk about a specific topic
+```
+> talk to innkeeper about town
+Innkeeper says: "The town's been quiet since the mine closed. Folk are scared."
+```
+
+### Topic leads to a subtopic
+```
+> talk to innkeeper about town
+Innkeeper says: "The town's been quiet since the mine closed. Folk are scared."
+
+> talk to innkeeper about mine
+Innkeeper says: "Nobody's been down there since the collapse."
+```
+
+`mine` is only reachable because `town` has `leads_to: ["mine"]`. Asking
+about `mine` before `town` returns the default response.
+
+### Topic gated on a flag
+```
+# rats_cleared flag not set
+> talk to innkeeper about reward
+Innkeeper says: "Bring me proof the rats are gone first."
+
+# rats_cleared flag is set
+> talk to innkeeper about reward
+Innkeeper says: "You did it! Here's what I promised."
+```
+
+### Topic gated on inventory
+```
+# sword not in inventory
+> talk to blacksmith about appraisal
+Blacksmith says: "Bring me something worth appraising."
+
+# sword in inventory
+> talk to blacksmith about appraisal
+Blacksmith says: "Fine craftsmanship. That blade is worth 50 gold."
+```
+
+### No match — default response
+```
+> talk to innkeeper about dragons
+Innkeeper says: "I wouldn't know anything about that."
+```
+
+### NPC has no dialogue
+```
+> talk to guard
+Guard doesn't seem interested in talking.
+```
+
+---
+
+## World data format
+
+```ruby
+"innkeeper" => {
+  "name" => "Innkeeper",
+  "keywords" => ["innkeeper"],
+  "dialogue" => {
+    "greeting" => "Welcome, traveller. What brings you to these parts?",
+    "default"  => "I wouldn't know anything about that.",
+    "topics" => {
+      "town" => {
+        "keywords"  => ["town", "village", "quiet"],
+        "text"      => "The town's been quiet since the mine closed. Folk are scared.",
+        "leads_to"  => ["mine"]
+      },
+      "mine" => {
+        "keywords"  => ["mine", "collapse", "closed"],
+        "text"      => "Nobody's been down there since the collapse.",
+        "locked_text" => "I'm not sure what you mean."
+      },
+      "work" => {
+        "keywords"    => ["work", "job", "help"],
+        "text"        => "I need someone to clear the rats from my cellar.",
+        "sets_flag"   => "rat_quest_started"
+      },
+      "reward" => {
+        "keywords"      => ["reward", "payment", "done"],
+        "requires_flag" => "rats_cleared",
+        "text"          => "You did it! Here's what I promised.",
+        "locked_text"   => "Bring me proof the rats are gone first."
+      },
+      "appraisal" => {
+        "keywords"      => ["appraise", "appraisal", "worth"],
+        "requires_item" => "sword",
+        "text"          => "Fine craftsmanship. That blade is worth 50 gold.",
+        "locked_text"   => "Bring me something worth appraising."
+      }
+    }
+  }
+}
+```
+
+---
+
+## Acceptance criteria
+
+- `talk to [npc]` with no topic returns the `greeting`
+- `talk to [npc] about [topic]` matches by keyword (any word in the input
+  matching any keyword in a topic counts as a match)
+- A topic with `leads_to` unlocks those subtopics; attempting to access a
+  subtopic before its parent returns `locked_text` (or `default` if none)
+- A topic with `requires_flag` returns `locked_text` if the flag is not set,
+  and `text` if it is
+- A topic with `requires_item` returns `locked_text` if the item is not in
+  inventory, and `text` if it is
+- A topic with `sets_flag` sets that flag when successfully accessed
+- No keyword match returns `default`
+- NPC with no `dialogue` key: "[Name] doesn't seem interested in talking."
+- NPC with `dialogue` but no `topics`: returns greeting only
+
+## Out of scope
+- Persistent per-NPC conversation state (tracking which topics have been seen)
+- NPC-initiated dialogue
+- Dialogue affecting combat
+- Items given through dialogue (use the existing `give` command instead)

--- a/test/lib/classic_game/handlers/interact_handler_test.rb
+++ b/test/lib/classic_game/handlers/interact_handler_test.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InteractHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  INNKEEPER_NPC = {
+    "name" => "Innkeeper",
+    "keywords" => ["innkeeper"],
+    "dialogue" => {
+      "greeting" => "Welcome, traveller. What brings you to these parts?",
+      "default" => "I wouldn't know anything about that.",
+      "topics" => {
+        "town" => {
+          "keywords" => %w[town village quiet],
+          "text" => "The town's been quiet since the mine closed. Folk are scared.",
+          "leads_to" => ["mine"]
+        },
+        "mine" => {
+          "keywords" => %w[mine collapse closed],
+          "text" => "Nobody's been down there since the collapse.",
+          "locked_text" => "I'm not sure what you mean."
+        },
+        "work" => {
+          "keywords" => %w[work job help],
+          "text" => "I need someone to clear the rats from my cellar.",
+          "sets_flag" => "rat_quest_started"
+        },
+        "reward" => {
+          "keywords" => %w[reward payment done],
+          "requires_flag" => "rats_cleared",
+          "text" => "You did it! Here's what I promised.",
+          "locked_text" => "Bring me proof the rats are gone first."
+        },
+        "appraisal" => {
+          "keywords" => %w[appraise appraisal worth],
+          "requires_item" => "sword",
+          "text" => "Fine craftsmanship. That blade is worth 50 gold.",
+          "locked_text" => "Bring me something worth appraising."
+        }
+      }
+    }
+  }.freeze
+
+  SILENT_GUARD = {
+    "name" => "Guard",
+    "keywords" => ["guard"]
+    # no "dialogue" key
+  }.freeze
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "Tavern",
+          "description" => "A warm tavern.",
+          "exits" => {},
+          "npcs" => %w[innkeeper guard]
+        }
+      },
+      items: {
+        "sword" => { "name" => "Iron Sword", "keywords" => %w[sword iron], "takeable" => true }
+      },
+      npcs: {
+        "innkeeper" => INNKEEPER_NPC.dup,
+        "guard" => SILENT_GUARD.dup
+      }
+    )
+    @game = build_game(world_data: @world, player_id: USER_ID)
+  end
+
+  # ─── Greeting ───────────────────────────────────────────────────────────────
+
+  test "talk to npc with no topic returns greeting" do
+    result = execute("talk to innkeeper")
+
+    assert result[:success]
+    assert_includes result[:response], "Welcome, traveller"
+  end
+
+  test "talk response wraps text in npc-says format" do
+    result = execute("talk to innkeeper")
+
+    assert_includes result[:response], 'Innkeeper says: "'
+  end
+
+  # ─── Topic matching ─────────────────────────────────────────────────────────
+
+  test "talk about topic matches by keyword" do
+    result = execute("talk to innkeeper about town")
+
+    assert result[:success]
+    assert_includes result[:response], "mine closed"
+  end
+
+  test "talk about topic matches alternate keyword in topic" do
+    result = execute("talk to innkeeper about village")
+
+    assert_includes result[:response], "mine closed"
+  end
+
+  # ─── leads_to gating ────────────────────────────────────────────────────────
+
+  test "subtopic locked before parent topic accessed" do
+    result = execute("talk to innkeeper about mine")
+
+    assert result[:success]
+    assert_includes result[:response], "I'm not sure what you mean"
+  end
+
+  test "subtopic accessible after parent topic accessed" do
+    execute("talk to innkeeper about town")
+    result = execute("talk to innkeeper about mine")
+
+    assert_includes result[:response], "Nobody's been down there"
+  end
+
+  test "accessing parent topic records subtopic in player dialogue_unlocked" do
+    execute("talk to innkeeper about town")
+
+    unlocked = @game.player_state(USER_ID).dig("dialogue_unlocked", "innkeeper")
+    assert_includes unlocked, "mine"
+  end
+
+  # ─── requires_flag ──────────────────────────────────────────────────────────
+
+  test "topic with requires_flag returns locked_text when flag not set" do
+    result = execute("talk to innkeeper about reward")
+
+    assert_includes result[:response], "Bring me proof"
+  end
+
+  test "topic with requires_flag returns text when flag is set" do
+    @game.set_flag("rats_cleared", true)
+    result = execute("talk to innkeeper about reward")
+
+    assert_includes result[:response], "You did it"
+  end
+
+  # ─── requires_item ──────────────────────────────────────────────────────────
+
+  test "topic with requires_item returns locked_text when item not in inventory" do
+    result = execute("talk to innkeeper about appraisal")
+
+    assert_includes result[:response], "Bring me something worth appraising"
+  end
+
+  test "topic with requires_item returns text when item in inventory" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("tavern", inventory: ["sword"])
+    )
+    result = execute("talk to innkeeper about appraisal")
+
+    assert_includes result[:response], "Fine craftsmanship"
+  end
+
+  # ─── sets_flag ──────────────────────────────────────────────────────────────
+
+  test "accessing topic with sets_flag sets the flag" do
+    execute("talk to innkeeper about work")
+
+    assert @game.get_flag("rat_quest_started")
+  end
+
+  # ─── Default / no match ─────────────────────────────────────────────────────
+
+  test "talk about unrecognized topic returns default response" do
+    result = execute("talk to innkeeper about dragons")
+
+    assert result[:success]
+    assert_includes result[:response], "I wouldn't know anything about that"
+  end
+
+  # ─── NPC has no dialogue ────────────────────────────────────────────────────
+
+  test "talk to npc with no dialogue returns not interested message" do
+    result = execute("talk to guard")
+
+    assert_not result[:success]
+    assert_includes result[:response], "Guard doesn't seem interested in talking"
+  end
+
+  # ─── NPC with dialogue but no topics ───────────────────────────────────────
+
+  test "talk to npc with dialogue but no topics returns greeting" do
+    shopkeeper_npc = {
+      "name" => "Shopkeeper",
+      "keywords" => ["shopkeeper"],
+      "dialogue" => { "greeting" => "Hello there." }
+    }
+    world = build_world(
+      starting_room: "shop",
+      rooms: {
+        "shop" => {
+          "name" => "Shop", "description" => "A small shop.", "exits" => {},
+          "npcs" => ["shopkeeper"]
+        }
+      },
+      npcs: { "shopkeeper" => shopkeeper_npc }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    command = ClassicGame::CommandParser.parse("talk to shopkeeper")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert_includes result[:response], "Hello there."
+  end
+
+  # ─── NPC not in room ────────────────────────────────────────────────────────
+
+  test "talk to npc not in current room fails" do
+    world = build_world(
+      starting_room: "empty_room",
+      rooms: {
+        "empty_room" => {
+          "name" => "Empty Room", "description" => "Nothing here.", "exits" => {},
+          "npcs" => []
+        }
+      },
+      npcs: { "innkeeper" => INNKEEPER_NPC.dup }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    command = ClassicGame::CommandParser.parse("talk to innkeeper")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert_not result[:success]
+    assert_includes result[:response], "don't see anyone"
+  end
+
+  # ─── No target ──────────────────────────────────────────────────────────────
+
+  test "talk with no target fails" do
+    result = execute("talk")
+
+    assert_not result[:success]
+    assert_includes result[:response], "whom"
+  end
+
+  private
+
+    def execute(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::InteractHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+end


### PR DESCRIPTION
Adds branching NPC dialogue trees to the classic game engine. Players can talk to NPCs using free-text (`talk to [npc]` or `talk to [npc] about [topic]`), with topics that branch based on world flags and player inventory.

Spec: specs/pr-27-npc_dialogue_trees.md

**Implementation plan added** — see spec file.

## Summary

Rewrote `InteractHandler#handle_talk` to support full dialogue tree logic: greeting on bare `talk to npc`, keyword-matched topic lookup, `leads_to` subtopic gating (stored in `player_state["dialogue_unlocked"]`), `requires_flag`/`requires_item` gates, and `sets_flag` side-effects. Added 17 tests covering all acceptance criteria; the handler lives entirely in the existing `InteractHandler` with no new production files.