### PR TITLE
Full-Featured QA World

### DIFF
--- a/.claude/skills/build-feature/SKILL.md
+++ b/.claude/skills/build-feature/SKILL.md
@@ -2,146 +2,67 @@
 name: build-feature
 description: Full pipeline — ingest a spec, plan the implementation, implement it, and mark the PR ready for review. No human checkpoints.
 argument-hint: [spec-filename (optional)]
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *)
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *), Skill
+model: sonnet
+effort: low
 context: fork
 ---
 
 # Build Feature (Full Pipeline)
 
-Runs the complete feature factory pipeline on a spec file:
+Orchestrates the complete feature factory by calling each skill in sequence:
 
-1. **Ingest** — create branch, draft PR, rename spec file
-2. **Plan** — explore codebase, write implementation plan into spec
-3. **Implement** — tests first, then code, full suite + RuboCop
-4. **Ship** — mark PR ready for review
+1. `/ingest-feature` — create branch, draft PR, rename spec file
+2. `/plan-feature` — explore codebase, write implementation plan
+3. `/implement-feature` — tests first, then code, mark PR ready
 
 No human checkpoints. The first human touchpoint is the PR ready for review.
 
-On any failure, stop immediately and leave the repo in a clean state.
-Print what failed and what the human needs to do to unblock.
+On any failure, stop immediately. Print what failed and what the human needs to do to unblock.
 
-> **Important:** Every shell command must be a single, simple call — no `$()`,
-> no `&&` chains. Use separate tool calls and carry values between them.
+> **Important:** This skill is a thin orchestrator. All logic lives in the
+> individual skills above. Do NOT duplicate their instructions here.
 
 ---
 
-## Phase 1: Find and validate the spec
+## Phase 1: Find the spec filename
 
-If `$ARGUMENTS` names a specific file, use that.
+If `$ARGUMENTS` names a specific file, use that as the spec filename.
 
 Otherwise:
 1. List all files in `specs/` using Glob.
-2. Find unprocessed files: no `pr-` prefix.
+2. Find unprocessed files: filename does NOT start with `pr-`.
 3. If none: print "No unprocessed specs found." and stop.
-4. If exactly one: proceed.
+4. If exactly one: use it.
 5. If multiple: print "Multiple unprocessed specs — pass a filename:" followed by the list, then stop.
-
-Validate the chosen spec:
-- Has a top-level `#` heading
-- Has a non-empty `## Acceptance criteria` section
-
-On failure: print what is missing and stop.
-
----
 
 ## Phase 2: Ingest
 
-Run each command as a separate tool call:
+Invoke the skill:
+```
+/ingest-feature <spec-filename>
+```
 
-1. `git checkout main`
-2. `git pull`
-3. Derive branch name: strip `.md`, replace `_` with `-`, prefix `feature/`
-4. `git checkout -b <branch-name>`
-5. `git push -u origin <branch-name>`
-6. `git commit --allow-empty -m "chore: initialize <branch-name>"`
-7. `git push`
-8. `gh pr create --draft --title "<# heading>" --body "<2-3 sentence summary>\n\nSpec: specs/pr-{number}-{filename}"`
-   Parse the PR number from the URL printed by this command — do not run another command to fetch it.
-9. Use the Edit tool to prepend `> PR: https://github.com/Fishy49/supertextadventure/pull/{number}\n\n` to the spec file
-10. `git mv specs/{filename} specs/pr-{number}-{filename}`
-11. `git add specs/`
-12. `git commit -m "chore: link spec to PR #{number}"`
-13. `git push`
-
----
+When it completes, note the PR number and the new `pr-{number}-{filename}` from its output. If it fails, stop and report.
 
 ## Phase 3: Plan
 
-Read each file individually using the Read tool (no shell commands for file reading):
-- The full spec file (especially `## Acceptance criteria`)
-- `app/lib/classic_game/base_handler.rb`
-- `app/lib/classic_game/command_parser.rb`
-- `app/lib/classic_game/engine.rb`
-- All files in `app/lib/classic_game/handlers/`
-- `test/support/classic_game_helper.rb`
-- All files in `test/lib/classic_game/`
-
-Use Grep to find existing code related to the feature.
-
-Write an implementation plan with these five sections:
-
-**1. Files to create** — full path + one-line purpose for each
-**2. Files to modify** — full path + specific changes (name the methods/constants)
-**3. Implementation steps** — ordered, atomic; include exact location and reasoning
-**4. Test plan** — for each acceptance criterion: test name, setup, input, expected output
-**5. Gotchas and constraints** — RuboCop rules, FakeGame methods, edge cases
-
-Use the Edit tool to append to the end of the spec file:
+Invoke the skill:
 ```
----
-
-## Implementation plan
-
-> Generated {date}
-
-{plan}
+/plan-feature pr-{number}-{filename}
 ```
 
-Then run each command as a separate tool call:
-1. `git add specs/`
-2. `git commit -m "chore: add implementation plan to PR #{number}"`
-3. `git push`
-
-Update the PR body:
-1. `gh pr view {number} --json body -q .body` — capture the result as `current_body`
-2. `gh pr edit {number} --body "{current_body}\n\n**Implementation plan added** — see spec file."`
-
----
+If it prints open questions or ambiguities, note them but continue — do not stop for human input. If it fails, stop and report.
 
 ## Phase 4: Implement
 
-Using only the implementation plan (no additional codebase exploration):
-
-**Tests first:**
-1. Create test file(s) per the test plan using the Write tool.
-2. `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/` — confirm tests fail.
-
-**Implement:**
-3. Work through implementation steps in order using Edit/Write tools.
-4. After each logical unit: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
-5. Do not proceed until current tests pass.
-
-**Full validation — run each as a separate tool call:**
-6. `PARALLEL_WORKERS=1 bin/rails test`
-7. `bundle exec rubocop --parallel`
-8. Fix all failures before continuing.
-
----
-
-## Phase 5: Ship
-
-Run each command as a separate tool call:
-
-1. `git add -A`
-2. `git commit -m "feat: <feature title>"`
-3. `git push`
-4. `gh pr view {number} --json body -q .body` — capture as `current_body`
-5. `gh pr edit {number} --body "{current_body}\n\n## Summary\n\n<2-3 sentences on what was built>"`
-6. `gh pr ready {number}`
-
-Print:
+Invoke the skill:
 ```
-✓ PR #{number} is ready for review: https://github.com/Fishy49/supertextadventure/pull/{number}
+/implement-feature pr-{number}-{filename}
 ```
 
-And the final test count.
+If it fails, stop and report.
+
+## Output
+
+Print the final output from `/implement-feature` (the PR link and test counts).

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -3,6 +3,8 @@ name: implement-feature
 description: Read an ingested, planned spec file and implement the feature — tests first, then code, then mark the PR ready for review.
 argument-hint: [pr-X-spec-filename]
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *)
+model: opus
+effort: high
 context: fork
 ---
 

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -41,12 +41,21 @@ Otherwise:
 
 Read the full spec file using the Read tool. The `## Implementation plan` section is the authoritative source — do not re-explore the codebase beyond what the plan references.
 
-## Phase 4: Write tests first
+## Phase 4: Write all tests first
 
-1. Create the test file(s) described in the plan's **Test plan** section.
+Write **both** unit tests and system (integration) tests before any implementation.
+
+### 4a: Unit tests
+1. Create the unit test file(s) described in the plan's **Test plan** section.
 2. Follow the exact patterns in `test/lib/classic_game/handlers/` — use `ClassicGameTestHelper`, `FakeGame`, `build_world`, `build_game`, `player_state_in`.
 3. Run: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
 4. Confirm the tests **fail**. If they pass already, stop and report — something is wrong.
+
+### 4b: System tests
+1. Create system test file(s) that exercise the new functionality through the browser via `/dev/game`.
+2. Follow the patterns in `test/system/qa_world/` — use `visit dev_game_path`, `find(".terminal-input").send_keys(...)`, and Capybara assertions.
+3. Run: `bin/rails test:system`
+4. Confirm the new system tests **fail**.
 
 ## Phase 5: Implement
 
@@ -56,16 +65,24 @@ Work through the **Implementation steps** from the plan in order:
 2. After each logical unit of work, run: `PARALLEL_WORKERS=1 bin/rails test test/lib/classic_game/`
 3. Do not move to the next step until the current tests pass.
 
-## Phase 6: Full suite + RuboCop
+## Phase 6: Update QA world
+
+Any new functionality (items, NPCs, creatures, room features, dialogue topics, etc.) must be represented in the QA world so it can be manually tested via `/dev/game` and exercised by system tests.
+
+1. Update `test/support/qa_world_data.rb` to include representative examples of the new functionality.
+2. Update or add system tests in `test/system/qa_world/` to cover the new QA world content.
+
+## Phase 7: Full suite + RuboCop
 
 Once all engine tests pass, run each command as a separate tool call:
 
 1. `PARALLEL_WORKERS=1 bin/rails test`
-2. `bundle exec rubocop --parallel`
+2. `bin/rails test:system`
+3. `bundle exec rubocop --parallel`
 
 Fix all failures and offenses before continuing. Do not suppress RuboCop rules unless `.rubocop.yml` already disables that cop.
 
-## Phase 7: Commit and mark ready
+## Phase 8: Commit and mark ready
 
 Run each command as a separate tool call:
 

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -73,8 +73,28 @@ Run each command as a separate tool call:
 2. `git commit -m "feat: <feature title from spec>"`
 3. `git push`
 4. Run `gh pr view {number} --json body -q .body` — capture the output as the current body
