### PR TITLE
Dice Roll Directives

### DIFF
--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -3,7 +3,7 @@ name: implement-feature
 description: Read an ingested, planned spec file and implement the feature — tests first, then code, then mark the PR ready for review.
 argument-hint: [pr-X-spec-filename]
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git *), Bash(gh *), Bash(bin/rails *), Bash(bundle *)
-model: opus
+model: sonnet
 effort: high
 context: fork
 ---

--- a/app/controllers/dev/game_controller.rb
+++ b/app/controllers/dev/game_controller.rb
@@ -48,11 +48,11 @@ module Dev
     private
 
       def refresh_qa_world
-        require Rails.root.join("test/support/qa_world_data")
-        world = World.find_by(name: "QA Test World")
-        return unless world
-
-        world.update!(world_data: TestSupport::QaWorldData.data)
+        load Rails.root.join("test/support/qa_world_data.rb")
+        world = World.find_or_initialize_by(name: "QA Test World")
+        world.description ||= "A full-featured world for QA / developer testing"
+        world.world_data = TestSupport::QaWorldData.data
+        world.save!
       end
 
       def find_or_create_dev_user

--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -19,6 +19,17 @@ class ClassicCommandJob
         command_text: message.content
       )
 
+      # If a dice roll was resolved, broadcast the visual dice event first
+      if result[:dice_roll]
+        Message.create!(
+          game: game,
+          game_user: message.game_user,
+          event_type: "roll",
+          event_data: result[:dice_roll],
+          content: ""
+        )
+      end
+
       # Create response message (will auto-broadcast via callback)
       Message.create!(
         game: game,

--- a/app/lib/classic_game/base_handler.rb
+++ b/app/lib/classic_game/base_handler.rb
@@ -225,6 +225,27 @@ module ClassicGame
         total_defense
       end
 
+      # Check if a dice roll is pending
+      def pending_roll?
+        player_state["pending_roll"].present?
+      end
+
+      # Execute directives from a dice roll branch (on_success or on_failure)
+      def execute_roll_directives(branch, room_id)
+        game.set_flag(branch["sets_flag"], true) if branch["sets_flag"]
+
+        if branch["unlocks_dialogue"]
+          topic = branch["unlocks_dialogue"]["topic"]
+          game.set_flag("dialogue_unlocked_#{topic}", true)
+        end
+
+        return unless branch["unlocks_exit"]
+
+        direction = branch["unlocks_exit"]["direction"]
+        exit_room = branch["unlocks_exit"]["room"] || room_id
+        game.unlock_exit(exit_room, direction)
+      end
+
       # Success response
       def success(message, state_changes: {})
         {

--- a/app/lib/classic_game/command_parser.rb
+++ b/app/lib/classic_game/command_parser.rb
@@ -35,7 +35,8 @@ module ClassicGame
       help: %w[help h ?],
       save: %w[save],
       quit: %w[quit exit q],
-      restart: %w[restart reset]
+      restart: %w[restart reset],
+      roll: %w[roll]
     }.freeze
 
     # Direction synonyms
@@ -101,7 +102,7 @@ module ClassicGame
             target = cleaned_words.empty? ? nil : cleaned_words.join(" ")
             [verb, target, nil]
 
-          when :inventory, :help, :save, :quit, :restart, :defend, :flee
+          when :inventory, :help, :save, :quit, :restart, :defend, :flee, :roll
             [verb, nil, nil]
 
           when :use, :give, :attack, :talk

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -32,6 +32,8 @@ module ClassicGame
         error_response("Something went wrong: #{e.message}")
       end
 
+      VALID_CONSUME_ON = %w[failure success any].freeze
+
       def validate_world_data(world_data)
         errors = []
         items = world_data["items"] || {}
@@ -41,6 +43,10 @@ module ClassicGame
           roll = item_def["dice_roll"]
           unless roll["on_success"].is_a?(Hash) && roll["on_failure"].is_a?(Hash)
             errors << "Item '#{item_id}' has a dice_roll missing on_success or on_failure."
+          end
+
+          if roll["consume_on"] && !VALID_CONSUME_ON.include?(roll["consume_on"])
+            errors << "Item '#{item_id}' has invalid consume_on '#{roll['consume_on']}' (must be: #{VALID_CONSUME_ON.join(', ')})."
           end
         end
         errors

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -7,6 +7,14 @@ module ClassicGame
         # Check if we're waiting for restart confirmation
         return handle_restart_confirmation(game, command_text) if game.game_state["pending_restart"]
 
+        # Check if a dice roll is pending — route all input to RollHandler
+        ps = game.player_state(user.id)
+        if ps["pending_roll"]
+          return ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
+            ClassicGame::CommandParser.parse(command_text)
+          )
+        end
+
         # Parse the command
         command = CommandParser.parse(command_text)
 
@@ -22,6 +30,20 @@ module ClassicGame
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))
         error_response("Something went wrong: #{e.message}")
+      end
+
+      def validate_world_data(world_data)
+        errors = []
+        items = world_data["items"] || {}
+        items.each do |item_id, item_def|
+          next unless item_def.is_a?(Hash) && item_def["dice_roll"]
+
+          roll = item_def["dice_roll"]
+          unless roll["on_success"].is_a?(Hash) && roll["on_failure"].is_a?(Hash)
+            errors << "Item '#{item_id}' has a dice_roll missing on_success or on_failure."
+          end
+        end
+        errors
       end
 
       private
@@ -44,6 +66,8 @@ module ClassicGame
                             ClassicGame::Handlers::ContainerHandler
                           when :talk, :attack, :give
                             ClassicGame::Handlers::InteractHandler
+                          when :roll
+                            ClassicGame::Handlers::RollHandler
                           when :restart
                             ClassicGame::Handlers::RestartHandler
                           when :defend, :flee

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -45,9 +45,11 @@ module ClassicGame
             errors << "Item '#{item_id}' has a dice_roll missing on_success or on_failure."
           end
 
-          if roll["consume_on"] && !VALID_CONSUME_ON.include?(roll["consume_on"])
-            errors << "Item '#{item_id}' has invalid consume_on '#{roll['consume_on']}' (must be: #{VALID_CONSUME_ON.join(', ')})."
-          end
+          next unless roll["consume_on"] && VALID_CONSUME_ON.exclude?(roll["consume_on"])
+
+          error_text = "Item '#{item_id}' has invalid consume_on '#{roll['consume_on']}'"
+          error_text += " (must be: #{VALID_CONSUME_ON.join(', ')})."
+          errors << error_text
         end
         errors
       end

--- a/app/lib/classic_game/handlers/container_handler.rb
+++ b/app/lib/classic_game/handlers/container_handler.rb
@@ -35,8 +35,12 @@ module ClassicGame
           # Check if it's locked
           if container_def["locked"]
             unlock_item = container_def["unlock_item"]
-            if unlock_item && item?(unlock_item)
-              # Player has the key, unlock and open
+            unlock_flag = container_def["unlock_flag"]
+            unlocked_by_flag = unlock_flag && game.get_flag(unlock_flag)
+            unlocked_by_item = unlock_item && item?(unlock_item)
+
+            if unlocked_by_flag || unlocked_by_item
+              # Unlocked via flag or key — open the container
               game.open_container(container_id)
               message = container_def["on_open_message"] || "You unlock and open the #{container_def['name']}."
 

--- a/app/lib/classic_game/handlers/item_handler.rb
+++ b/app/lib/classic_game/handlers/item_handler.rb
@@ -160,6 +160,13 @@ module ClassicGame
             return failure("Invalid world data: dice roll missing on_success or on_failure.")
           end
 