-5. Run `gh pr edit {number} --body "{current body}\n\n## Summary\n\n<2-3 sentences on what was implemented>"`
-   where `{current body}` is the literal text returned in step 4
+5. Append a **Summary** section to the PR body using `gh pr edit`. Structure it as:
+
+   ```markdown
+   ## Summary
+
+   <1-2 sentence high-level description of what changed and why>
+
+   ### Changes
+   - **file_or_area** — what changed and why
+   - **file_or_area** — what changed and why
+   - ...
+
+   ### Test results
+   - Unit: X runs, Y assertions, 0 failures
+   - System: X runs, Y assertions, 0 failures
+   - RuboCop: X files, no offenses
+   ```
+
+   Keep each bullet concise (one line). Group related changes into a single bullet
+   (e.g. one bullet for "fixture + helper + seeds" rather than three separate ones).
+   Use the `--body` flag with the full body (current body + appended summary).
+   Write the body to a temp file and pass it via `--body-file` to avoid shell quoting issues.
 6. `gh pr ready {number}`
 
 ## Output

--- a/.claude/skills/ingest-feature/SKILL.md
+++ b/.claude/skills/ingest-feature/SKILL.md
@@ -3,6 +3,8 @@ name: ingest-feature
 description: Ingest a feature spec from specs/, create a branch and draft PR, rename the spec file with the PR number, and add a PR link to the top of the file.
 argument-hint: [spec-filename]
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *)
+model: sonnet
+effort: low
 context: fork
 ---
 

--- a/.claude/skills/plan-feature/SKILL.md
+++ b/.claude/skills/plan-feature/SKILL.md
@@ -3,6 +3,8 @@ name: plan-feature
 description: Read an ingested spec file, explore the codebase, write a detailed implementation plan, and append it to the spec file and PR.
 argument-hint: [pr-X-spec-filename]
 allowed-tools: Read, Glob, Grep, Bash(git *), Bash(gh *), Edit
+model: opus
+effort: max
 context: fork
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# SuperTextAdventure
+
+A Rails 8 text adventure game engine with a classic parser-based game mode.
+
+## Writing a feature spec
+
+Feature specs live in `specs/` and drive the build pipeline (`/ingest-feature` → `/plan-feature` → `/implement-feature`).
+
+### Required structure
+
+```markdown
+# Feature Title
+
+Brief description of what the feature does and why.
+
+## Acceptance criteria
+
+- Concrete, testable statement of done
+- Another criterion
+- ...
+```
+
+The `# heading` and `## Acceptance criteria` section are **required** — the ingest tool will reject the file without them.
+
+### Optional sections
+
+Add any of these if they help clarify intent:
+
+- **Player-facing behaviour** — examples of what the user sees (commands, output)
+- **Constraints** — hard rules, performance bounds, security requirements
+- **Gotchas** — edge cases, known pitfalls, things to verify before assuming they work
+
+### Tips
+
+- Keep it short. Describe *what* and *why*, not *how* — the plan step figures out implementation.
+- Name the file descriptively with underscores (e.g. `qa_world.md`). The pipeline derives the branch name from it.
+- Don't add a `pr-` prefix — that's added automatically by `/ingest-feature`.
+
+### Pipeline
+
+1. **`/ingest-feature`** — creates a branch, opens a draft PR, links the spec
+2. **`/plan-feature`** — reads the spec, explores the codebase, writes an implementation plan
+3. **`/implement-feature`** — writes tests first, implements, runs full suite, marks PR ready

--- a/app/controllers/dev/game_controller.rb
+++ b/app/controllers/dev/game_controller.rb
@@ -38,12 +38,22 @@ module Dev
       game = Game.find_by(created_by: dev_user&.id, game_type: :classic)
       game&.destroy
 
+      refresh_qa_world
+
       session.delete(:dev_game_id)
 
       redirect_to dev_game_path
     end
 
     private
+
+      def refresh_qa_world
+        require Rails.root.join("test/support/qa_world_data")
+        world = World.find_by(name: "QA Test World")
+        return unless world
+
+        world.update!(world_data: TestSupport::QaWorldData.data)
+      end
 
       def find_or_create_dev_user
         User.find_or_create_by!(username: DEV_USERNAME) do |u|

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -293,7 +293,22 @@ module ClassicGame
           update_player_state(new_player_state)
 
           # Set defeat flag if specified
-          game.set_flag(creature_def["sets_flag_on_defeat"], true) if creature_def["sets_flag_on_defeat"]
+          if creature_def["sets_flag_on_defeat"]
+            flag_name = creature_def["sets_flag_on_defeat"]
+            game.set_flag(flag_name, true)
+
+            # Auto-reveal any hidden exits now unlocked by this flag
+            room_id = player_state["current_room"]
+            room_def = world_snapshot.dig("rooms", room_id)
+            (room_def["exits"] || {}).each do |direction, exit_data|
+              next unless exit_data.is_a?(Hash) && exit_data["hidden"]
+              next if game.exit_revealed?(room_id, direction.to_s)
+              next unless exit_data["requires_flag"] == flag_name
+
+              game.reveal_exit(room_id, direction.to_s)
+              lines << "" << (exit_data["reveal_msg"] || "A new passage has been revealed to the #{direction}.")
+            end
+          end
 
           success(lines.join("\n"))
         end

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -292,6 +292,9 @@ module ClassicGame
           new_player_state["combat"] = nil
           update_player_state(new_player_state)
 
+          # Set defeat flag if specified
+          game.set_flag(creature_def["sets_flag_on_defeat"], true) if creature_def["sets_flag_on_defeat"]
+
           success(lines.join("\n"))
         end
 

--- a/app/lib/classic_game/handlers/container_handler.rb
+++ b/app/lib/classic_game/handlers/container_handler.rb
@@ -39,6 +39,14 @@ module ClassicGame
               # Player has the key, unlock and open
               game.open_container(container_id)
               message = container_def["on_open_message"] || "You unlock and open the #{container_def['name']}."
+
+              # Show contents if any
+              contents = game.container_contents(container_id)
+              if contents.any?
+                content_names = contents.map { |item_id| world_snapshot.dig("items", item_id, "name") || item_id }
+                message += "\n\nInside you see: #{content_names.join(', ')}"
+              end
+
               return success(message)
             else
               locked_msg = container_def["locked_message"] || "It's locked."

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -226,12 +226,17 @@ module ClassicGame
           if visible_exits.any?
             lines << ""
 
-            # Check if any exits have unlocked messages to show
+            # Check if any exits have descriptive messages to show
             exit_descriptions = []
             visible_exits.each do |direction, exit_data|
               next unless exit_data.is_a?(Hash)
 
-              # Check if this exit has been unlocked and has an unlocked_msg
+              # Show reveal_msg for revealed hidden exits
+              if exit_data["hidden"] && exit_data["reveal_msg"].present? && game.exit_revealed?(room_id, direction.to_s)
+                exit_descriptions << exit_data["reveal_msg"]
+              end
+
+              # Show unlocked_msg for unlocked exits
               if exit_data["unlocked_msg"].present? && game.exit_unlocked?(room_id, direction.to_s)
                 exit_descriptions << exit_data["unlocked_msg"]
               end

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -6,7 +6,7 @@ module ClassicGame
       def handle(command)
         case command[:verb]
         when :talk
-          handle_talk(command[:target])
+          handle_talk(command)
         when :give
           handle_give(command[:target], command[:modifier])
         when :attack
@@ -18,23 +18,77 @@ module ClassicGame
 
       private
 
-        def handle_talk(target)
-          return failure("Talk to whom?") unless target
+        def handle_talk(command)
+          target = command[:target]
+          modifier = command[:modifier]
 
-          # Find the NPC
-          npc_id, npc_def = find_npc(target)
+          # "talk to X" parses as target="" modifier="X"
+          # "talk to X about Y" parses as target="" modifier="X about Y"
+          npc_name, topic_name = resolve_talk_target(target, modifier)
+
+          return failure("Talk to whom?") if npc_name.blank?
+
+          npc_id, npc_def = find_npc(npc_name)
           return failure("You don't see anyone like that here.") unless npc_def
           return failure("You don't see anyone like that here.") unless npc_in_room?(npc_id)
 
-          # Get dialogue
           dialogue = npc_def["dialogue"]
           return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue
 
-          # For now, return default dialogue
-          # Future: could implement conversation trees, quest states, etc.
+          if topic_name.present?
+            handle_talk_topic(npc_def, dialogue, topic_name)
+          else
+            handle_talk_greeting(npc_def, dialogue)
+          end
+        end
+
+        def resolve_talk_target(target, modifier)
+          if target.present?
+            [target, modifier]
+          elsif modifier.present?
+            parts = modifier.split(" about ", 2)
+            [parts[0], parts[1]]
+          else
+            [nil, nil]
+          end
+        end
+
+        def handle_talk_greeting(npc_def, dialogue)
           response = dialogue["default"] || "#{npc_def['name']} nods at you."
 
+          # Set flag if specified on greeting
+          game.set_flag(dialogue["sets_flag"], true) if dialogue["sets_flag"]
+
           success("#{npc_def['name']} says: \"#{response}\"")
+        end
+
+        def handle_talk_topic(npc_def, dialogue, topic_name)
+          topics = dialogue["topics"]
+          return failure("#{npc_def['name']} doesn't know about that.") unless topics
+
+          topic = topics[topic_name]
+          return failure("#{npc_def['name']} doesn't know about that.") unless topic
+
+          # Check flag requirement
+          if topic["requires_flag"] && !game.get_flag(topic["requires_flag"])
+            return failure("#{npc_def['name']} says: \"#{topic['locked_text']}\"")
+          end
+
+          # Check item requirement
+          if topic["requires_item"] && !item?(topic["requires_item"])
+            return failure("#{npc_def['name']} says: \"#{topic['locked_text']}\"")
+          end
+
+          # Set flag if specified
+          game.set_flag(topic["sets_flag"], true) if topic["sets_flag"]
+
+          # Build response
+          response = "#{npc_def['name']} says: \"#{topic['text']}\""
+
+          # Append leads_to hint
+          response += "\n\nYou could ask about '#{topic['leads_to']}'." if topic["leads_to"]
+
+          success(response)
         end
 
         def handle_give(item_target, npc_target)

--- a/app/lib/classic_game/handlers/item_handler.rb
+++ b/app/lib/classic_game/handlers/item_handler.rb
@@ -106,6 +106,8 @@ module ClassicGame
             handle_unlock(item_id, item_def, use_action, modifier)
           when "message"
             success(use_action["text"])
+          when "heal"
+            handle_heal(item_id, item_def, use_action)
           when "script"
             # For future: custom script execution
             failure("That doesn't do anything right now.")
@@ -127,6 +129,25 @@ module ClassicGame
           end
 
           success(use_action["success_msg"] || "You use the #{item_def['name']}.")
+        end
+
+        def handle_heal(item_id, item_def, use_action)
+          heal_amount = use_action["amount"] || 5
+          new_player_state = player_state.dup
+          current_health = new_player_state["health"] || 10
+          max_health = new_player_state["max_health"] || 10
+
+          new_health = [current_health + heal_amount, max_health].min
+          new_player_state["health"] = new_health
+
+          # Remove item if consumable
+          new_player_state["inventory"] = (new_player_state["inventory"] || []) - [item_id] if item_def["consumable"]
+
+          update_player_state(new_player_state)
+
+          actual_heal = new_health - current_health
+          message = use_action["text"] || "You use the #{item_def['name']} and recover #{actual_heal} health!"
+          success(message)
         end
 
         def handle_reveal_exit(_item_id, _item_def, reveal_data)

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -31,7 +31,6 @@ module ClassicGame
           exit_data["unlocked_msg"]
           permanently_unlock = exit_data["permanently_unlock"]
           hidden = exit_data["hidden"]
-          reveal_msg = exit_data["reveal_msg"]
 
           # Check if exit is hidden and not yet revealed
           if hidden && direction && !game.exit_revealed?(player_state["current_room"], direction)
@@ -39,8 +38,6 @@ module ClassicGame
             return failure("You can't go that way.") unless requires_flag && game.get_flag(requires_flag)
 
             game.reveal_exit(player_state["current_room"], direction)
-            return success(reveal_msg) if reveal_msg
-
           end
 
           # Check if exit is permanently unlocked
@@ -122,6 +119,16 @@ module ClassicGame
             lines << "Present: #{npc_names.join(', ')}"
           end
 
+          # List creatures
+          creatures = room_state["creatures"] || []
+          if creatures.any?
+            lines << ""
+            creature_names = creatures.map do |creature_id|
+              world_snapshot.dig("creatures", creature_id, "name") || creature_id
+            end
+            lines << "Creatures: #{creature_names.join(', ')}"
+          end
+
           # List exits (filter out hidden unrevealed exits)
           exits = room_def["exits"] || {}
           visible_exits = exits.select do |direction, exit_data|
@@ -136,12 +143,17 @@ module ClassicGame
           if visible_exits.any?
             lines << ""
 
-            # Check if any exits have unlocked messages to show
+            # Check if any exits have descriptive messages to show
             exit_descriptions = []
             visible_exits.each do |direction, exit_data|
               next unless exit_data.is_a?(Hash)
 
-              # Check if this exit has been unlocked and has an unlocked_msg
+              # Show reveal_msg for revealed hidden exits
+              if exit_data["hidden"] && exit_data["reveal_msg"].present? && game.exit_revealed?(room_id, direction.to_s)
+                exit_descriptions << exit_data["reveal_msg"]
+              end
+
+              # Show unlocked_msg for unlocked exits
               if exit_data["unlocked_msg"].present? && game.exit_unlocked?(room_id, direction.to_s)
                 exit_descriptions << exit_data["unlocked_msg"]
               end

--- a/db/seeds/feature_test_world.rb
+++ b/db/seeds/feature_test_world.rb
@@ -1,27 +1,11 @@
 # frozen_string_literal: true
 
 # QA Test World — used by the debug game mode route (/dev/game).
-# Minimal world with a single room to keep tests fast.
+# Full-featured world for manual QA and system tests.
+
+require_relative "../../test/support/qa_world_data"
 
 World.find_or_create_by!(name: "QA Test World") do |world|
-  world.description = "A minimal world for QA / developer testing"
-  world.world_data = {
-    "meta" => {
-      "starting_room" => "test_room",
-      "version" => "1.0",
-      "author" => "SuperTextAdventure"
-    },
-    "rooms" => {
-      "test_room" => {
-        "name" => "Test Chamber",
-        "description" => "A bare stone chamber used for developer testing. Nothing of interest here.",
-        "exits" => {},
-        "items" => [],
-        "npcs" => []
-      }
-    },
-    "items" => {},
-    "npcs" => {},
-    "creatures" => {}
-  }
+  world.description = "A full-featured world for QA / developer testing"
+  world.world_data = TestSupport::QaWorldData.data
 end

--- a/db/seeds/feature_test_world.rb
+++ b/db/seeds/feature_test_world.rb
@@ -5,7 +5,7 @@
 
 require_relative "../../test/support/qa_world_data"
 
-World.find_or_create_by!(name: "QA Test World") do |world|
-  world.description = "A full-featured world for QA / developer testing"
-  world.world_data = TestSupport::QaWorldData.data
-end
+world = World.find_or_initialize_by(name: "QA Test World")
+world.description = "A full-featured world for QA / developer testing"
+world.world_data = TestSupport::QaWorldData.data
+world.save!

--- a/specs/pr-34-qa_world.md
+++ b/specs/pr-34-qa_world.md
@@ -142,3 +142,233 @@ All tests use `/dev/game` and run through the browser with Capybara + Cuprite.
   that `ItemHandler` supports this before assuming it works.
 - Container `open` requires the key item in inventory — verify
   `ContainerHandler` checks inventory, not room items.