+          # Prevent re-triggering a roll whose success flag is already set
+          success_flag = roll_data.dig("on_success", "sets_flag")
+          if success_flag && game.get_flag(success_flag)
+            completed_msg = roll_data["completed_message"] || "Nothing happens."
+            return success(completed_msg)
+          end
+
           new_state = player_state.dup
           new_state["pending_roll"] = roll_data.merge("source_item" => item_id)
           update_player_state(new_state)

--- a/app/lib/classic_game/handlers/item_handler.rb
+++ b/app/lib/classic_game/handlers/item_handler.rb
@@ -92,6 +92,9 @@ module ClassicGame
             return handle_use_on_exit(item_id, item_def, exit_direction) if exit_direction
           end
 
+          # Check if item triggers a dice roll
+          return handle_dice_roll_trigger(item_id, item_def) if item_def["dice_roll"]
+
           # Check if item reveals an exit
           return handle_reveal_exit(item_id, item_def, item_def["reveals_exit"]) if item_def["reveals_exit"]
 
@@ -148,6 +151,22 @@ module ClassicGame
           actual_heal = new_health - current_health
           message = use_action["text"] || "You use the #{item_def['name']} and recover #{actual_heal} health!"
           success(message)
+        end
+
+        def handle_dice_roll_trigger(item_id, item_def)
+          roll_data = item_def["dice_roll"]
+
+          unless roll_data["on_success"] && roll_data["on_failure"]
+            return failure("Invalid world data: dice roll missing on_success or on_failure.")
+          end
+
+          new_state = player_state.dup
+          new_state["pending_roll"] = roll_data.merge("source_item" => item_id)
+          update_player_state(new_state)
+
+          attempt_message = roll_data["attempt_message"] ||
+                            "You attempt the action... Roll to determine the outcome."
+          success("#{attempt_message}\nType ROLL to roll the dice.")
         end
 
         def handle_reveal_exit(_item_id, _item_def, reveal_data)

--- a/app/lib/classic_game/handlers/roll_handler.rb
+++ b/app/lib/classic_game/handlers/roll_handler.rb
@@ -31,9 +31,12 @@ module ClassicGame
           # Execute directives from the winning branch
           execute_roll_directives(branch, player_state["current_room"])
 
-          # Clear pending roll
+          # Clear pending roll and consume item if applicable
           new_state = player_state.dup
           new_state.delete("pending_roll")
+          if should_consume?(roll_spec, succeeded)
+            new_state["inventory"] = (new_state["inventory"] || []) - [roll_spec["source_item"]]
+          end
           update_player_state(new_state)
 
           # Build response
@@ -41,6 +44,15 @@ module ClassicGame
           response_text = "You rolled a #{rolled}. #{outcome}\n#{branch['message']}"
 
           success(response_text).merge(dice_roll: result)
+        end
+
+        def should_consume?(roll_spec, succeeded)
+          consume_on = roll_spec["consume_on"]
+          return false unless consume_on
+
+          consume_on == "any" ||
+            (consume_on == "failure" && !succeeded) ||
+            (consume_on == "success" && succeeded)
         end
     end
   end

--- a/app/lib/classic_game/handlers/roll_handler.rb
+++ b/app/lib/classic_game/handlers/roll_handler.rb
@@ -40,7 +40,7 @@ module ClassicGame
           outcome = succeeded ? "Success!" : "Failed."
           response_text = "You rolled a #{rolled}. #{outcome}\n#{branch['message']}"
 
-          success(response_text)
+          success(response_text).merge(dice_roll: result)
         end
     end
   end

--- a/app/lib/classic_game/handlers/roll_handler.rb
+++ b/app/lib/classic_game/handlers/roll_handler.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module Handlers
+    class RollHandler < BaseHandler
+      def handle(command)
+        # If no pending roll, reject
+        return failure("Nothing to roll for.") unless pending_roll?
+
+        # If command is not :roll, prompt the player
+        return failure("You need to ROLL first. Type ROLL to roll the dice.") unless command[:verb] == :roll
+
+        resolve_roll
+      end
+
+      private
+
+        def resolve_roll
+          roll_spec = player_state["pending_roll"]
+          dc = roll_spec["dc"]
+          dice_notation = roll_spec["dice"] || "1d20"
+
+          # Roll the dice
+          result = DiceRoll.new(dice_notation)
+          rolled = result.total
+
+          # Determine outcome
+          succeeded = rolled >= dc
+          branch = succeeded ? roll_spec["on_success"] : roll_spec["on_failure"]
+
+          # Execute directives from the winning branch
+          execute_roll_directives(branch, player_state["current_room"])
+
+          # Clear pending roll
+          new_state = player_state.dup
+          new_state.delete("pending_roll")
+          update_player_state(new_state)
+
+          # Build response
+          outcome = succeeded ? "Success!" : "Failed."
+          response_text = "You rolled a #{rolled}. #{outcome}\n#{branch['message']}"
+
+          success(response_text)
+        end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -285,8 +285,14 @@ class Game < ApplicationRecord
       update!(world: selected_world) unless world
 
       # Snapshot the world data into game_state to isolate from future world changes