+
+---
+
+## Implementation plan
+
+> Generated 2026-03-25
+
+### 1. Files to create
+
+| File | Purpose |
+|------|---------|
+| `test/support/qa_world_data.rb` | Shared module `TestSupport::QaWorldData` that returns the full QA world hash via `.data`. Single source of truth for fixture, helper, and seeds. |
+| `test/system/qa_world/navigation_test.rb` | System tests for movement, locked exits, hidden exits. |
+| `test/system/qa_world/items_test.rb` | System tests for take, drop, use (consumable). |
+| `test/system/qa_world/containers_test.rb` | System tests for locked container open/close. |
+| `test/system/qa_world/dialogue_test.rb` | System tests for NPC talk, topics, flag-gated topics, leads_to chains. |
+| `test/system/qa_world/exchange_test.rb` | System tests for give-item-to-NPC flow. |
+| `test/system/qa_world/combat_test.rb` | System tests for attack, defeat + loot, flee. |
+
+### 2. Files to modify
+
+| File | Changes |
+|------|---------|
+| `app/lib/classic_game/handlers/interact_handler.rb` | **`handle_talk`**: Extend to support topic-based dialogue. Currently only returns `dialogue["default"]`. Must: (1) Fall back to `command[:modifier]` when `command[:target]` is blank (because `talk to X` puts NPC in modifier due to `extract_target_and_modifier` splitting on "to"); (2) Accept `command[:modifier]` as a topic name when the target is the NPC (i.e. `talk to innkeeper about rooms` currently parses as target="" modifier="innkeeper about rooms" — rework to parse NPC + topic out of that); (3) Look up topic in `dialogue["topics"][topic_name]`; (4) Check `requires_flag` / `requires_item` on topics and show `locked_text` when unmet; (5) Handle `sets_flag` on greeting; (6) Handle `leads_to` to return follow-up topic hints. Also add a new private method `handle_talk_topic(npc_id, npc_def, topic_name)`. |
+| `app/lib/classic_game/handlers/item_handler.rb` | **`handle_use`**: Add a `"heal"` case to `on_use["type"]` so consumable items work outside combat. When type is `"heal"`, increase player health by `on_use["amount"]`, cap at `max_health`, remove item from inventory if `item_def["consumable"]` is true, and return a success message. |
+| `test/support/qa_world_data.rb` | (New file — see section 1.) |
+| `test/support/system_test_helper.rb` | **`create_qa_world`**: Replace the inline minimal world hash with `TestSupport::QaWorldData.data`. Require the new `qa_world_data.rb` file at top. |
+| `test/fixtures/worlds.yml` | **`qa_test_world`**: Replace inline JSON with `<%= TestSupport::QaWorldData.data.to_json %>`. Add a `require` comment at the top or use ERB to load the module. |
+| `test/fixtures/games.yml` | **`classic_open`**: Update `game_state.world_snapshot` to use `TestSupport::QaWorldData.data` so the fixture's snapshot matches the new world. |
+| `db/seeds/feature_test_world.rb` | Replace the inline minimal world hash with `TestSupport::QaWorldData.data`. Require the shared module at top. |
+| `test/system/classic_game_test.rb` | Update `"initial room description"` assertion from `"Test Chamber"` to `"Town Square"` (new starting room name). Update `"navigation command with no exits"` — town_square now has exits in all four directions, so `go north` will succeed. Change to test an invalid direction like `go northeast`. Update `"reset game"` assertion from `"Test Chamber"` to `"Town Square"`. |
+
+### 3. Implementation steps
+
+**Step 1 — Create `test/support/qa_world_data.rb`**
+
+Define `TestSupport::QaWorldData.data` returning a frozen hash with:
+
+- **`meta`**: `starting_room: "town_square"`, version, author.
+- **`rooms`** (5 rooms):
+  - `town_square`: name "Town Square", description mentioning a bustling square, exits `{ north: "tower_top", south: "cave", east: "tavern", west: "market" }` where north is a complex exit `{ to: "tower_top", requires_flag: "tower_unlocked", locked_msg: "The tower gate is locked." }`. Items: `["rusty_key"]`. NPCs: `["crier"]`. No creatures.
+  - `tavern`: name "The Tavern", description of a cozy inn. Exits: `{ west: "town_square" }`. Items: `["chest"]`. NPCs: `["innkeeper"]`.
+  - `market`: name "The Market", description of stalls. Exits: `{ east: "town_square" }`. NPCs: `["merchant"]`. No items/creatures.
+  - `cave`: name "The Cave", description of a dark cave. Exits: `{ north: "town_square", east: { to: "alcove", hidden: true, requires_flag: "spider_slain", reveal_msg: "With the spider defeated, you notice a narrow passage to the east." } }`. Creatures: `["cave_spider"]`.
+  - `tower_top`: name "Tower Top", description of a high vantage point. Exits: `{ south: "town_square" }`. Items: `["gem"]`.
+- Add a hidden room `alcove` (6th "room" but really a sub-area of cave): name "Secret Alcove", exits `{ west: "cave" }`, items: `["shield"]`. (Note: spec says 5 rooms max. We can treat alcove as part of cave, but it needs to be a separate room entry. Actually the map shows exactly 5 rooms. We should put the shield directly in the cave as a room item, or have the spider drop it. The spec says cave "Contains a shield (defense item)" AND spider drops shield — the spider drops the shield on defeat, so the shield is NOT a room item. The alcove can be omitted. The hidden exit can reveal a passage to `alcove` but let's keep alcove minimal or skip it. Actually re-reading: "A hidden exit to a secret alcove revealed by a flag." So alcove IS a room. But the spec says 5 rooms max. Resolution: the 5 rooms in the map are town_square, tavern, market, cave, tower_top. The alcove is a bonus sub-room. The spec says "5 rooms max" in constraints but also describes the alcove. We'll include alcove as a 6th room since the spec explicitly requires a hidden exit. Alternatively, make the hidden exit go from cave back to town_square via a secret path. But the spec explicitly says "secret alcove". Let's include it — the constraint "5 rooms max" is about the main map; the alcove is effectively a pocket room.)
+  - `alcove`: name "Secret Alcove", description of a small hidden chamber. Exits: `{ west: "cave" }`. Items: `["shield"]`.
+- **`items`**:
+  - `rusty_key`: name "Rusty Key", keywords `["key", "rusty"]`, takeable true, description "An old rusty iron key."
+  - `chest`: name "Wooden Chest", keywords `["chest"]`, is_container true, starts_closed true, locked true, unlock_item "rusty_key", locked_message "The chest is locked. It looks like it needs a key.", contents `["health_potion"]`, on_open_message "You unlock the chest with the rusty key and open it."
+  - `health_potion`: name "Health Potion", keywords `["potion", "health"]`, takeable true, consumable true, description "A bubbling red potion.", on_use `{ type: "heal", amount: 5, text: "You drink the health potion and feel revitalized!" }`, combat_effect `{ type: "heal", amount: 5 }`.
+  - `gem`: name "Sparkling Gem", keywords `["gem", "sparkling"]`, takeable true, description "A brilliant gemstone that glows faintly."
+  - `enchanted_sword`: name "Enchanted Sword", keywords `["sword", "enchanted"]`, takeable true, weapon_damage 8, description "A sword that hums with magical energy."
+  - `shield`: name "Iron Shield", keywords `["shield", "iron"]`, takeable true, defense_bonus 3, description "A sturdy iron shield."
+- **`npcs`**:
+  - `crier`: name "Town Crier", keywords `["crier", "town crier"]`, description "A loud man in official garb.", dialogue `{ default: "Hear ye! The innkeeper at the tavern knows many secrets. The tower is locked by ancient magic!", sets_flag: "spoke_to_crier" }`.
+  - `innkeeper`: name "Innkeeper", keywords `["innkeeper", "keeper"]`, description "A jovial woman behind the bar.", dialogue with `default` greeting and `topics` hash:
+    - `rooms`: `{ text: "There are five main areas...", leads_to: "tower" }` (base topic, always available)
+    - `tower`: `{ text: "The tower can be unlocked... I've done it for you.", requires_flag: "spoke_to_crier", locked_text: "The innkeeper eyes you suspiciously. 'I don't share secrets with strangers. Perhaps the town crier can vouch for you.'", sets_flag: "tower_unlocked" }` (flag-gated topic)
+    - `supplies`: `{ text: "Ah, you have the key! The chest in the corner holds a potion.", requires_item: "rusty_key", locked_text: "The innkeeper glances at the chest. 'That chest needs a special key to open.'" }` (item-gated topic)
+  - `merchant`: name "Merchant", keywords `["merchant", "trader"]`, description "A shrewd-looking trader.", accepts_item "gem", gives_item "enchanted_sword", accept_message "The merchant's eyes light up! 'A gem! Here, take this enchanted sword in return.'", dialogue `{ default: "Looking to trade? I'm after a sparkling gem. Bring me one and I'll make it worth your while." }`.
+- **`creatures`**:
+  - `cave_spider`: name "Cave Spider", keywords `["spider", "cave spider"]`, description "A giant spider lurking in the shadows.", health 8, attack 3, defense 1, loot `["shield"]`, on_defeat_msg "The cave spider crumples to the ground!", on_flee_msg "The spider hisses as you retreat.", sets_flag_on_defeat "spider_slain".
+
+**Step 2 — Update `InteractHandler#handle_talk` to support topics**
+
+In `app/lib/classic_game/handlers/interact_handler.rb`, rewrite `handle_talk`:
+
+```ruby
+def handle_talk(command)
+  target = command[:target]
+  modifier = command[:modifier]
+
+  # "talk to X" parses as target="" modifier="X"
+  # "talk to X about Y" parses as target="" modifier="X about Y"
+  npc_name, topic_name = resolve_talk_target(target, modifier)
+
+  return failure("Talk to whom?") if npc_name.blank?
+
+  npc_id, npc_def = find_npc(npc_name)
+  return failure("You don't see anyone like that here.") unless npc_def
+  return failure("You don't see anyone like that here.") unless npc_in_room?(npc_id)
+
+  dialogue = npc_def["dialogue"]
+  return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue
+
+  if topic_name.present?
+    handle_talk_topic(npc_def, dialogue, topic_name)
+  else
+    handle_talk_greeting(npc_def, dialogue)
+  end
+end
+```
+
+Change the method signature of `handle` so it passes the full command:
+```ruby
+when :talk
+  handle_talk(command)
+```
+
+Add private methods:
+- `resolve_talk_target(target, modifier)` — splits the NPC name from the topic. If target is present and non-blank, use target as NPC name, modifier as topic. If target is blank and modifier present, split modifier on " about " to get NPC name and optional topic.
+- `handle_talk_greeting(npc_def, dialogue)` — returns default greeting text. If dialogue has `sets_flag`, set it.
+- `handle_talk_topic(npc_def, dialogue, topic_name)` — looks up `dialogue["topics"][topic_name]`. Checks `requires_flag` (returns `locked_text` if flag not set). Checks `requires_item` (returns `locked_text` if item not in inventory). If checks pass, returns topic text. If topic has `sets_flag`, set it. If topic has `leads_to`, append a hint like "You could ask about [leads_to topic]."
+
+**Step 3 — Update `ItemHandler#handle_use` to support consumable healing outside combat**
+
+In `app/lib/classic_game/handlers/item_handler.rb`, add a `"heal"` case to the `on_use["type"]` switch in `handle_use`:
+
+```ruby
+when "heal"
+  handle_heal(item_id, item_def, use_action)
+```
+
+Add private method `handle_heal(item_id, item_def, use_action)`:
+- Read `use_action["amount"]` (default 5).
+- Read current player health and max_health.
+- Calculate new health (capped at max_health).
+- If `item_def["consumable"]`, remove item from inventory.
+- Return success with `use_action["text"]` or default message including actual heal amount.
+
+**Step 4 — Handle `sets_flag_on_defeat` in `CombatHandler`**
+
+In `app/lib/classic_game/handlers/combat_handler.rb`, in `handle_creature_defeat`, after removing the creature from the room and clearing combat state, add:
+
+```ruby
+# Set defeat flag if specified
+game.set_flag(creature_def["sets_flag_on_defeat"], true) if creature_def["sets_flag_on_defeat"]
+```
+
+This is needed so the cave's hidden exit can be revealed after the spider is killed.
+
+**Step 5 — Wire up `TestSupport::QaWorldData` in existing files**
+
+- **`test/support/system_test_helper.rb`**: Add `require_relative "qa_world_data"` at top. Change `create_qa_world` body to use `TestSupport::QaWorldData.data` for `world.world_data`.
+- **`test/fixtures/worlds.yml`**: Add ERB require at top: `<% require_relative "../support/qa_world_data" %>`. Replace inline JSON in `qa_test_world` with `<%= TestSupport::QaWorldData.data.to_json %>`.
+- **`test/fixtures/games.yml`**: Add ERB require at top: `<% require_relative "../support/qa_world_data" %>`. Update `classic_open` fixture's `game_state` to snapshot the new world data: `<%= { "world_snapshot" => TestSupport::QaWorldData.data, "player_states" => {}, "room_states" => {}, "global_flags" => {}, "container_states" => {} }.to_json %>`.
+- **`db/seeds/feature_test_world.rb`**: Add `require_relative "../../test/support/qa_world_data"` at top. Replace inline hash with `TestSupport::QaWorldData.data`.
+
+**Step 6 — Update existing system tests in `test/system/classic_game_test.rb`**
+
+- `"initial room description"`: Change `assert_text "Test Chamber"` to `assert_text "Town Square"`.
+- `"send look command"`: Change `assert_text "Test Chamber"` to `assert_text "Town Square"`.
+- `"navigation command with no exits"`: Town square now has all 4 exits. Change `"go north"` to `"go northeast"` (no NE exit exists) so the "can't go" assertion still holds.
+- `"reset game"`: Change `assert_text "Test Chamber"` to `assert_text "Town Square"`.
+
+**Step 7 — Create system test files**
+
+All system tests inherit from `ApplicationSystemTestCase` (which includes `SystemTestHelper`). Each test visits `dev_game_path` which creates the QA world and a game. Use `find(".terminal-input").send_keys("command", :return)` to issue commands and `assert_text` to verify responses.
+
+Create `test/system/qa_world/` directory and the 6 test files listed in section 1. Detailed test cases are in section 4 below.
+
+### 4. Test plan
+
+#### Navigation (`test/system/qa_world/navigation_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "move north from town_square to tower_top when unlocked"` | Visit dev_game_path. Set tower_unlocked flag by talking to crier then innkeeper about tower (or directly via debug). | `go north` | Rejection message "tower gate is locked" initially. After flag set and retry: `assert_text "Tower Top"` |
+| `test "move south from town_square to cave"` | Visit dev_game_path | `go south` | `assert_text "The Cave"` |
+| `test "move east from town_square to tavern"` | Visit dev_game_path | `go east` | `assert_text "The Tavern"` or `assert_text "Tavern"` |
+| `test "move west from town_square to market"` | Visit dev_game_path | `go west` | `assert_text "The Market"` or `assert_text "Market"` |
+| `test "locked exit blocks movement"` | Visit dev_game_path (no flags set) | `go north` | `assert_text "locked"` (locked_msg from tower exit) |
+| `test "unlock exit via flag and move through"` | Visit dev_game_path. Talk to crier (sets spoke_to_crier). Go east to tavern. Talk to innkeeper about tower (sets tower_unlocked). Go west back to town_square. | `go north` | `assert_text "Tower Top"` |
+
+#### Items (`test/system/qa_world/items_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "take rusty_key from town_square"` | Visit dev_game_path | `take key` | `assert_text "Rusty Key"` in response; `inventory` shows "Rusty Key" |
+| `test "drop item shows it in room"` | Visit dev_game_path, take key | `drop key` then `look` | `assert_text "Rusty Key"` in room description |
+| `test "use health_potion outside combat"` | Visit dev_game_path, take key, go east, open chest, take potion | `use potion` | `assert_text "health"` or `assert_text "revitalized"` |
+
+#### Containers (`test/system/qa_world/containers_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "open chest without key is rejected"` | Visit dev_game_path, go east (to tavern) | `open chest` | `assert_text "locked"` or `assert_text "needs a key"` |
+| `test "open chest with key shows contents"` | Visit dev_game_path, take key, go east | `open chest` | `assert_text "Health Potion"` |
+
+#### NPC Dialogue (`test/system/qa_world/dialogue_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "talk to crier shows greeting"` | Visit dev_game_path | `talk to crier` | `assert_text "Hear ye"` or similar greeting |
+| `test "talk to innkeeper about base topic"` | Visit dev_game_path, go east | `talk to innkeeper about rooms` | `assert_text "five main areas"` or topic text |
+| `test "flag-gated topic shows locked_text before flag"` | Visit dev_game_path, go east | `talk to innkeeper about tower` | `assert_text "don't share secrets"` or locked_text |
+| `test "flag-gated topic succeeds after flag set"` | Visit dev_game_path, talk to crier (sets spoke_to_crier), go east | `talk to innkeeper about tower` | `assert_text "unlocked"` or topic text about tower |
+| `test "leads_to topic chain"` | Visit dev_game_path, go east | `talk to innkeeper about rooms` | Response mentions "tower" as a follow-up topic; then `talk to innkeeper about tower` follows the chain |
+
+#### NPC Item Exchange (`test/system/qa_world/exchange_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "give gem to merchant receives enchanted_sword"` | Visit dev_game_path, unlock tower, go north, take gem, go south, go west | `give gem to merchant` | `assert_text "Enchanted Sword"` |
+| `test "give wrong item to merchant is rejected"` | Visit dev_game_path, take key, go west | `give key to merchant` | `assert_text "doesn't want"` |
+
+#### Combat (`test/system/qa_world/combat_test.rb`)
+
+| Test name | Setup | Input | Expected output |
+|-----------|-------|-------|-----------------|
+| `test "attack cave_spider shows combat feedback"` | Visit dev_game_path, go south | `attack spider` | `assert_text "combat"` or `assert_text "Cave Spider"` and combat prompt |
+| `test "defeat spider drops shield"` | Visit dev_game_path, go south, attack spider repeatedly | Multiple `attack` commands | `assert_text "drops"` and `assert_text "Iron Shield"` after defeat |
+| `test "flee exits combat"` | Visit dev_game_path, go south, attack spider | `flee` (may need retries due to 50% chance) | Eventually `assert_text "flee"` and no longer in combat |
+
+### 5. Gotchas and constraints
+
+- **Parser split on "to"**: `talk to innkeeper about rooms` currently parses as `{ verb: :talk, target: "", modifier: "innkeeper about rooms" }` because "to" is the first connector found and everything before it (nothing) becomes target. The `resolve_talk_target` helper must split the modifier on " about " to extract NPC name and topic. "talk to crier" gives target="" modifier="crier" — that case needs no further splitting.
+
+- **Dialogue `sets_flag` on greeting vs. topic**: The crier's greeting sets `spoke_to_crier`. This should be handled in `handle_talk_greeting`, not just topic handling. The `dialogue` hash should support a top-level `sets_flag` key on the greeting.
+
+- **`sets_flag_on_defeat` on creatures**: The engine's `CombatHandler#handle_creature_defeat` does NOT currently read a `sets_flag_on_defeat` key from the creature definition. This must be added (Step 4) or the hidden exit in the cave will never reveal.
+
+- **Consumable items outside combat**: The current `ItemHandler#handle_use` does NOT have a `"heal"` case in the `on_use["type"]` switch. Only `CombatHandler#handle_use_item` handles healing via `combat_effect`. Step 3 adds this. The `health_potion` item needs both `on_use` (for outside combat) and `combat_effect` (for inside combat).
+
+- **ContainerHandler checks inventory, not room items**: Confirmed. `ContainerHandler#handle_open` line 38 uses `item?(unlock_item)` which calls `player_state["inventory"]&.include?(unlock_item)`. So the rusty_key must be in inventory (taken), not just lying in the room.
+
+- **RuboCop rules**: Double-quoted strings throughout (matching existing codebase). MethodLength max 60 lines — the `handle_talk` rewrite and `resolve_talk_target` should each stay well under. Frozen string literal comment at top of every file.
+
+- **FakeGame methods available in unit tests**: `set_flag`, `get_flag`, `exit_unlocked?`, `unlock_exit`, `exit_revealed?`, `reveal_exit`, `container_open?`, `open_container`, `close_container`, `container_contents`, `remove_from_container`. The `player_state_in` helper builds player state hashes. `build_world` and `build_game` are available via `ClassicGameTestHelper`.
+
+- **System test timing**: Capybara's `assert_text` has a default wait of 5 seconds (`Capybara.default_max_wait_time = 5`). Combat flee has a 50% success rate — tests may need to retry the flee command or use a loop with a reasonable cap.
+
+- **Fixture ERB require path**: The worlds.yml fixture needs `<% require_relative "../support/qa_world_data" %>` at the very top for the ERB to evaluate. Same for games.yml.
+
+- **Existing system tests**: `classic_game_test.rb` references "Test Chamber" (old starting room name) in 3 assertions and assumes "go north" fails (old room had no exits). All 3 must be updated to "Town Square" and the no-exits test must use a direction that has no exit in the new world.
+
+- **Hidden exit reveal flow**: The cave's east exit to alcove is hidden and requires `spider_slain` flag. The spider's `sets_flag_on_defeat` sets this flag. After killing the spider, `look` in the cave should show the east exit. MovementHandler's `handle_complex_exit` already handles auto-reveal by flag for hidden exits (line 39-43 of movement_handler.rb).
+
+- **`game.starting_hp`**: The `InteractHandler#handle_attack` reads `game.starting_hp` (line 97). `FakeGame` does not implement this. System tests go through the real Game model which does. For unit tests of the talk/topic feature, this is irrelevant. But if adding unit tests for the new talk feature, FakeGame is sufficient.

--- a/specs/pr-34-qa_world.md
+++ b/specs/pr-34-qa_world.md
@@ -1,0 +1,144 @@
+> PR: https://github.com/Fishy49/supertextadventure/pull/34
+
+# Full-Featured QA World
+
+Replace the current bare-bones QA Test World (a single empty room) with a
+rich, self-contained world that exercises **every game engine capability** in
+one compact map. Developers hit `/dev/game` and immediately have a playground
+for manual QA; system tests use the same world to verify end-to-end behaviour.
+
+---
+
+## Player-facing behaviour
+
+The developer visits `/dev/game` and lands in a small but feature-complete
+world. Every engine capability is reachable within a few commands.
+
+### Map layout (5 rooms)
+
+```
+                  [tower_top]
+                      |
+[market] -- [town_square] -- [tavern]
+                      |
+                  [cave]
+```
+
+- **town_square** — Starting room. Has an NPC (town crier) and a takeable
+  item (rusty_key). Exits in all four directions.
+- **tavern** — Contains the innkeeper NPC with a full dialogue tree
+  (greeting, topics, flag-gated topic, item-gated topic, `leads_to` chain).
+  A locked container (chest) that requires `rusty_key` to open, containing a
+  health_potion (consumable).
+- **market** — Contains a merchant NPC who accepts an item (gem) and gives a
+  reward (enchanted_sword, weapon). Demonstrates the give-item-to-NPC flow.
+- **cave** — Contains a creature (cave_spider) for combat testing. A hidden
+  exit to a secret alcove revealed by a flag. Contains a shield (defense item).
+- **tower_top** — Locked exit from town_square, unlocked by a flag set
+  during dialogue. Contains the gem item needed for the merchant trade.
+
+### Capabilities covered
+
+| Capability              | Where exercised                              |
+|-------------------------|----------------------------------------------|
+| Movement (all dirs)     | town_square exits N/S/E/W                    |
+| Look / examine          | Every room has a description + items          |
+| Take / drop items       | rusty_key in town_square, gem in tower_top   |
+| Inventory management    | Carry items between rooms                     |
+| Locked exits            | tower_top exit (flag-gated)                  |
+| Hidden/revealed exits   | cave secret alcove (flag-gated reveal)       |
+| Open/close containers   | chest in tavern (key-gated)                  |
+| Consumable items        | health_potion (restores health)              |
+| Weapons & defense       | enchanted_sword (weapon), shield (defense)   |
+| NPC greeting            | talk to crier / innkeeper                    |
+| NPC topic dialogue      | talk to innkeeper about rooms                |
+| NPC flag-gated topic    | innkeeper topic requires `spoke_to_crier`    |
+| NPC item-gated topic    | innkeeper topic requires rusty_key           |
+| NPC leads_to chain      | innkeeper topics chain: rooms -> tower       |
+| NPC sets_flag           | crier sets `spoke_to_crier` flag             |
+| NPC give/receive items  | give gem to merchant -> receive enchanted_sword |
+| Combat (attack/defend/flee) | cave_spider in cave                      |
+| Creature drops          | cave_spider drops shield on defeat           |
+| Global flags            | spoke_to_crier, tower_unlocked, spider_slain |
+| Restart                 | Always available                              |
+
+---
+
+## Constraints
+
+- The QA world replaces the current minimal `QA Test World` — same name, same
+  lookup. No second world is created.
+- World data lives in a single method (`create_qa_world` in
+  `SystemTestHelper` and the `qa_test_world` fixture) so there is exactly one
+  source of truth that both dev mode and tests use.
+- Extract the world data hash into a shared module (e.g.
+  `TestSupport::QaWorldData`) that the fixture template, `create_qa_world`,
+  and seeds can all reference.
+- Keep the world small — 5 rooms max. The goal is coverage, not scale.
+- Every item, NPC, and creature must have `keywords` for parser matching.
+
+---
+
+## Acceptance criteria
+
+- `/dev/game` loads the full-featured QA world (not the old empty room)
+- The QA world contains at least 5 rooms connected by exits in cardinal
+  directions
+- At least 2 NPCs with dialogue trees (including flag-gated and item-gated
+  topics, and a `leads_to` chain)
+- At least 1 NPC that accepts an item and gives a reward
+- At least 1 locked exit that can be unlocked via a flag
+- At least 1 hidden exit that is revealed via a flag
+- At least 1 locked container that requires a key item to open
+- At least 1 consumable item, 1 weapon, and 1 defense item
+- At least 1 creature that can be fought and drops loot
+- System tests exist that exercise each capability listed above through the
+  browser (via `/dev/game`)
+- All existing system tests continue to pass
+- `bin/rails test:system` passes on a clean checkout
+
+### System tests
+
+All tests use `/dev/game` and run through the browser with Capybara + Cuprite.
+
+#### Navigation (`test/system/qa_world/navigation_test.rb`)
+- Move in all four directions from town_square and arrive at the correct rooms
+- Attempt to move through a locked exit and see a rejection message
+- Unlock the exit (via flag) and move through successfully
+
+#### Items (`test/system/qa_world/items_test.rb`)
+- Take rusty_key from town_square, confirm it appears in inventory
+- Drop an item and confirm it appears in room description
+- Use health_potion and confirm health restored / item consumed
+
+#### Containers (`test/system/qa_world/containers_test.rb`)
+- Attempt to open chest without key, see rejection
+- Open chest with rusty_key in inventory, see contents
+
+#### NPC Dialogue (`test/system/qa_world/dialogue_test.rb`)
+- Talk to crier, receive greeting, flag `spoke_to_crier` set
+- Talk to innkeeper about a base topic
+- Attempt flag-gated topic before flag is set, see locked_text
+- Set flag via crier, then access gated topic successfully
+- Follow a `leads_to` topic chain
+
+#### NPC Item Exchange (`test/system/qa_world/exchange_test.rb`)
+- Give gem to merchant, receive enchanted_sword
+- Attempt to give wrong item, see rejection
+
+#### Combat (`test/system/qa_world/combat_test.rb`)
+- Enter cave, attack cave_spider, see combat feedback
+- Defeat spider, see loot drop (shield)
+- Test flee to exit combat and return to previous room
+
+#### Gotchas
+
+- The fixture file uses ERB (`<%= ... .to_json %>`) for the `world_data`
+  column. The shared data module must return a plain Ruby hash so both the
+  fixture ERB and the helper can use it.
+- The debug bar reads from `game_state`, not `world_data`. Make sure the
+  engine initialises state correctly for rooms with locked/hidden exits.
+- Consumable items need a `consumable` key with `effect` and `amount` — check
+  that `ItemHandler` supports this before assuming it works.
+- Container `open` requires the key item in inventory — verify
+  `ContainerHandler` checks inventory, not room items.

--- a/test/fixtures/games.yml
+++ b/test/fixtures/games.yml
@@ -1,3 +1,4 @@
+<% require_relative "../support/qa_world_data" %>
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
@@ -32,6 +33,9 @@ classic_open:
   max_players: 4
   world: qa_test_world
   game_state: <%= {
-    "world_snapshot" => { "meta" => { "starting_room" => "test_room" }, "rooms" => { "test_room" => { "name" => "Test Chamber", "description" => "A bare stone chamber.", "exits" => {}, "items" => [], "npcs" => [] } }, "items" => {}, "npcs" => {}, "creatures" => {} },
-    "player_states" => {}, "room_states" => {}, "global_flags" => {}, "container_states" => {}
+    "world_snapshot" => TestSupport::QaWorldData.data,
+    "player_states" => {},
+    "room_states" => {},
+    "global_flags" => {},
+    "container_states" => {}
   }.to_json %>

--- a/test/fixtures/worlds.yml
+++ b/test/fixtures/worlds.yml
@@ -1,3 +1,4 @@
+<% require_relative "../support/qa_world_data" %>
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
@@ -12,9 +13,5 @@ two:
 
 qa_test_world:
   name: "QA Test World"
-  description: "A minimal world for QA / developer testing"
-  world_data: <%= {
-    "meta" => { "starting_room" => "test_room", "version" => "1.0", "author" => "SuperTextAdventure" },
-    "rooms" => { "test_room" => { "name" => "Test Chamber", "description" => "A bare stone chamber used for developer testing. Nothing of interest here.", "exits" => {}, "items" => [], "npcs" => [] } },
-    "items" => {}, "npcs" => {}, "creatures" => {}
-  }.to_json %>
+  description: "A full-featured world for QA / developer testing"
+  world_data: <%= TestSupport::QaWorldData.data.to_json %>

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -1,0 +1,254 @@
+# frozen_string_literal: true
+
+module TestSupport
+  module QaWorldData # rubocop:disable Metrics/ModuleLength
+    def self.data
+      @data ||= {
+        "meta" => meta,
+        "rooms" => rooms,
+        "items" => items,
+        "npcs" => npcs,
+        "creatures" => creatures
+      }.freeze
+    end
+
+    def self.meta
+      {
+        "starting_room" => "town_square",
+        "version" => "2.0",
+        "author" => "SuperTextAdventure"
+      }
+    end
+
+    def self.rooms
+      {
+        "town_square" => town_square_room,
+        "tavern" => tavern_room,
+        "market" => market_room,
+        "cave" => cave_room,
+        "tower_top" => tower_top_room,
+        "alcove" => alcove_room
+      }
+    end
+
+    def self.town_square_room
+      {
+        "name" => "Town Square",
+        "description" => "A bustling town square with cobblestone streets. A fountain gurgles in the center.",
+        "exits" => {
+          "north" => {
+            "to" => "tower_top",
+            "requires_flag" => "tower_unlocked",
+            "locked_msg" => "The tower gate is locked."
+          },
+          "south" => "cave",
+          "east" => "tavern",
+          "west" => "market"
+        },
+        "items" => ["rusty_key"],
+        "npcs" => ["crier"]
+      }
+    end
+
+    def self.tavern_room
+      {
+        "name" => "The Tavern",
+        "description" => "A cozy inn with a roaring fireplace. The smell of ale fills the air.",
+        "exits" => { "west" => "town_square" },
+        "items" => ["chest"],
+        "npcs" => ["innkeeper"]
+      }
+    end
+
+    def self.market_room
+      {
+        "name" => "The Market",
+        "description" => "Colorful stalls line the street, filled with exotic wares.",
+        "exits" => { "east" => "town_square" },
+        "items" => [],
+        "npcs" => ["merchant"]
+      }
+    end
+
+    def self.cave_room
+      {
+        "name" => "The Cave",
+        "description" => "A dark and damp cave. Water drips from the ceiling.",
+        "exits" => {
+          "north" => "town_square",
+          "east" => {
+            "to" => "alcove",
+            "hidden" => true,
+            "requires_flag" => "spider_slain",
+            "reveal_msg" => "With the spider defeated, you notice a narrow passage to the east."
+          }
+        },
+        "items" => [],
+        "npcs" => [],
+        "creatures" => ["cave_spider"]
+      }
+    end
+
+    def self.tower_top_room
+      {
+        "name" => "Tower Top",
+        "description" => "A high vantage point overlooking the entire town. The wind howls around you.",
+        "exits" => { "south" => "town_square" },
+        "items" => ["gem"],
+        "npcs" => []
+      }
+    end
+
+    def self.alcove_room
+      {
+        "name" => "Secret Alcove",
+        "description" => "A small hidden chamber carved into the rock. Glittering crystals line the walls.",
+        "exits" => { "west" => "cave" },
+        "items" => ["shield"],
+        "npcs" => []
+      }
+    end
+
+    def self.items
+      {
+        "rusty_key" => {
+          "name" => "Rusty Key",
+          "keywords" => %w[key rusty],
+          "takeable" => true,
+          "description" => "An old rusty iron key."
+        },
+        "chest" => chest_item,
+        "health_potion" => health_potion_item,
+        "gem" => {
+          "name" => "Sparkling Gem",
+          "keywords" => %w[gem sparkling],
+          "takeable" => true,
+          "description" => "A brilliant gemstone that glows faintly."
+        },
+        "enchanted_sword" => {
+          "name" => "Enchanted Sword",
+          "keywords" => %w[sword enchanted],
+          "takeable" => true,
+          "weapon_damage" => 8,
+          "description" => "A sword that hums with magical energy."
+        },
+        "shield" => {
+          "name" => "Iron Shield",
+          "keywords" => %w[shield iron],
+          "takeable" => true,
+          "defense_bonus" => 3,
+          "description" => "A sturdy iron shield."
+        }
+      }
+    end
+
+    def self.chest_item
+      {
+        "name" => "Wooden Chest",
+        "keywords" => ["chest"],
+        "is_container" => true,
+        "starts_closed" => true,
+        "locked" => true,
+        "unlock_item" => "rusty_key",
+        "locked_message" => "The chest is locked. It looks like it needs a key.",
+        "contents" => ["health_potion"],
+        "on_open_message" => "You unlock the chest with the rusty key and open it."
+      }
+    end
+
+    def self.health_potion_item
+      {
+        "name" => "Health Potion",
+        "keywords" => %w[potion health],
+        "takeable" => true,
+        "consumable" => true,
+        "description" => "A bubbling red potion.",
+        "on_use" => { "type" => "heal", "amount" => 5, "text" => "You drink the health potion and feel revitalized!" },
+        "combat_effect" => { "type" => "heal", "amount" => 5 }
+      }
+    end
+
+    def self.npcs
+      {
+        "crier" => {
+          "name" => "Town Crier",
+          "keywords" => ["crier", "town crier"],
+          "description" => "A loud man in official garb.",
+          "dialogue" => {
+            "default" => "Hear ye! The innkeeper at the tavern knows many secrets. " \
+                         "The tower is locked by ancient magic!",
+            "sets_flag" => "spoke_to_crier"
+          }
+        },
+        "innkeeper" => innkeeper_npc,
+        "merchant" => merchant_npc
+      }
+    end
+
+    def self.innkeeper_npc
+      {
+        "name" => "Innkeeper",
+        "keywords" => %w[innkeeper keeper],
+        "description" => "A jovial woman behind the bar.",
+        "dialogue" => {
+          "default" => "Welcome to the tavern! What would you like to know?",
+          "topics" => {
+            "rooms" => {
+              "text" => "There are five main areas in this town. " \
+                        "The square, the tavern, the market, the cave, and the tower.",
+              "leads_to" => "tower"
+            },
+            "tower" => innkeeper_tower_topic,
+            "supplies" => {
+              "text" => "Ah, you have the key! The chest in the corner holds a potion that might help you.",
+              "requires_item" => "rusty_key",
+              "locked_text" => "The innkeeper glances at the chest. 'That chest needs a special key to open.'"
+            }
+          }
+        }
+      }
+    end
+
+    def self.innkeeper_tower_topic
+      {
+        "text" => "The tower can be unlocked with the right knowledge. " \
+                  "I've done it for you — the gate should open now.",
+        "requires_flag" => "spoke_to_crier",
+        "locked_text" => "The innkeeper eyes you suspiciously. " \
+                         "'I don't share secrets with strangers. Perhaps the town crier can vouch for you.'",
+        "sets_flag" => "tower_unlocked"
+      }
+    end
+
+    def self.merchant_npc
+      {
+        "name" => "Merchant",
+        "keywords" => %w[merchant trader],
+        "description" => "A shrewd-looking trader.",
+        "accepts_item" => "gem",
+        "gives_item" => "enchanted_sword",
+        "accept_message" => "The merchant's eyes light up! 'A gem! Here, take this enchanted sword in return.'",
+        "dialogue" => {
+          "default" => "Looking to trade? I'm after a sparkling gem. Bring me one and I'll make it worth your while."
+        }
+      }
+    end
+
+    def self.creatures
+      {
+        "cave_spider" => {
+          "name" => "Cave Spider",
+          "keywords" => ["spider", "cave spider"],
+          "description" => "A giant spider lurking in the shadows.",
+          "health" => 8,
+          "attack" => 3,
+          "defense" => 1,
+          "loot" => ["shield"],
+          "on_defeat_msg" => "The cave spider crumples to the ground!",
+          "on_flee_msg" => "The spider hisses as you retreat.",
+          "sets_flag_on_defeat" => "spider_slain"
+        }
+      }
+    end
+  end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -16,7 +16,8 @@ module TestSupport
       {
         "starting_room" => "town_square",
         "version" => "2.0",
-        "author" => "SuperTextAdventure"
+        "author" => "SuperTextAdventure",
+        "description" => "A QA world that has lots of things to test"
       }
     end
 
@@ -104,7 +105,7 @@ module TestSupport
         "name" => "Secret Alcove",
         "description" => "A small hidden chamber carved into the rock. Glittering crystals line the walls.",
         "exits" => { "west" => "cave" },
-        "items" => ["shield"],
+        "items" => [],
         "npcs" => []
       }
     end

--- a/test/support/system_test_helper.rb
+++ b/test/support/system_test_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "qa_world_data"
+
 module SystemTestHelper
   def sign_in_as(user, password: "testpassword")
     visit login_url
@@ -11,26 +13,8 @@ module SystemTestHelper
 
   def create_qa_world
     World.find_or_create_by!(name: "QA Test World") do |world|
-      world.description = "A minimal world for QA / developer testing"
-      world.world_data = {
-        "meta" => {
-          "starting_room" => "test_room",
-          "version" => "1.0",
-          "author" => "SuperTextAdventure"
-        },
-        "rooms" => {
-          "test_room" => {
-            "name" => "Test Chamber",
-            "description" => "A bare stone chamber used for developer testing. Nothing of interest here.",
-            "exits" => {},
-            "items" => [],
-            "npcs" => []
-          }
-        },
-        "items" => {},
-        "npcs" => {},
-        "creatures" => {}
-      }
+      world.description = "A full-featured world for QA / developer testing"
+      world.world_data = TestSupport::QaWorldData.data
     end
   end
 end

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -11,14 +11,14 @@ class ClassicGameTest < ApplicationSystemTestCase
 
   test "initial room description" do
     visit dev_game_path
-    assert_text "Test Chamber"
+    assert_text "Town Square"
   end
 
   test "send look command" do
     visit dev_game_path
     find(".terminal-input").click
     find(".terminal-input").send_keys("look", :return)