+      world_snapshot_data = selected_world.world_data.deep_dup
+
+      # Validate dice roll directives have both branches
+      validation_errors = ClassicGame::Engine.validate_world_data(world_snapshot_data)
+      raise "Invalid world data: #{validation_errors.join('; ')}" if validation_errors.any?
+
       update!(game_state: {
-                "world_snapshot" => selected_world.world_data.deep_dup,
+                "world_snapshot" => world_snapshot_data,
                 "player_states" => {},
                 "room_states" => {},
                 "global_flags" => {},

--- a/specs/pr-36-dice_roll_directives.md
+++ b/specs/pr-36-dice_roll_directives.md
@@ -71,3 +71,201 @@ without both branches is invalid world data.
   forward progress
 - Directive actions are the same set supported elsewhere in the engine (flags,
   dialogue, exits) — no new action types introduced by this feature
+
+---
+
+## Implementation plan
+
+> Generated 2026-03-27
+
+### 1. Files to create
+
+| File | Purpose |
+|------|---------|
+| `app/lib/classic_game/handlers/roll_handler.rb` | Handler for the `roll` verb — resolves a pending dice roll against DC, executes the matching branch directives, and returns the outcome message. |
+| `test/lib/classic_game/handlers/roll_handler_test.rb` | Tests for RollHandler covering success, failure, directive actions, validation, and edge cases. |
+
+### 2. Files to modify
+
+| File | Changes |
+|------|---------|
+| `app/lib/classic_game/command_parser.rb` | Add `:roll` verb to the `VERBS` hash (synonyms: `%w[roll]`). Add `:roll` to the no-argument verb list in `extract_parts` so it parses like `:inventory`. |
+| `app/lib/classic_game/engine.rb` | (a) Add a new priority intercept at the top of `execute`: if `player_state` has a `"pending_roll"` hash, route **all** input to `RollHandler` (similar to the `pending_restart` pattern). (b) Add `:roll` to the `get_handler` case statement, mapping to `ClassicGame::Handlers::RollHandler`. |
+| `app/lib/classic_game/base_handler.rb` | Add two protected helpers: `execute_roll_directives(branch)` — processes `sets_flag`, `unlocks_dialogue`, and `unlocks_exit` from a directive branch hash; `pending_roll?` — returns whether the player has an active pending roll. |
+| `app/lib/classic_game/handlers/item_handler.rb` | In `handle_use`, after finding the item and before any `on_use` processing: if the item definition contains a `"dice_roll"` key, validate both branches exist, set `pending_roll` on player state with the roll spec, and return the attempt message instead of executing the normal use flow. |
+| `test/lib/classic_game/command_parser_test.rb` | Add a test for the `roll` verb parsing. |
+| `test/support/classic_game_helper.rb` | Add an `unlock_dialogue(npc_id, topic_id)` convenience method on `FakeGame` that calls `set_flag("dialogue_unlocked_#{topic_id}", true)` — useful for asserting unlocks_dialogue directive results. |
+
+### 3. Implementation steps
+
+**Step 1 — Add `roll` verb to CommandParser**
+
+In `app/lib/classic_game/command_parser.rb`:
+- Add `roll: %w[roll]` to the `VERBS` hash, inside the `# Special` group (after `restart`).
+- Add `:roll` to the `when :inventory, :help, :save, :quit, :restart, :defend, :flee` branch in `extract_parts` so it returns `[verb, nil, nil]`.
+
+**Step 2 — Add `pending_roll?` and `execute_roll_directives` helpers to BaseHandler**
+
+In `app/lib/classic_game/base_handler.rb`, add two new protected methods:
+
+- `pending_roll?` — returns `player_state["pending_roll"].present?`.
+- `execute_roll_directives(branch, room_id)` — iterates over the directive keys in the branch hash:
+  - `"sets_flag"` — calls `game.set_flag(value, true)`.
+  - `"unlocks_dialogue"` — reads `npc` and `topic` from the sub-hash, calls `game.set_flag("dialogue_unlocked_#{topic}", true)`.
+  - `"unlocks_exit"` — reads `room` (defaults to `room_id`) and `direction`, calls `game.unlock_exit(room, direction)`.
+
+**Step 3 — Create RollHandler**
+
+Create `app/lib/classic_game/handlers/roll_handler.rb`:
+
+```
+ClassicGame::Handlers::RollHandler < BaseHandler
+```
+
+`handle(command)`:
+1. Guard: return `failure("Nothing to roll for.")` unless `pending_roll?`.
+2. Read `roll_spec = player_state["pending_roll"]` — contains `"dc"`, `"stat"`, `"dice"` (default `"1d20"`), `"on_success"`, `"on_failure"`, `"source_item"`.
+3. Parse the dice notation from `roll_spec["dice"] || "1d20"` using the existing `DiceRoll` class: `result = DiceRoll.new(roll_spec["dice"] || "1d20")`.
+4. Compare `result.total` against `roll_spec["dc"]`.
+5. Select the winning branch: `branch = result.total >= dc ? roll_spec["on_success"] : roll_spec["on_failure"]`.
+6. Call `execute_roll_directives(branch, player_state["current_room"])`.
+7. Clear `pending_roll` from player state.
+8. Build the response: `"You rolled a #{result.total}. #{result.total >= dc ? 'Success!' : 'Failed.'}\n#{branch['message']}"`.
+9. Return `success(response_text)`.
+
+**Step 4 — Wire RollHandler into Engine**
+
+In `app/lib/classic_game/engine.rb`, method `execute`:
+- After the `pending_restart` check (line 8) and before `CommandParser.parse`, add:
+  ```ruby
+  player_state = game.player_state(user.id)
+  if player_state["pending_roll"]
+    return ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
+      ClassicGame::CommandParser.parse(command_text)
+    )
+  end
+  ```
+  This ensures that while a roll is pending, any input (even non-"roll" commands) is routed to the RollHandler, which will reject non-roll input with a prompt.
+
+- In the `get_handler` case statement, add:
+  ```ruby
+  when :roll
+    ClassicGame::Handlers::RollHandler
+  ```
+
+Actually, refine the RollHandler `handle` method: if `pending_roll?` is true but the verb is not `:roll`, return `failure("You need to ROLL first. Type ROLL to roll the dice.")`. If `pending_roll?` is false and verb is `:roll`, return `failure("Nothing to roll for.")`.
+
+**Step 5 — Add dice roll trigger to ItemHandler**
+
+In `app/lib/classic_game/handlers/item_handler.rb`, in `handle_use`, after verifying the player has the item (line 87), add a new check before the `reveals_exit` check (line 96):
+
+```ruby
+# Check if item triggers a dice roll
+if item_def["dice_roll"]
+  return handle_dice_roll_trigger(item_id, item_def)
+end
+```
+
+Add private method `handle_dice_roll_trigger(item_id, item_def)`:
+1. Read `roll_data = item_def["dice_roll"]`.
+2. Validate both branches: `return failure("Invalid world data: dice roll missing on_success or on_failure.")` unless `roll_data["on_success"] && roll_data["on_failure"]`.
+3. Set `pending_roll` on player state:
+   ```ruby
+   new_state = player_state.dup
+   new_state["pending_roll"] = roll_data.merge("source_item" => item_id)
+   update_player_state(new_state)
+   ```
+4. Build attempt message: `roll_data["attempt_message"] || "You attempt the action... Roll to determine the outcome."`.
+5. Append: `"\nType ROLL to roll the dice."`.
+6. Return `success(attempt_message)`.
+
+**Step 6 — Add world-load validation for dice_roll branches**
+
+In `app/lib/classic_game/engine.rb`, add a class method `validate_world_data(world_data)` that iterates all items in `world_data["items"]` and for any item with a `"dice_roll"` key, checks that both `"on_success"` and `"on_failure"` are present hashes. Returns an array of error strings. This can be called at game setup time.
+
+In `Game#setup_classic_game` (in `app/models/game.rb`), after snapshotting the world, call `ClassicGame::Engine.validate_world_data(world_snapshot)` and raise if errors are found. This fulfills the acceptance criterion "a roll with only one branch is rejected with a clear error at world-load time."
+
+**Step 7 — Write tests**
+
+See Test Plan below.
+
+### 4. Test plan
+
+All tests go in `test/lib/classic_game/handlers/roll_handler_test.rb`. They use `ClassicGameTestHelper` and `FakeGame`.
+
+#### Test: "roll command parses correctly"
+- **File**: `test/lib/classic_game/command_parser_test.rb`
+- **Input**: `"roll"`
+- **Expected**: `{ verb: :roll, target: nil }`
+
+#### Test: "successful roll sets flag and returns success message"
+- **Setup**: World with item `"lockpick"` having `dice_roll: { dc: 10, stat: "dexterity", on_success: { sets_flag: "door_unlocked", message: "The lock clicks open." }, on_failure: { message: "You fail.", sets_flag: "lock_jammed" } }`. Player has `lockpick` in inventory. Player has `pending_roll` already set (simulating post-use state).
+- **Input**: `"roll"`
+- **Mock**: Stub `DiceRoll` or `rand` to produce a total >= 10.
+- **Expected**: Response includes "Success!" and "The lock clicks open.". Flag `"door_unlocked"` is set. `pending_roll` cleared from player state.
+
+#### Test: "failed roll executes on_failure directive and returns failure message"
+- **Setup**: Same world. `pending_roll` set with DC 15.
+- **Input**: `"roll"`
+- **Mock**: Stub to produce total < 15.
+- **Expected**: Response includes "Failed." and the failure message. Failure flag/directive is executed. `pending_roll` cleared.
+
+#### Test: "roll with unlocks_dialogue directive sets dialogue flag"
+- **Setup**: `on_failure: { unlocks_dialogue: { npc: "guard_captain", topic: "door" }, message: "..." }`. Pending roll set, roll fails.
+- **Input**: `"roll"`
+- **Expected**: `game.get_flag("dialogue_unlocked_door")` is truthy.
+
+#### Test: "roll with unlocks_exit directive unlocks the exit"
+- **Setup**: `on_success: { unlocks_exit: { direction: "north" }, message: "..." }`. Pending roll set, roll succeeds.
+- **Input**: `"roll"`
+- **Expected**: `game.exit_unlocked?(current_room, "north")` is true.
+
+#### Test: "non-roll command while roll is pending returns prompt to roll"
+- **Setup**: Player has `pending_roll` set.
+- **Input**: `"go north"`
+- **Expected**: Response includes "You need to ROLL first".
+
+#### Test: "roll with no pending roll returns nothing to roll for"
+- **Setup**: No `pending_roll` on player state.
+- **Input**: `"roll"`
+- **Expected**: `success: false`, response includes "Nothing to roll for."
+
+#### Test: "using item with dice_roll sets pending_roll and returns attempt message"
+- **Setup**: Item `"lockpick"` with `dice_roll` data in world. Player has `lockpick` in inventory.
+- **Input**: `"use lockpick"`
+- **Expected**: `success: true`, response includes "Roll to determine the outcome" and "Type ROLL". Player state now has `pending_roll`.
+
+#### Test: "item with dice_roll missing on_failure is rejected"
+- **Setup**: Item with `dice_roll: { dc: 10, on_success: { ... } }` (no `on_failure`).
+- **Input**: `"use lockpick"`
+- **Expected**: `success: false`, response includes "Invalid world data".
+
+#### Test: "player always receives the message from the matching branch"
+- **Setup**: Two different messages in success vs failure branches. Run twice, once succeeding, once failing.
+- **Expected**: Each run returns exactly the message from its branch.
+
+### 5. Gotchas and constraints
+
+- **Follow the `pending_restart` pattern exactly.** The engine already has a priority-intercept pattern for `pending_restart` (line 8 of `Engine.execute`). The `pending_roll` intercept should be structured identically — check before parsing, route to handler, let handler decide validity.
+
+- **RuboCop rules to respect:**
+  - `Style/StringLiterals: double_quotes` — all strings must use double quotes.
+  - `Metrics/MethodLength: Max 60` — keep handler methods under 60 lines.
+  - `Layout/IndentationConsistency: indented_internal_methods` — private/protected methods indented one extra level inside the class body (matching all existing handlers).
+  - `# frozen_string_literal: true` at top of every Ruby file.
+
+- **DiceRoll class expects a string like `"1d20"`.** It uses `scan(/(\d{1,2}d\d{1,2})|([-+]\d{1,2})/)` to parse. The `dice_roll` world data should default to `"1d20"` if no dice notation is specified, so `DiceRoll.new(roll_spec["dice"] || "1d20")` is correct.
+
+- **FakeGame in tests does not call `save!` with real persistence.** The `set_flag`, `unlock_exit` etc. methods on FakeGame modify in-memory state, which is sufficient. The `unlock_dialogue` convenience helper should be added to FakeGame for test readability.
+
+- **`execute_roll_directives` must handle all three action types idempotently.** `sets_flag` calls `game.set_flag(name, true)`. `unlocks_dialogue` calls `game.set_flag("dialogue_unlocked_#{topic}", true)` — this mirrors `InteractHandler#handle_talk_topic` line 96. `unlocks_exit` calls `game.unlock_exit(room, direction)` — this mirrors `ItemHandler#handle_use_on_exit` line 271.
+
+- **The `pending_roll` hash stored on player state must include the full roll spec** (dc, on_success, on_failure, optional dice notation, source_item). This is cleared after the roll resolves, regardless of outcome.
+
+- **World validation happens at game setup time** (in `Game#setup_classic_game`), not at World save time. This keeps the World model simple and catches errors only when a game is actually created from invalid world data.
+
+- **No new "action types" are introduced.** The directives `sets_flag`, `unlocks_dialogue`, and `unlocks_exit` already exist in the engine (used by InteractHandler, ItemHandler, CombatHandler). The roll handler just reuses the same game state mutation methods.
+
+- **The spec mentions a "Roll state" where the user types "ROLL 1d20".** For simplicity, the implementation should accept bare `ROLL` (the dice notation comes from the world data, not the player). The pending_roll spec already knows which dice to roll. This avoids parsing issues and keeps the player experience simple.
+
+- **Edge case: player dies or restarts while a roll is pending.** The `pending_restart` check in Engine.execute happens before the `pending_roll` check, so restart always takes priority. If the game is fully reset, `pending_roll` is cleared along with all player state.

--- a/specs/pr-36-dice_roll_directives.md
+++ b/specs/pr-36-dice_roll_directives.md
@@ -1,3 +1,5 @@
+> PR: https://github.com/Fishy49/supertextadventure/pull/36
+
 # Dice Roll Directives
 
 Dice rolls defined in the world JSON can specify branching outcomes — one for

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -9,6 +9,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
                       options: { headless: ENV["CI"].present? || ENV["HEADLESS"].present?,
                                  browser_path: ENV.fetch("BROWSER_PATH", nil),
                                  pending_connection_errors: false,
+                                 process_timeout: 30,
                                  browser_options: { "no-sandbox" => nil } }
 
   Capybara.default_max_wait_time = 10

--- a/test/lib/classic_game/command_parser_test.rb
+++ b/test/lib/classic_game/command_parser_test.rb
@@ -142,6 +142,12 @@ class CommandParserTest < ActiveSupport::TestCase
     assert_nil result[:target]
   end
 
+  test "roll command parses correctly" do
+    result = ClassicGame::CommandParser.parse("roll")
+    assert_equal :roll, result[:verb]
+    assert_nil result[:target]
+  end
+
   # ─── Edge cases ─────────────────────────────────────────────────────────────
 
   test "blank input returns unknown verb" do

--- a/test/lib/classic_game/handlers/item_handler_test.rb
+++ b/test/lib/classic_game/handlers/item_handler_test.rb
@@ -169,6 +169,95 @@ class ItemHandlerTest < ActiveSupport::TestCase
     assert_includes result[:response].downcase, "can't use"
   end
 
+  # ─── DICE ROLL RE-TRIGGER GUARD ──────────────────────────────────────────────
+
+  test "using dice roll item after success flag is set shows completed message" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "items" => [] }
+      },
+      items: {
+        "lockpick" => {
+          "name" => "Lockpick", "keywords" => ["lockpick"], "takeable" => true,
+          "dice_roll" => {
+            "dc" => 12, "dice" => "1d20",
+            "completed_message" => "The chest lock is already open.",
+            "on_success" => { "sets_flag" => "chest_unlocked", "message" => "Click!" },
+            "on_failure" => { "message" => "Nope." }
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room1", inventory: ["lockpick"]))
+    game.set_flag("chest_unlocked", true)
+
+    command = ClassicGame::CommandParser.parse("use lockpick")
+    result = ClassicGame::Handlers::ItemHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "The chest lock is already open."
+    assert_nil game.player_state(USER_ID)["pending_roll"]
+  end
+
+  test "using dice roll item after success flag is set uses default message when no completed_message" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "items" => [] }
+      },
+      items: {
+        "lockpick" => {
+          "name" => "Lockpick", "keywords" => ["lockpick"], "takeable" => true,
+          "dice_roll" => {
+            "dc" => 12, "dice" => "1d20",
+            "on_success" => { "sets_flag" => "chest_unlocked", "message" => "Click!" },
+            "on_failure" => { "message" => "Nope." }
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room1", inventory: ["lockpick"]))
+    game.set_flag("chest_unlocked", true)
+
+    command = ClassicGame::CommandParser.parse("use lockpick")
+    result = ClassicGame::Handlers::ItemHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "Nothing happens."
+  end
+
+  test "using dice roll item without success flag set triggers roll normally" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "items" => [] }
+      },
+      items: {
+        "lockpick" => {
+          "name" => "Lockpick", "keywords" => ["lockpick"], "takeable" => true,
+          "dice_roll" => {
+            "dc" => 12, "dice" => "1d20",
+            "completed_message" => "Already done.",
+            "on_success" => { "sets_flag" => "chest_unlocked", "message" => "Click!" },
+            "on_failure" => { "message" => "Nope." }
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room1", inventory: ["lockpick"]))
+
+    command = ClassicGame::CommandParser.parse("use lockpick")
+    result = ClassicGame::Handlers::ItemHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "Type ROLL"
+    assert game.player_state(USER_ID)["pending_roll"]
+  end
+
   # ─── USE ON EXIT ────────────────────────────────────────────────────────────
 
   test "use item on locked exit unlocks it" do

--- a/test/lib/classic_game/handlers/roll_handler_test.rb
+++ b/test/lib/classic_game/handlers/roll_handler_test.rb
@@ -214,6 +214,87 @@ class RollHandlerTest < ActiveSupport::TestCase
     assert_includes result[:response], "Invalid world data"
   end
 
+  # ─── CONSUME_ON DIRECTIVE ─────────────────────────────────────────────────
+
+  test "consume_on failure removes item from inventory on failed roll" do
+    roll_data = guaranteed_failure_roll.merge(
+      "consume_on" => "failure",
+      "on_success" => { "message" => "It works." },
+      "on_failure" => { "message" => "The pick snaps!" }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("roll")
+
+    assert result[:success]
+    assert_includes result[:response], "The pick snaps!"
+    assert_not_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
+  test "consume_on failure keeps item on successful roll" do
+    roll_data = guaranteed_success_roll.merge(
+      "consume_on" => "failure",
+      "on_success" => { "message" => "It works." },
+      "on_failure" => { "message" => "It breaks." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
+  test "consume_on success removes item from inventory on successful roll" do
+    roll_data = guaranteed_success_roll.merge(
+      "consume_on" => "success",
+      "on_success" => { "message" => "Used up!" },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert_not_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
+  test "consume_on success keeps item on failed roll" do
+    roll_data = guaranteed_failure_roll.merge(
+      "consume_on" => "success",
+      "on_success" => { "message" => "Used up!" },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
+  test "consume_on any removes item regardless of outcome" do
+    roll_data = guaranteed_success_roll.merge(
+      "consume_on" => "any",
+      "on_success" => { "message" => "Done." },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert_not_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
+  test "no consume_on keeps item in inventory" do
+    roll_data = guaranteed_success_roll.merge(
+      "on_success" => { "message" => "Done." },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert_includes @game.player_state(USER_ID)["inventory"], "lockpick"
+  end
+
   # ─── PLAYER RECEIVES CORRECT BRANCH MESSAGE ──────────────────────────────
 
   test "player always receives the message from the success branch on success" do

--- a/test/lib/classic_game/handlers/roll_handler_test.rb
+++ b/test/lib/classic_game/handlers/roll_handler_test.rb
@@ -1,0 +1,265 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RollHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {
+            "north" => {
+              "to" => "room2",
+              "requires_flag" => "door_unlocked",
+              "locked_msg" => "The door is locked."
+            }
+          },
+          "items" => ["lockpick"]
+        },
+        "room2" => {
+          "name" => "Room 2",
+          "description" => "Another room.",
+          "exits" => {}
+        }
+      },
+      items: {
+        "lockpick" => {
+          "name" => "Lockpick",
+          "keywords" => %w[lockpick pick],
+          "takeable" => true,
+          "dice_roll" => {
+            "dc" => 12,
+            "stat" => "dexterity",
+            "dice" => "1d20",
+            "on_success" => {
+              "sets_flag" => "door_unlocked",
+              "message" => "The lock clicks open."
+            },
+            "on_failure" => {
+              "sets_flag" => "lock_jammed",
+              "message" => "You scratch up the lock badly."
+            }
+          }
+        }
+      },
+      npcs: {
+        "guard_captain" => {
+          "name" => "Guard Captain",
+          "keywords" => %w[guard captain],
+          "dialogue" => {
+            "greeting" => "Move along.",
+            "default" => "I have nothing to say.",
+            "topics" => {
+              "door" => {
+                "keywords" => %w[door entrance],
+                "text" => "There is a secret passage around back.",
+                "locked_text" => "I don't know what you mean."
+              }
+            }
+          }
+        }
+      }
+    )
+    @game = build_game(world_data: @world, player_id: USER_ID,
+                       player_state: player_state_in("room1", inventory: ["lockpick"]))
+  end
+
+  # ─── SUCCESSFUL ROLL ──────────────────────────────────────────────────────
+  # DC 1 with 1d20 guarantees success (min roll is 1 which equals DC)
+
+  test "successful roll sets flag and returns success message" do
+    roll_data = guaranteed_success_roll.merge(
+      "on_success" => { "sets_flag" => "door_unlocked", "message" => "The lock clicks open." },
+      "on_failure" => { "sets_flag" => "lock_jammed", "message" => "You scratch up the lock badly." }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("roll")
+
+    assert result[:success]
+    assert_includes result[:response], "Success!"
+    assert_includes result[:response], "The lock clicks open."
+    assert @game.get_flag("door_unlocked")
+    assert_nil @game.player_state(USER_ID)["pending_roll"]
+  end
+
+  # ─── FAILED ROLL ──────────────────────────────────────────────────────────
+  # DC 100 with 1d20 guarantees failure (max roll is 20 which is < 100)
+
+  test "failed roll executes on_failure directive and returns failure message" do
+    roll_data = guaranteed_failure_roll.merge(
+      "on_success" => { "sets_flag" => "door_unlocked", "message" => "The lock clicks open." },
+      "on_failure" => { "sets_flag" => "lock_jammed", "message" => "You scratch up the lock badly." }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("roll")
+
+    assert result[:success]
+    assert_includes result[:response], "Failed."
+    assert_includes result[:response], "You scratch up the lock badly."
+    assert @game.get_flag("lock_jammed")
+    assert_nil @game.player_state(USER_ID)["pending_roll"]
+  end
+
+  # ─── UNLOCKS_DIALOGUE DIRECTIVE ───────────────────────────────────────────
+
+  test "roll with unlocks_dialogue directive sets dialogue flag" do
+    roll_data = guaranteed_failure_roll.merge(
+      "on_success" => { "sets_flag" => "ok", "message" => "Ok." },
+      "on_failure" => {
+        "unlocks_dialogue" => { "npc" => "guard_captain", "topic" => "door" },
+        "message" => "You fail. Maybe the guard captain knows another way."
+      }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert @game.get_flag("dialogue_unlocked_door")
+  end
+
+  # ─── UNLOCKS_EXIT DIRECTIVE ───────────────────────────────────────────────
+
+  test "roll with unlocks_exit directive unlocks the exit" do
+    roll_data = guaranteed_success_roll.merge(
+      "on_success" => {
+        "unlocks_exit" => { "direction" => "north" },
+        "message" => "The door swings open."
+      },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    execute_roll("roll")
+
+    assert @game.exit_unlocked?("room1", "north")
+  end
+
+  # ─── NON-ROLL COMMAND WHILE PENDING ───────────────────────────────────────
+
+  test "non-roll command while roll is pending returns prompt to roll" do
+    roll_data = guaranteed_success_roll.merge(
+      "on_success" => { "message" => "Ok." },
+      "on_failure" => { "message" => "Nope." }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("go north")
+
+    assert_not result[:success]
+    assert_includes result[:response], "You need to ROLL first"
+  end
+
+  # ─── ROLL WITH NO PENDING ROLL ───────────────────────────────────────────
+
+  test "roll with no pending roll returns nothing to roll for" do
+    result = execute_roll("roll")
+
+    assert_not result[:success]
+    assert_includes result[:response], "Nothing to roll for."
+  end
+
+  # ─── USE ITEM WITH DICE_ROLL SETS PENDING_ROLL ───────────────────────────
+
+  test "using item with dice_roll sets pending_roll and returns attempt message" do
+    command = ClassicGame::CommandParser.parse("use lockpick")
+    result = ClassicGame::Handlers::ItemHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "Type ROLL"
+    assert @game.player_state(USER_ID)["pending_roll"]
+    assert_equal "lockpick", @game.player_state(USER_ID).dig("pending_roll", "source_item")
+  end
+
+  # ─── INVALID DICE_ROLL DATA ──────────────────────────────────────────────
+
+  test "item with dice_roll missing on_failure is rejected" do
+    bad_world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A room.",
+          "exits" => {},
+          "items" => ["bad_pick"]
+        }
+      },
+      items: {
+        "bad_pick" => {
+          "name" => "Bad Pick",
+          "keywords" => ["pick"],
+          "takeable" => true,
+          "dice_roll" => {
+            "dc" => 10,
+            "on_success" => { "sets_flag" => "ok", "message" => "It works." }
+          }
+        }
+      }
+    )
+    bad_game = build_game(world_data: bad_world, player_id: USER_ID,
+                          player_state: player_state_in("room1", inventory: ["bad_pick"]))
+
+    command = ClassicGame::CommandParser.parse("use pick")
+    result = ClassicGame::Handlers::ItemHandler.new(game: bad_game, user_id: USER_ID).handle(command)
+
+    assert_not result[:success]
+    assert_includes result[:response], "Invalid world data"
+  end
+
+  # ─── PLAYER RECEIVES CORRECT BRANCH MESSAGE ──────────────────────────────
+
+  test "player always receives the message from the success branch on success" do
+    roll_data = guaranteed_success_roll.merge(
+      "on_success" => { "message" => "The lock clicks open." },
+      "on_failure" => { "message" => "You scratch up the lock badly." }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("roll")
+    assert_includes result[:response], "The lock clicks open."
+    assert_not_includes result[:response], "You scratch up the lock badly."
+  end
+
+  test "player always receives the message from the failure branch on failure" do
+    roll_data = guaranteed_failure_roll.merge(
+      "on_success" => { "message" => "The lock clicks open." },
+      "on_failure" => { "message" => "You scratch up the lock badly." }
+    )
+    apply_pending_roll(roll_data)
+
+    result = execute_roll("roll")
+    assert_includes result[:response], "You scratch up the lock badly."
+    assert_not_includes result[:response], "The lock clicks open."
+  end
+
+  private
+
+    def execute_roll(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::RollHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+
+    def apply_pending_roll(roll_data)
+      new_state = @game.player_state(USER_ID).dup
+      new_state["pending_roll"] = roll_data
+      @game.update_player_state(USER_ID, new_state)
+    end
+
+    # DC 1 with 1d20 → always succeeds (min roll = 1 = DC)
+    def guaranteed_success_roll
+      { "dc" => 1, "dice" => "1d20", "source_item" => "lockpick" }
+    end
+
+    # DC 100 with 1d20 → always fails (max roll = 20 < 100)
+    def guaranteed_failure_roll
+      { "dc" => 100, "dice" => "1d20", "source_item" => "lockpick" }
+    end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -56,7 +56,7 @@ module TestSupport
         "name" => "The Tavern",
         "description" => "A cozy inn with a roaring fireplace. The smell of ale fills the air.",
         "exits" => { "west" => "town_square" },
-        "items" => ["chest"],
+        "items" => %w[chest lockpick],
         "npcs" => ["innkeeper"]
       }
     end
@@ -139,6 +139,30 @@ module TestSupport
           "takeable" => true,
           "defense_bonus" => 3,
           "description" => "A sturdy iron shield."
+        },
+        "lockpick" => lockpick_item
+      }
+    end
+
+    def self.lockpick_item
+      {
+        "name" => "Lockpick",
+        "keywords" => %w[lockpick pick],
+        "takeable" => true,
+        "description" => "A thin metal pick for opening locks.",
+        "dice_roll" => {
+          "dc" => 12,
+          "stat" => "dexterity",
+          "dice" => "1d20",
+          "attempt_message" => "You carefully insert the lockpick and attempt to pick the lock...",
+          "on_success" => {
+            "sets_flag" => "tavern_lockpick_success",
+            "message" => "The lock clicks open with a satisfying snap!"
+          },
+          "on_failure" => {
+            "sets_flag" => "tavern_lockpick_failed",
+            "message" => "The pick slips and bends. You will need another approach."
+          }
         }
       }
     end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -154,6 +154,8 @@ module TestSupport
           "dc" => 12,
           "stat" => "dexterity",
           "dice" => "1d20",
+          "consume_on" => "failure",
+          "completed_message" => "The chest lock is already open.",
           "attempt_message" => "You carefully insert the lockpick and attempt to pick the lock...",
           "on_success" => {
             "sets_flag" => "tavern_lockpick_success",
@@ -161,7 +163,7 @@ module TestSupport
           },
           "on_failure" => {
             "sets_flag" => "tavern_lockpick_failed",
-            "message" => "The pick slips and bends. You will need another approach."
+            "message" => "The lockpick snaps! You will need another approach."
           }
         }
       }

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -175,9 +175,10 @@ module TestSupport
         "starts_closed" => true,
         "locked" => true,
         "unlock_item" => "rusty_key",
-        "locked_message" => "The chest is locked. It looks like it needs a key.",
+        "unlock_flag" => "tavern_lockpick_success",
+        "locked_message" => "The chest is locked. You could try picking the lock.",
         "contents" => ["health_potion"],
-        "on_open_message" => "You unlock the chest with the rusty key and open it."
+        "on_open_message" => "You unlock the chest and open it."
       }
     end
 

--- a/test/system/qa_world/combat_test.rb
+++ b/test/system/qa_world/combat_test.rb
@@ -79,32 +79,46 @@ module QaWorld
 
       # Fight the spider, restarting the game if the player dies.
       # Navigates to the cave and attacks until the spider is defeated.
+      # Grab the rusty key, open the chest for the health potion, then fight.
+      # The potion gives a heal mid-combat, making the fight reliably winnable.
       def defeat_spider
-        3.times do |attempt|
-          find(".terminal-input").send_keys("go south", :return)
-          assert_text "The Cave"
+        # Deterministic setup: key → tavern → open chest → take potion
+        find(".terminal-input").send_keys("take key", :return)
+        assert_text "Rusty Key"
 
-          find(".terminal-input").send_keys("attack spider", :return)
-          assert_text "Cave Spider"
+        find(".terminal-input").send_keys("go east", :return)
+        assert_text "The Tavern"
 
-          defeated = false
-          10.times do
+        find(".terminal-input").send_keys("open chest", :return)
+        assert_text "Health Potion"
+
+        find(".terminal-input").send_keys("take potion", :return)
+        assert_text "You take"
+
+        find(".terminal-input").send_keys("go west", :return)
+        assert_text "Town Square"
+
+        find(".terminal-input").send_keys("go south", :return)
+        assert_text "The Cave"
+
+        find(".terminal-input").send_keys("attack spider", :return)
+        assert_text "Cave Spider"
+
+        # First exchange — take at least one hit so the potion isn't wasted
+        find(".terminal-input").send_keys("attack", :return)
+
+        unless page.has_text?("crumples", wait: 1)
+          # Heal after taking damage, giving us ~15 effective HP
+          find(".terminal-input").send_keys("use potion", :return)
+          assert_text "recover"
+
+          14.times do
             find(".terminal-input").send_keys("attack", :return)
-            if page.has_text?("crumples", wait: 1)
-              defeated = true
-              break
-            end
+            break if page.has_text?("crumples", wait: 1)
           end
-
-          break if defeated
-
-          # Player died — restart and try again
-          assert attempt < 2, "Failed to defeat spider after 3 attempts"
-          find(".terminal-input").send_keys("restart", :return)
-          assert_text "Restart?"
-          find(".terminal-input").send_keys("yes", :return)
-          assert_text "Town Square"
         end
+
+        assert_text "crumples"
       end
   end
 end

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -60,5 +60,99 @@ module QaWorld
       find(".terminal-input").send_keys("look", :return)
       assert_text "You need to ROLL first"
     end
+
+    test "successful roll sets unlock flag and chest becomes openable" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      # Retry until we roll a success (DC 12 on 1d20, ~55% chance each attempt)
+      20.times do
+        find(".terminal-input").send_keys("use lockpick", :return)
+        assert_text "Type ROLL"
+        find(".terminal-input").send_keys("roll", :return)
+        break if page.has_text?("Success!", wait: 2)
+      end
+
+      assert_text "Success!"
+      assert_text "The lock clicks open"
+
+      # The unlock flag should now allow opening the chest without the key
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "Health Potion"
+    end
+
+    test "failed roll shows failure branch message" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      # Retry until we roll a failure (DC 12 on 1d20, ~45% chance each attempt)
+      20.times do
+        find(".terminal-input").send_keys("use lockpick", :return)
+        assert_text "Type ROLL"
+        find(".terminal-input").send_keys("roll", :return)
+        break if page.has_text?("Failed.", wait: 2)
+      end
+
+      assert_text "Failed."
+      assert_text "The pick slips and bends"
+    end
+
+    test "rolling dice creates a dice event message showing the roll total" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      find(".terminal-input").send_keys("use lockpick", :return)
+      assert_text "Type ROLL"
+
+      find(".terminal-input").send_keys("roll", :return)
+      assert_text(/Success!|Failed\./)
+
+      # A dice event message with the roll breakdown should appear
+      assert_text "TOTAL:"
+    end
+
+    test "chest contents can be taken after successful lockpick roll" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      20.times do
+        find(".terminal-input").send_keys("use lockpick", :return)
+        assert_text "Type ROLL"
+        find(".terminal-input").send_keys("roll", :return)
+        break if page.has_text?("Success!", wait: 2)
+      end
+
+      assert_text "Success!"
+
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "Health Potion"
+
+      find(".terminal-input").send_keys("take potion", :return)
+      assert_text "You take the Health Potion"
+    end
   end
 end

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -129,7 +129,7 @@ module QaWorld
       # Uses message-count sync to avoid stale text matching after restarts.
       def roll_until_outcome(desired, max_attempts: 20)
         max_attempts.times do |i|
-          restart_game if i > 0
+          restart_game if i.positive?
 
           send_and_wait("go east")
           send_and_wait("take lockpick")

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -39,7 +39,8 @@ module QaWorld
 
       # Roll the dice — outcome is random, but we should see either Success or Failed
       find(".terminal-input").send_keys("roll", :return)
-      assert_selector ".message", text: /Success!|Failed\./
+      assert_text(/Success!|Failed\./)
+
     end
 
     test "non-roll command while roll pending is rejected" do

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -40,7 +40,6 @@ module QaWorld
       # Roll the dice — outcome is random, but we should see either Success or Failed
       find(".terminal-input").send_keys("roll", :return)
       assert_text(/Success!|Failed\./)
-
     end
 
     test "non-roll command while roll pending is rejected" do

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -8,18 +8,15 @@ module QaWorld
       visit dev_game_path
       find(".terminal-input").click
 
-      # Go to tavern, get the lockpick from the innkeeper's storeroom
       find(".terminal-input").send_keys("take key", :return)
       assert_text "Rusty Key"
 
       find(".terminal-input").send_keys("go east", :return)
       assert_text "The Tavern"
 
-      # Pick up the lockpick (placed in tavern by QA world)
       find(".terminal-input").send_keys("take lockpick", :return)
       assert_text "Lockpick"
 
-      # Use the lockpick to trigger a dice roll
       find(".terminal-input").send_keys("use lockpick", :return)
       assert_text "Type ROLL"
     end
@@ -37,7 +34,6 @@ module QaWorld
       find(".terminal-input").send_keys("use lockpick", :return)
       assert_text "Type ROLL"
 
-      # Roll the dice — outcome is random, but we should see either Success or Failed
       find(".terminal-input").send_keys("roll", :return)
       assert_text(/Success!|Failed\./)
     end
@@ -55,7 +51,6 @@ module QaWorld
       find(".terminal-input").send_keys("use lockpick", :return)
       assert_text "Type ROLL"
 
-      # Try a non-roll command
       find(".terminal-input").send_keys("look", :return)
       assert_text "You need to ROLL first"
     end
@@ -64,48 +59,25 @@ module QaWorld
       visit dev_game_path
       find(".terminal-input").click
 
-      find(".terminal-input").send_keys("go east", :return)
-      assert_text "The Tavern"
+      roll_until_outcome("Success!")
 
-      find(".terminal-input").send_keys("take lockpick", :return)
-      assert_text "Lockpick"
-
-      # Retry until we roll a success (DC 12 on 1d20, ~55% chance each attempt)
-      20.times do
-        find(".terminal-input").send_keys("use lockpick", :return)
-        assert_text "Type ROLL"
-        find(".terminal-input").send_keys("roll", :return)
-        break if page.has_text?("Success!", wait: 2)
-      end
-
-      assert_text "Success!"
       assert_text "The lock clicks open"
 
-      # The unlock flag should now allow opening the chest without the key
       find(".terminal-input").send_keys("open chest", :return)
       assert_text "Health Potion"
     end
 
-    test "failed roll shows failure branch message" do
+    test "failed roll shows failure branch message and consumes lockpick" do
       visit dev_game_path
       find(".terminal-input").click
 
-      find(".terminal-input").send_keys("go east", :return)
-      assert_text "The Tavern"
+      roll_until_outcome("Failed.")
 
-      find(".terminal-input").send_keys("take lockpick", :return)
-      assert_text "Lockpick"
+      assert_text "The lockpick snaps!"
 
-      # Retry until we roll a failure (DC 12 on 1d20, ~45% chance each attempt)
-      20.times do
-        find(".terminal-input").send_keys("use lockpick", :return)
-        assert_text "Type ROLL"
-        find(".terminal-input").send_keys("roll", :return)
-        break if page.has_text?("Failed.", wait: 2)
-      end
-
-      assert_text "Failed."
-      assert_text "The pick slips and bends"
+      # Lockpick should be consumed (consume_on: failure)
+      send_and_wait("use lockpick")
+      assert_text "don't have"
     end
 
     test "rolling dice creates a dice event message showing the roll total" do
@@ -124,7 +96,6 @@ module QaWorld
       find(".terminal-input").send_keys("roll", :return)
       assert_text(/Success!|Failed\./)
 
-      # A dice event message with the roll breakdown should appear
       assert_text "TOTAL:"
     end
 
@@ -132,20 +103,7 @@ module QaWorld
       visit dev_game_path
       find(".terminal-input").click
 
-      find(".terminal-input").send_keys("go east", :return)
-      assert_text "The Tavern"
-
-      find(".terminal-input").send_keys("take lockpick", :return)
-      assert_text "Lockpick"
-
-      20.times do
-        find(".terminal-input").send_keys("use lockpick", :return)
-        assert_text "Type ROLL"
-        find(".terminal-input").send_keys("roll", :return)
-        break if page.has_text?("Success!", wait: 2)
-      end
-
-      assert_text "Success!"
+      roll_until_outcome("Success!")
 
       find(".terminal-input").send_keys("open chest", :return)
       assert_text "Health Potion"
@@ -153,5 +111,49 @@ module QaWorld
       find(".terminal-input").send_keys("take potion", :return)
       assert_text "You take the Health Potion"
     end
+
+    test "using lockpick after success shows completed message instead of re-triggering roll" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      roll_until_outcome("Success!")
+
+      # Lockpick survives success (consume_on: failure) — try to use it again
+      find(".terminal-input").send_keys("use lockpick", :return)
+      assert_text "The chest lock is already open"
+    end
+
+    private
+
+      # Navigate to tavern, take lockpick, use it, and roll.
+      # Uses message-count sync to avoid stale text matching after restarts.
+      def roll_until_outcome(desired, max_attempts: 20)
+        max_attempts.times do |i|
+          restart_game if i > 0
+
+          send_and_wait("go east")
+          send_and_wait("take lockpick")
+          send_and_wait("use lockpick")
+          send_and_wait("roll")
+
+          break if page.has_text?(desired, wait: 3)
+        end
+
+        assert_text desired
+      end
+
+      # Send a command and wait for the engine response to appear by counting
+      # new .game-message elements. This avoids matching stale text from prior
+      # game rounds.
+      def send_and_wait(text)
+        count = all(".game-message", wait: false).count
+        find(".terminal-input").send_keys(text, :return)
+        assert_selector ".game-message", minimum: count + 2, wait: 5
+      end
+
+      def restart_game
+        send_and_wait("restart")
+        send_and_wait("yes")
+      end
   end
 end

--- a/test/system/qa_world/dice_roll_test.rb
+++ b/test/system/qa_world/dice_roll_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class DiceRollTest < ApplicationSystemTestCase
+    test "use lockpick triggers dice roll prompt" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern, get the lockpick from the innkeeper's storeroom
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Pick up the lockpick (placed in tavern by QA world)
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      # Use the lockpick to trigger a dice roll
+      find(".terminal-input").send_keys("use lockpick", :return)
+      assert_text "Type ROLL"
+    end
+
+    test "rolling dice after using lockpick resolves the roll" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      find(".terminal-input").send_keys("use lockpick", :return)
+      assert_text "Type ROLL"
+
+      # Roll the dice — outcome is random, but we should see either Success or Failed
+      find(".terminal-input").send_keys("roll", :return)
+      assert_selector ".message", text: /Success!|Failed\./
+    end
+
+    test "non-roll command while roll pending is rejected" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("take lockpick", :return)
+      assert_text "Lockpick"
+
+      find(".terminal-input").send_keys("use lockpick", :return)
+      assert_text "Type ROLL"
+
+      # Try a non-roll command
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "You need to ROLL first"
+    end
+  end
+end


### PR DESCRIPTION
Adds branching outcomes to dice rolls defined in world JSON, ensuring players are never deadlocked. Each roll directive requires both an `on_success` and `on_failure` block, each with a message and a directive action (set flag, unlock dialogue, unlock exit). Invalid world data (missing a branch) is rejected at load time.

Spec: specs/pr-36-dice_roll_directives.md

## Build Progress

- [x] Ingest (started 11:05 UTC · finished 11:06 UTC)
- [x] Plan (started 11:06 UTC · finished 13:25 UTC)
- [x] Implement (started 13:25 UTC)

## Summary

Add dice roll directives to the classic game engine so that items can trigger skill checks with branching outcomes (success/failure), each executing directives like setting flags, unlocking dialogue, or unlocking exits.

### Changes
- **RollHandler** — new handler that resolves pending dice rolls against a DC, executes the winning branch's directives, and returns the outcome message; also returns the `DiceRoll` result object so the job layer can create a dice event message
- **BaseHandler** — added `pending_roll?` and `execute_roll_directives` protected helpers for processing `sets_flag`, `unlocks_dialogue`, and `unlocks_exit` directives
- **CommandParser** — added `roll` verb to the verb list and no-argument parsing branch
- **Engine** — added priority intercept for `pending_roll` state (routes all input to RollHandler), added `:roll` to handler routing, added `validate_world_data` class method for dice roll branch validation and `consume_on` value validation
- **ItemHandler** — added `handle_dice_roll_trigger` to set `pending_roll` state when using an item with a `dice_roll` definition; added re-trigger guard that short-circuits with `completed_message` when the success flag is already set
- **ContainerHandler** — added `unlock_flag` support: if a container has an `"unlock_flag"` key and that flag is set, it opens without requiring the key item
- **ClassicCommandJob** — creates an `event_type: "roll"` event message (with dice breakdown) before the text response when a roll resolves, so the ASCII dice partials render
- **Game model** — calls `Engine.validate_world_data` at setup time to reject items with incomplete dice roll branches

### `consume_on` directive

Items with a `dice_roll` block can specify when the item is consumed:

```json
"dice_roll": {
  "dc": 12,
  "consume_on": "failure",
  "completed_message": "The chest lock is already open.",
  ...
}
```

| Value | Behaviour |
|-------|-----------|
| `"failure"` | Item removed from inventory on failed roll (e.g. lockpick snaps) |
| `"success"` | Item consumed on successful roll |
| `"any"` | Always consumed after rolling |
| *(omitted)* | Item stays in inventory |

The `completed_message` field (optional, default `"Nothing happens."`) is shown when a player tries to re-use an item whose `on_success.sets_flag` is already set.

### Bug fixes (post-implementation QA)

**Successful lockpick roll didn't unlock the chest** — `on_success` correctly set `tavern_lockpick_success` in `global_flags`, but `ContainerHandler` only checked `unlock_item` (key in inventory) and never consulted flags. Fixed by adding `unlock_flag` support to `ContainerHandler` and adding `"unlock_flag": "tavern_lockpick_success"` to the QA world chest.

**No dice ASCII after a classic game ROLL** — the ASCII dice partials only rendered for `event_type: "roll"` messages, which were only created by the AI game's `/roll` command. The classic ROLL command returned a plain host message. Fixed by having `ClassicCommandJob` create a roll event message when the engine result includes a `dice_roll` object.

### Dev tooling fix
The **Reset Game** button in the debug view now uses `load` instead of `require` (picks up changes to `qa_world_data.rb` without a server restart) and recreates the QA world if it was deleted rather than silently returning.

### Test results
- Unit: 110 runs, 309 assertions, 0 failures
- System: 8 dice roll tests, 36 total QA world tests (all passing)