-    assert_text "Test Chamber"
+    assert_text "Town Square"
   end
 
   test "unknown command" do
@@ -31,7 +31,7 @@ class ClassicGameTest < ApplicationSystemTestCase
   test "navigation command with no exits" do
     visit dev_game_path
     find(".terminal-input").click
-    find(".terminal-input").send_keys("go north", :return)
+    find(".terminal-input").send_keys("go northeast", :return)
     assert_text "can't go"
   end
 
@@ -41,6 +41,6 @@ class ClassicGameTest < ApplicationSystemTestCase
     click_on "Reset Game"
     # Reset redirects to dev_game_path which then redirects to the new game page
     assert_current_path(%r{/games/})
-    assert_text "Test Chamber"
+    assert_text "Town Square"
   end
 end

--- a/test/system/host_test.rb
+++ b/test/system/host_test.rb
@@ -26,7 +26,7 @@ class HostTest < ApplicationSystemTestCase
     visit game_url(id: games(:classic_open).uuid)
     find(".terminal-input").click
     find(".terminal-input").send_keys("look", :return)
-    assert_text "Test Chamber"
+    assert_text "Town Square"
   end
 
   test "mute all players" do

--- a/test/system/qa_world/combat_test.rb
+++ b/test/system/qa_world/combat_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class CombatTest < ApplicationSystemTestCase
+    test "attack cave_spider shows combat feedback" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go south to cave
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+
+      # Attack the spider
+      find(".terminal-input").send_keys("attack spider", :return)
+      assert_text "Cave Spider"
+      assert_text "combat"
+    end
+
+    test "defeat spider drops shield" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go south to cave
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+
+      # Attack the spider
+      find(".terminal-input").send_keys("attack spider", :return)
+      assert_text "Cave Spider"
+
+      # Keep attacking until defeated (spider has 8 HP, min damage is 1)
+      10.times do
+        find(".terminal-input").send_keys("attack", :return)
+        break if page.has_text?("crumples", wait: 1)
+      end
+
+      assert_text "Iron Shield"
+    end
+
+    test "flee exits combat" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go south to cave
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+
+      # Attack the spider to start combat
+      find(".terminal-input").send_keys("attack spider", :return)
+      assert_text "Cave Spider"
+
+      # Try to flee (50% chance, retry up to 10 times)
+      10.times do
+        find(".terminal-input").send_keys("flee", :return)
+        break if page.has_text?("flee from combat", wait: 1)
+      end
+
+      assert_text "flee"
+    end
+  end
+end

--- a/test/system/qa_world/combat_test.rb
+++ b/test/system/qa_world/combat_test.rb
@@ -4,50 +4,65 @@ require "application_system_test_case"
 
 module QaWorld
   class CombatTest < ApplicationSystemTestCase
+    test "entering cave shows spider" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+      assert_text "Cave Spider"
+    end
+
     test "attack cave_spider shows combat feedback" do
       visit dev_game_path
       find(".terminal-input").click
 
-      # Go south to cave
       find(".terminal-input").send_keys("go south", :return)
       assert_text "The Cave"
 
-      # Attack the spider
       find(".terminal-input").send_keys("attack spider", :return)
       assert_text "Cave Spider"
       assert_text "combat"
     end
 
-    test "defeat spider drops shield" do
+    test "defeat spider drops shield and reveals passage" do
       visit dev_game_path
       find(".terminal-input").click
 
-      # Go south to cave
-      find(".terminal-input").send_keys("go south", :return)
-      assert_text "The Cave"
-
-      # Attack the spider
-      find(".terminal-input").send_keys("attack spider", :return)
-      assert_text "Cave Spider"
-
-      # Keep attacking until defeated (spider has 8 HP, min damage is 1)
-      10.times do
-        find(".terminal-input").send_keys("attack", :return)
-        break if page.has_text?("crumples", wait: 1)
-      end
+      defeat_spider
 
       assert_text "Iron Shield"
+      assert_text "narrow passage"
+    end
+
+    test "go east in cave after killing spider enters alcove in one step" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      defeat_spider
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "Secret Alcove"
+    end
+
+    test "look in cave after passage revealed shows passage description" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      defeat_spider
+
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "narrow passage"
+      assert_text "EAST"
     end
 
     test "flee exits combat" do
       visit dev_game_path
       find(".terminal-input").click
 
-      # Go south to cave
       find(".terminal-input").send_keys("go south", :return)
       assert_text "The Cave"
 
-      # Attack the spider to start combat
       find(".terminal-input").send_keys("attack spider", :return)
       assert_text "Cave Spider"
 
@@ -59,5 +74,37 @@ module QaWorld
 
       assert_text "flee"
     end
+
+    private
+
+      # Fight the spider, restarting the game if the player dies.
+      # Navigates to the cave and attacks until the spider is defeated.
+      def defeat_spider
+        3.times do |attempt|
+          find(".terminal-input").send_keys("go south", :return)
+          assert_text "The Cave"
+
+          find(".terminal-input").send_keys("attack spider", :return)
+          assert_text "Cave Spider"
+
+          defeated = false
+          10.times do
+            find(".terminal-input").send_keys("attack", :return)
+            if page.has_text?("crumples", wait: 1)
+              defeated = true
+              break
+            end
+          end
+
+          break if defeated
+
+          # Player died — restart and try again
+          assert attempt < 2, "Failed to defeat spider after 3 attempts"
+          find(".terminal-input").send_keys("restart", :return)
+          assert_text "Restart?"
+          find(".terminal-input").send_keys("yes", :return)
+          assert_text "Town Square"
+        end
+      end
   end
 end

--- a/test/system/qa_world/containers_test.rb
+++ b/test/system/qa_world/containers_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class ContainersTest < ApplicationSystemTestCase
+    test "open chest without key is rejected" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Try to open chest without the key
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "locked"
+    end
+
+    test "open chest with key shows contents" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Take the key first
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Open the chest
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "Health Potion"
+    end
+  end
+end

--- a/test/system/qa_world/dialogue_test.rb
+++ b/test/system/qa_world/dialogue_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class DialogueTest < ApplicationSystemTestCase
+    test "talk to crier shows greeting" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("talk to crier", :return)
+      assert_text "Hear ye"
+    end
+
+    test "talk to innkeeper about base topic" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to innkeeper about rooms", :return)
+      assert_text "five main areas"
+    end
+
+    test "flag-gated topic shows locked_text before flag" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern without talking to crier first
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to innkeeper about tower", :return)
+      assert_text "don't share secrets"
+    end
+
+    test "flag-gated topic succeeds after flag set" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Talk to crier to set spoke_to_crier flag
+      find(".terminal-input").send_keys("talk to crier", :return)
+      assert_text "Hear ye"
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to innkeeper about tower", :return)
+      assert_text "tower can be unlocked"
+    end
+
+    test "leads_to topic chain" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to innkeeper about rooms", :return)
+      assert_text "tower"
+    end
+  end
+end

--- a/test/system/qa_world/exchange_test.rb
+++ b/test/system/qa_world/exchange_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class ExchangeTest < ApplicationSystemTestCase
+    test "give gem to merchant receives enchanted_sword" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Unlock tower: talk to crier, go east to tavern, talk about tower, go back
+      find(".terminal-input").send_keys("talk to crier", :return)
+      assert_text "Hear ye"
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to innkeeper about tower", :return)
+      assert_text "tower can be unlocked"
+
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "Town Square"
+
+      # Go north to tower top
+      find(".terminal-input").send_keys("go north", :return)
+      assert_text "Tower Top"
+
+      # Take the gem
+      find(".terminal-input").send_keys("take gem", :return)
+      assert_text "Sparkling Gem"
+
+      # Go back south to town square
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "Town Square"
+
+      # Go west to market
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "The Market"
+
+      # Give gem to merchant
+      find(".terminal-input").send_keys("give gem to merchant", :return)
+      assert_text "Enchanted Sword"
+    end
+
+    test "give wrong item to merchant is rejected" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Take rusty key
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      # Go west to market
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "The Market"
+
+      # Try to give key to merchant
+      find(".terminal-input").send_keys("give key to merchant", :return)
+      assert_text "doesn't want"
+    end
+  end
+end

--- a/test/system/qa_world/items_test.rb
+++ b/test/system/qa_world/items_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class ItemsTest < ApplicationSystemTestCase
+    test "take rusty_key from town_square" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "Rusty Key"
+    end
+
+    test "drop item shows it in room" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("drop key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "Rusty Key"
+    end
+
+    test "use health_potion outside combat" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Take the key
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Open the chest (need key in inventory)
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "unlock the chest"
+
+      # Take the potion
+      find(".terminal-input").send_keys("take potion", :return)
+      assert_text "Health Potion"
+
+      # Use the potion
+      find(".terminal-input").send_keys("use potion", :return)
+      assert_text "revitalized"
+    end
+  end
+end

--- a/test/system/qa_world/navigation_test.rb
+++ b/test/system/qa_world/navigation_test.rb
@@ -9,6 +9,7 @@ module QaWorld
       find(".terminal-input").click
       find(".terminal-input").send_keys("go south", :return)
       assert_text "The Cave"
+      assert_text "Cave Spider"
     end
 
     test "move east from town_square to tavern" do

--- a/test/system/qa_world/navigation_test.rb
+++ b/test/system/qa_world/navigation_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class NavigationTest < ApplicationSystemTestCase
+    test "move south from town_square to cave" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+    end
+
+    test "move east from town_square to tavern" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+    end
+
+    test "move west from town_square to market" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "The Market"
+    end
+
+    test "locked exit blocks movement" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("go north", :return)
+      assert_text "locked"
+    end
+
+    test "unlock exit via flag and move through" do
+      visit dev_game_path
+
+      # Talk to crier to set spoke_to_crier flag
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("talk to crier", :return)
+      assert_text "Hear ye"
+
+      # Go east to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Talk to innkeeper about tower to set tower_unlocked flag
+      find(".terminal-input").send_keys("talk to innkeeper about tower", :return)
+      assert_text "tower can be unlocked"
+
+      # Go back to town square
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "Town Square"
+
+      # Now go north should work
+      find(".terminal-input").send_keys("go north", :return)
+      assert_text "Tower Top"
+    end
+  end
+end

--- a/test/system/world_editor_test.rb
+++ b/test/system/world_editor_test.rb
@@ -16,7 +16,7 @@ class WorldEditorTest < ApplicationSystemTestCase
   test "edit room description via entity modal" do
     visit edit_world_url(worlds(:qa_test_world))
     # Click the Edit button for the test_room in the preview panel
-    first(:link, "Edit", href: /entity_form.*entity_id=test_room/).click
+    first(:link, "Edit", href: /entity_form.*entity_id=town_square/).click
     # Wait for the entity modal slide panel to appear
     assert_selector "textarea[name='description']"
     fill_in "description", with: "Updated room description for testing"


### PR DESCRIPTION
Replace the current bare-bones QA Test World with a rich, self-contained world that exercises every game engine capability in one compact map. Developers can use `/dev/game` as an immediate manual QA playground, while system tests use the same world to verify end-to-end behaviour.

Spec: specs/pr-34-qa_world.md

## Summary

Replaced the minimal single-room QA world with a full-featured 6-room world that covers every engine capability — navigation, items, containers, NPC dialogue, item exchange, and combat — all reachable within a few commands from the starting room.

### Changes

- **`test/support/qa_world_data.rb`** — New shared module (`TestSupport::QaWorldData`) providing the full world data hash, used by fixtures, helpers, and seeds as a single source of truth
- **`InteractHandler`** — Extended `handle_talk` with topic-based dialogue: flag-gated topics, item-gated topics, `leads_to` chains, and `sets_flag` on greeting
- **`ItemHandler`** — Added `"heal"` case to `handle_use` for consumable items outside combat
- **`CombatHandler`** — Added `sets_flag_on_defeat` support so creature kills can unlock exits
- **`ContainerHandler`** — Fixed locked container open to show contents immediately after unlocking
- **Fixtures, seeds, and helpers** — Wired `qa_test_world` fixture, `create_qa_world`, and `db/seeds/feature_test_world.rb` to use shared `QaWorldData`
- **6 new system test files** — `test/system/qa_world/` covering navigation, items, containers, dialogue, exchange, and combat (22 new tests)
- **Existing system tests** — Updated `classic_game_test`, `host_test`, and `world_editor_test` for the richer world

### Test results

- Unit: 82 runs, 212 assertions, 0 failures, 0 errors
- System: 40 runs, 91 assertions, 0 failures, 0 errors
- RuboCop: 140 files inspected, no offenses
