### PR TITLE
Complex Creatures

### DIFF
--- a/app/controllers/worlds_controller.rb
+++ b/app/controllers/worlds_controller.rb
@@ -218,12 +218,21 @@ class WorldsController < ApplicationController
           "gives_item" => params[:gives_item].presence
         }.compact
       when "creature"
-        {
+        data = {
           "name" => params[:name],
           "description" => params[:description],
           "health" => params[:health].to_i,
-          "hostile" => params[:hostile] == "1"
-        }.compact
+          "hostile" => params[:hostile] == "1",
+          "talk_text" => params[:talk_text].presence
+        }
+        if params[:attack_condition_json].present?
+          begin
+            data["attack_condition"] = JSON.parse(params[:attack_condition_json])
+          rescue JSON::ParserError
+            # Ignore malformed JSON — field will be omitted
+          end
+        end
+        data.compact
       when "meta"
         {
           "starting_room" => params[:starting_room],

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -21,11 +21,14 @@ module ClassicGame
         # Route to appropriate handler
         handler = get_handler(command[:verb], game: game, user_id: user.id)
 
-        if handler
-          handler.handle(command)
-        else
-          unknown_command_response(command)
-        end
+        result = if handler
+                   handler.handle(command)
+                 else
+                   unknown_command_response(command)
+                 end
+
+        # Check for aggressive creatures after the player acts
+        check_aggressive_creatures(game, user, command, result)
       rescue StandardError => e
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))
@@ -55,6 +58,77 @@ module ClassicGame
       end
 
       private
+
+        def check_aggressive_creatures(game, user, command, result)
+          ps = game.player_state(user.id)
+          return result if ps.dig("combat", "active")
+
+          # Increment room action counter
+          ps["room_actions"] ||= {}
+          room_id = ps["current_room"]
+          ps["room_actions"][room_id] = (ps["room_actions"][room_id] || 0) + 1
+          game.update_player_state(user.id, ps)
+
+          room_state = game.room_state(room_id)
+          creatures = room_state["creatures"] || []
+          world = game.world_snapshot
+
+          creatures.each do |creature_id|
+            creature_def = world.dig("creatures", creature_id)
+            next unless creature_def
+            next unless creature_def["hostile"]
+            next if should_defer_attack?(creature_def, ps, room_id, command, creature_id)
+
+            # Creature attacks — build attack via InteractHandler
+            attack_command = { verb: :attack, target: creature_id, modifier: nil, raw: "attack #{creature_id}" }
+            handler = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: user.id)
+            attack_result = handler.handle(attack_command)
+
+            aggro_text = creature_def["aggro_text"] || "The #{creature_def['name']} attacks you!"
+            combined = "#{result[:response]}\n\n#{aggro_text}\n\n#{attack_result[:response]}"
+            return result.merge(
+              response: combined,
+              state_changes: (result[:state_changes] || {}).merge(attack_result[:state_changes] || {})
+            )
+          end
+
+          result
+        end
+
+        def should_defer_attack?(creature_def, player_state, room_id, command, creature_id)
+          condition = creature_def["attack_condition"]
+
+          # No condition = attack immediately on any action
+          return false unless condition
+
+          if condition["moves"]
+            actions = player_state.dig("room_actions", room_id) || 0
+            return actions < condition["moves"]
+          end
+
+          if condition["room_entries"]
+            entries = player_state.dig("room_entries", room_id) || 0
+            return entries < condition["room_entries"]
+          end
+
+          if condition["on_talk"]
+            return !(command[:verb] == :talk && talk_targets_creature?(command, creature_id, creature_def))
+          end
+
+          # Unknown condition type — don't attack
+          true
+        end
+
+        def talk_targets_creature?(command, creature_id, creature_def)
+          target = command[:modifier].presence || command[:target]
+          return false if target.blank?
+
+          target_lower = target.downcase
+          return true if creature_id.downcase.include?(target_lower) || target_lower.include?(creature_id.downcase)
+
+          keywords = creature_def["keywords"] || []
+          keywords.any? { |kw| kw.downcase.include?(target_lower) || target_lower.include?(kw.downcase) }
+        end
 
         def get_handler(verb, game:, user_id:)
           # PRIORITY: Route to CombatHandler if in combat

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -29,8 +29,11 @@ module ClassicGame
           return failure("Talk to whom?") if npc_name.blank?
 
           npc_id, npc_def = find_npc(npc_name)
-          return failure("You don't see anyone like that here.") unless npc_def
-          return failure("You don't see anyone like that here.") unless npc_in_room?(npc_id)
+
+          # If no NPC found or not in room, try creature
+          unless npc_def && npc_in_room?(npc_id)
+            return handle_talk_to_creature(npc_name)
+          end
 
           dialogue = npc_def["dialogue"]
           return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue
@@ -183,6 +186,15 @@ module ClassicGame
           end
 
           failure("#{npc_def['name']} doesn't want that.")
+        end
+
+        def handle_talk_to_creature(name)
+          creature_id, creature_def = find_creature(name)
+          return failure("You don't see anyone like that here.") unless creature_def
+          return failure("You don't see anyone like that here.") unless creature_in_room?(creature_id)
+
+          talk_text = creature_def["talk_text"] || "It has no clue what you're saying."
+          success(talk_text)
         end
 
         def handle_attack(target)

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -31,9 +31,7 @@ module ClassicGame
           npc_id, npc_def = find_npc(npc_name)
 
           # If no NPC found or not in room, try creature
-          unless npc_def && npc_in_room?(npc_id)
-            return handle_talk_to_creature(npc_name)
-          end
+          return handle_talk_to_creature(npc_name) unless npc_def && npc_in_room?(npc_id)
 
           dialogue = npc_def["dialogue"]
           return failure("#{npc_def['name']} doesn't seem interested in talking.") unless dialogue

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -75,6 +75,9 @@ module ClassicGame
           new_state["visited_rooms"] ||= []
           new_state["visited_rooms"] << room_id unless new_state["visited_rooms"].include?(room_id)
 
+          new_state["room_entries"] ||= {}
+          new_state["room_entries"][room_id] = (new_state["room_entries"][room_id] || 0) + 1
+
           update_player_state(new_state)
 
           # Generate room description

--- a/app/views/worlds/forms/_creature_form.html.erb
+++ b/app/views/worlds/forms/_creature_form.html.erb
@@ -28,4 +28,21 @@
       </label>
     </div>
   </div>
+
+  <div>
+    <label class="block mb-1 text-sm font-bold">Talk Text</label>
+    <%= text_area_tag :talk_text, entity_data["talk_text"],
+        rows: 2,
+        placeholder: "What the creature says when spoken to",
+        class: "w-full bg-stone-900 border border-terminal-green p-2 text-terminal-green focus:outline-none" %>
+  </div>
+
+  <div>
+    <label class="block mb-1 text-sm font-bold">Attack Condition (JSON)</label>
+    <%= text_area_tag :attack_condition_json,
+        entity_data["attack_condition"] ? entity_data["attack_condition"].to_json : nil,
+        rows: 2,
+        placeholder: '{"moves": 3} or {"on_talk": true} or {"room_entries": 2}',
+        class: "w-full bg-stone-900 border border-terminal-green p-2 text-terminal-green focus:outline-none" %>
+  </div>
 </div>

--- a/test/lib/classic_game/handlers/creature_interaction_test.rb
+++ b/test/lib/classic_game/handlers/creature_interaction_test.rb
@@ -6,61 +6,23 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   include ClassicGameTestHelper
 
   USER_ID = 1
+  FakeUser = Struct.new(:id)
 
   # ─── TALK TO CREATURE ─────────────────────────────────────────────────────
 
   test "talk to non-hostile creature returns talk_text" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["rat"]
-        }
-      },
-      creatures: {
-        "rat" => {
-          "name" => "Rat",
-          "keywords" => ["rat"],
-          "hostile" => false,
-          "health" => 5,
-          "attack" => 1,
-          "talk_text" => "The rat looks at you with disdain."
-        }
-      }
-    )
+    world = build_creature_world("rat", "hostile" => false, "talk_text" => "The rat looks at you with disdain.")
     game = build_game(world_data: world, player_id: USER_ID)
-
-    command = ClassicGame::CommandParser.parse("talk to rat")
-    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+    result = talk("talk to rat", game)
 
     assert result[:success]
     assert_includes result[:response], "The rat looks at you with disdain."
   end
 
   test "talk to creature with no talk_text returns default" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["rat"]
-        }
-      },
-      creatures: {
-        "rat" => {
-          "name" => "Rat",
-          "keywords" => ["rat"],
-          "hostile" => false,
-          "health" => 5,
-          "attack" => 1
-        }
-      }
-    )
+    world = build_creature_world("rat", "hostile" => false)
     game = build_game(world_data: world, player_id: USER_ID)
-
-    command = ClassicGame::CommandParser.parse("talk to rat")
-    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+    result = talk("talk to rat", game)
 
     assert result[:success]
     assert_includes result[:response], "It has no clue what you're saying."
@@ -69,27 +31,12 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   test "talk to creature not in room fails" do
     world = build_world(
       starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => []
-        }
-      },
-      creatures: {
-        "rat" => {
-          "name" => "Rat",
-          "keywords" => ["rat"],
-          "hostile" => false,
-          "health" => 5,
-          "attack" => 1,
-          "talk_text" => "Squeak."
-        }
-      }
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "creatures" => [] } },
+      creatures: { "rat" => { "name" => "Rat", "keywords" => ["rat"], "hostile" => false, "health" => 5,
+                               "attack" => 1, "talk_text" => "Squeak." } }
     )
     game = build_game(world_data: world, player_id: USER_ID)
-
-    command = ClassicGame::CommandParser.parse("talk to rat")
-    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+    result = talk("talk to rat", game)
 
     assert_not result[:success]
     assert_includes result[:response].downcase, "don't see anyone"
@@ -98,35 +45,16 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   test "talk to NPC takes priority over creature with same keyword" do
     world = build_world(
       starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "npcs" => ["bob"],
-          "creatures" => ["bob_creature"]
-        }
-      },
-      npcs: {
-        "bob" => {
-          "name" => "Bob",
-          "keywords" => ["bob"],
-          "dialogue" => { "greeting" => "Hello, friend!" }
-        }
-      },
-      creatures: {
-        "bob_creature" => {
-          "name" => "Bob the Beast",
-          "keywords" => ["bob"],
-          "hostile" => false,
-          "health" => 10,
-          "attack" => 2,
-          "talk_text" => "Growl."
-        }
-      }
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {},
+                             "npcs" => ["bob"], "creatures" => ["bob_creature"] } },
+      npcs: { "bob" => { "name" => "Bob", "keywords" => ["bob"],
+                          "dialogue" => { "greeting" => "Hello, friend!" } } },
+      creatures: { "bob_creature" => { "name" => "Bob the Beast", "keywords" => ["bob"],
+                                        "hostile" => false, "health" => 10, "attack" => 2,
+                                        "talk_text" => "Growl." } }
     )
     game = build_game(world_data: world, player_id: USER_ID)
-
-    command = ClassicGame::CommandParser.parse("talk to bob")
-    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+    result = talk("talk to bob", game)
 
     assert result[:success]
     assert_includes result[:response], "Hello, friend!"
@@ -136,56 +64,15 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   # ─── AGGRESSIVE CREATURES (via Engine) ─────────────────────────────────────
 
   test "hostile creature with no attack_condition attacks after first action" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["wolf"]
-        }
-      },
-      creatures: {
-        "wolf" => {
-          "name" => "Wolf",
-          "keywords" => ["wolf"],
-          "hostile" => true,
-          "health" => 20,
-          "attack" => 3
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
-
+    game, user = build_engine_game("wolf", "hostile" => true, "health" => 20, "attack" => 3)
     result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
 
     assert_includes result[:response].downcase, "attacks you"
   end
 
   test "hostile creature with moves condition does not attack before threshold" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["spider"]
-        }
-      },
-      creatures: {
-        "spider" => {
-          "name" => "Spider",
-          "keywords" => ["spider"],
-          "hostile" => true,
-          "health" => 10,
-          "attack" => 2,
-          "attack_condition" => { "moves" => 3 }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2,
+                                              "attack_condition" => { "moves" => 3 })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
@@ -195,28 +82,8 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with moves condition attacks at threshold" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["spider"]
-        }
-      },
-      creatures: {
-        "spider" => {
-          "name" => "Spider",
-          "keywords" => ["spider"],
-          "hostile" => true,
-          "health" => 10,
-          "attack" => 2,
-          "attack_condition" => { "moves" => 3 }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2,
+                                              "attack_condition" => { "moves" => 3 })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
@@ -226,29 +93,9 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with on_talk condition attacks when talked to" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["troll"]
-        }
-      },
-      creatures: {
-        "troll" => {
-          "name" => "Troll",
-          "keywords" => ["troll"],
-          "hostile" => true,
-          "health" => 15,
-          "attack" => 4,
-          "talk_text" => "The troll grunts.",
-          "attack_condition" => { "on_talk" => true }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4,
+                                             "talk_text" => "The troll grunts.",
+                                             "attack_condition" => { "on_talk" => true })
 
     result = ClassicGame::Engine.execute(game: game, user: user, command_text: "talk to troll")
 
@@ -257,29 +104,9 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with on_talk condition does not attack on other actions" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["troll"]
-        }
-      },
-      creatures: {
-        "troll" => {
-          "name" => "Troll",
-          "keywords" => ["troll"],
-          "hostile" => true,
-          "health" => 15,
-          "attack" => 4,
-          "talk_text" => "The troll grunts.",
-          "attack_condition" => { "on_talk" => true }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4,
+                                             "talk_text" => "The troll grunts.",
+                                             "attack_condition" => { "on_talk" => true })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
 
@@ -288,27 +115,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "non-hostile creature never auto-attacks" do
-    world = build_world(
-      starting_room: "room1",
-      rooms: {
-        "room1" => {
-          "name" => "Room", "description" => "A room.", "exits" => {},
-          "creatures" => ["bunny"]
-        }
-      },
-      creatures: {
-        "bunny" => {
-          "name" => "Bunny",
-          "keywords" => ["bunny"],
-          "hostile" => false,
-          "health" => 5,
-          "attack" => 1
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    game, user = build_engine_game("bunny", "hostile" => false, "health" => 5, "attack" => 1)
 
     5.times { ClassicGame::Engine.execute(game: game, user: user, command_text: "look") }
 
@@ -320,30 +127,18 @@ class CreatureInteractionTest < ActiveSupport::TestCase
     world = build_world(
       starting_room: "room1",
       rooms: {
-        "room1" => {
-          "name" => "Room 1", "description" => "First room.",
-          "exits" => { "east" => "room2" }
-        },
-        "room2" => {
-          "name" => "Room 2", "description" => "Second room.",
-          "exits" => { "west" => "room1" },
-          "creatures" => ["ghost"]
-        }
+        "room1" => { "name" => "Room 1", "description" => "First room.",
+                      "exits" => { "east" => "room2" } },
+        "room2" => { "name" => "Room 2", "description" => "Second room.",
+                      "exits" => { "west" => "room1" }, "creatures" => ["ghost"] }
       },
       creatures: {
-        "ghost" => {
-          "name" => "Ghost",
-          "keywords" => ["ghost"],
-          "hostile" => true,
-          "health" => 12,
-          "attack" => 3,
-          "attack_condition" => { "room_entries" => 2 }
-        }
+        "ghost" => { "name" => "Ghost", "keywords" => ["ghost"], "hostile" => true,
+                      "health" => 12, "attack" => 3, "attack_condition" => { "room_entries" => 2 } }
       }
     )
     game = build_game(world_data: world, player_id: USER_ID)
-    game.define_singleton_method(:starting_hp) { 10 }
-    user = OpenStruct.new(id: USER_ID)
+    user = FakeUser.new(USER_ID)
 
     # Entry 1: move to room2
     result1 = ClassicGame::Engine.execute(game: game, user: user, command_text: "go east")
@@ -356,4 +151,28 @@ class CreatureInteractionTest < ActiveSupport::TestCase
     result2 = ClassicGame::Engine.execute(game: game, user: user, command_text: "go east")
     assert_includes result2[:response].downcase, "attacks you"
   end
+
+  private
+
+    def talk(input, game)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+    end
+
+    def build_creature_world(creature_id, creature_attrs = {})
+      defaults = { "name" => creature_id.capitalize, "keywords" => [creature_id], "health" => 5, "attack" => 1 }
+      build_world(
+        starting_room: "room1",
+        rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {},
+                               "creatures" => [creature_id] } },
+        creatures: { creature_id => defaults.merge(creature_attrs) }
+      )
+    end
+
+    def build_engine_game(creature_id, creature_attrs = {})
+      world = build_creature_world(creature_id, creature_attrs)
+      game = build_game(world_data: world, player_id: USER_ID)
+      user = FakeUser.new(USER_ID)
+      [game, user]
+    end
 end

--- a/test/lib/classic_game/handlers/creature_interaction_test.rb
+++ b/test/lib/classic_game/handlers/creature_interaction_test.rb
@@ -32,8 +32,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
     world = build_world(
       starting_room: "room1",
       rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "creatures" => [] } },
-      creatures: { "rat" => { "name" => "Rat", "keywords" => ["rat"], "hostile" => false, "health" => 5,
-                               "attack" => 1, "talk_text" => "Squeak." } }
+      creatures: { "rat" => { "name" => "Rat", "keywords" => ["rat"], "hostile" => false, "health" => 5, "attack" => 1, "talk_text" => "Squeak." } }
     )
     game = build_game(world_data: world, player_id: USER_ID)
     result = talk("talk to rat", game)
@@ -45,13 +44,9 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   test "talk to NPC takes priority over creature with same keyword" do
     world = build_world(
       starting_room: "room1",
-      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {},
-                             "npcs" => ["bob"], "creatures" => ["bob_creature"] } },
-      npcs: { "bob" => { "name" => "Bob", "keywords" => ["bob"],
-                          "dialogue" => { "greeting" => "Hello, friend!" } } },
-      creatures: { "bob_creature" => { "name" => "Bob the Beast", "keywords" => ["bob"],
-                                        "hostile" => false, "health" => 10, "attack" => 2,
-                                        "talk_text" => "Growl." } }
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "npcs" => ["bob"], "creatures" => ["bob_creature"] } },
+      npcs: { "bob" => { "name" => "Bob", "keywords" => ["bob"], "dialogue" => { "greeting" => "Hello, friend!" } } },
+      creatures: { "bob_creature" => { "name" => "Bob the Beast", "keywords" => ["bob"], "hostile" => false, "health" => 10, "attack" => 2, "talk_text" => "Growl." } }
     )
     game = build_game(world_data: world, player_id: USER_ID)
     result = talk("talk to bob", game)
@@ -71,8 +66,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with moves condition does not attack before threshold" do
-    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2,
-                                              "attack_condition" => { "moves" => 3 })
+    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2, "attack_condition" => { "moves" => 3 })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
@@ -82,8 +76,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with moves condition attacks at threshold" do
-    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2,
-                                              "attack_condition" => { "moves" => 3 })
+    game, user = build_engine_game("spider", "hostile" => true, "health" => 10, "attack" => 2, "attack_condition" => { "moves" => 3 })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
@@ -93,9 +86,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with on_talk condition attacks when talked to" do
-    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4,
-                                             "talk_text" => "The troll grunts.",
-                                             "attack_condition" => { "on_talk" => true })
+    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4, "talk_text" => "The troll grunts.", "attack_condition" => { "on_talk" => true })
 
     result = ClassicGame::Engine.execute(game: game, user: user, command_text: "talk to troll")
 
@@ -104,9 +95,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   end
 
   test "hostile creature with on_talk condition does not attack on other actions" do
-    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4,
-                                             "talk_text" => "The troll grunts.",
-                                             "attack_condition" => { "on_talk" => true })
+    game, user = build_engine_game("troll", "hostile" => true, "health" => 15, "attack" => 4, "talk_text" => "The troll grunts.", "attack_condition" => { "on_talk" => true })
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
 
@@ -127,14 +116,11 @@ class CreatureInteractionTest < ActiveSupport::TestCase
     world = build_world(
       starting_room: "room1",
       rooms: {
-        "room1" => { "name" => "Room 1", "description" => "First room.",
-                      "exits" => { "east" => "room2" } },
-        "room2" => { "name" => "Room 2", "description" => "Second room.",
-                      "exits" => { "west" => "room1" }, "creatures" => ["ghost"] }
+        "room1" => { "name" => "Room 1", "description" => "First room.", "exits" => { "east" => "room2" } },
+        "room2" => { "name" => "Room 2", "description" => "Second room.", "exits" => { "west" => "room1" }, "creatures" => ["ghost"] }
       },
       creatures: {
-        "ghost" => { "name" => "Ghost", "keywords" => ["ghost"], "hostile" => true,
-                      "health" => 12, "attack" => 3, "attack_condition" => { "room_entries" => 2 } }
+        "ghost" => { "name" => "Ghost", "keywords" => ["ghost"], "hostile" => true, "health" => 12, "attack" => 3, "attack_condition" => { "room_entries" => 2 } }
       }
     )
     game = build_game(world_data: world, player_id: USER_ID)
@@ -163,8 +149,7 @@ class CreatureInteractionTest < ActiveSupport::TestCase
       defaults = { "name" => creature_id.capitalize, "keywords" => [creature_id], "health" => 5, "attack" => 1 }
       build_world(
         starting_room: "room1",
-        rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {},
-                               "creatures" => [creature_id] } },
+        rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {}, "creatures" => [creature_id] } },
         creatures: { creature_id => defaults.merge(creature_attrs) }
       )
     end

--- a/test/lib/classic_game/handlers/creature_interaction_test.rb
+++ b/test/lib/classic_game/handlers/creature_interaction_test.rb
@@ -1,0 +1,359 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CreatureInteractionTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  # ─── TALK TO CREATURE ─────────────────────────────────────────────────────
+
+  test "talk to non-hostile creature returns talk_text" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["rat"]
+        }
+      },
+      creatures: {
+        "rat" => {
+          "name" => "Rat",
+          "keywords" => ["rat"],
+          "hostile" => false,
+          "health" => 5,
+          "attack" => 1,
+          "talk_text" => "The rat looks at you with disdain."
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+
+    command = ClassicGame::CommandParser.parse("talk to rat")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "The rat looks at you with disdain."
+  end
+
+  test "talk to creature with no talk_text returns default" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["rat"]
+        }
+      },
+      creatures: {
+        "rat" => {
+          "name" => "Rat",
+          "keywords" => ["rat"],
+          "hostile" => false,
+          "health" => 5,
+          "attack" => 1
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+
+    command = ClassicGame::CommandParser.parse("talk to rat")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "It has no clue what you're saying."
+  end
+
+  test "talk to creature not in room fails" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => []
+        }
+      },
+      creatures: {
+        "rat" => {
+          "name" => "Rat",
+          "keywords" => ["rat"],
+          "hostile" => false,
+          "health" => 5,
+          "attack" => 1,
+          "talk_text" => "Squeak."
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+
+    command = ClassicGame::CommandParser.parse("talk to rat")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert_not result[:success]
+    assert_includes result[:response].downcase, "don't see anyone"
+  end
+
+  test "talk to NPC takes priority over creature with same keyword" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "npcs" => ["bob"],
+          "creatures" => ["bob_creature"]
+        }
+      },
+      npcs: {
+        "bob" => {
+          "name" => "Bob",
+          "keywords" => ["bob"],
+          "dialogue" => { "greeting" => "Hello, friend!" }
+        }
+      },
+      creatures: {
+        "bob_creature" => {
+          "name" => "Bob the Beast",
+          "keywords" => ["bob"],
+          "hostile" => false,
+          "health" => 10,
+          "attack" => 2,
+          "talk_text" => "Growl."
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+
+    command = ClassicGame::CommandParser.parse("talk to bob")
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "Hello, friend!"
+    assert_not_includes result[:response], "Growl."
+  end
+
+  # ─── AGGRESSIVE CREATURES (via Engine) ─────────────────────────────────────
+
+  test "hostile creature with no attack_condition attacks after first action" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["wolf"]
+        }
+      },
+      creatures: {
+        "wolf" => {
+          "name" => "Wolf",
+          "keywords" => ["wolf"],
+          "hostile" => true,
+          "health" => 20,
+          "attack" => 3
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    assert_includes result[:response].downcase, "attacks you"
+  end
+
+  test "hostile creature with moves condition does not attack before threshold" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["spider"]
+        }
+      },
+      creatures: {
+        "spider" => {
+          "name" => "Spider",
+          "keywords" => ["spider"],
+          "hostile" => true,
+          "health" => 10,
+          "attack" => 2,
+          "attack_condition" => { "moves" => 3 }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    ps = game.player_state(USER_ID)
+    assert_nil ps.dig("combat", "active"), "Combat should not be active before threshold"
+  end
+
+  test "hostile creature with moves condition attacks at threshold" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["spider"]
+        }
+      },
+      creatures: {
+        "spider" => {
+          "name" => "Spider",
+          "keywords" => ["spider"],
+          "hostile" => true,
+          "health" => 10,
+          "attack" => 2,
+          "attack_condition" => { "moves" => 3 }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    assert_includes result[:response].downcase, "attacks you"
+  end
+
+  test "hostile creature with on_talk condition attacks when talked to" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["troll"]
+        }
+      },
+      creatures: {
+        "troll" => {
+          "name" => "Troll",
+          "keywords" => ["troll"],
+          "hostile" => true,
+          "health" => 15,
+          "attack" => 4,
+          "talk_text" => "The troll grunts.",
+          "attack_condition" => { "on_talk" => true }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "talk to troll")
+
+    assert_includes result[:response], "The troll grunts."
+    assert_includes result[:response].downcase, "attacks you"
+  end
+
+  test "hostile creature with on_talk condition does not attack on other actions" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["troll"]
+        }
+      },
+      creatures: {
+        "troll" => {
+          "name" => "Troll",
+          "keywords" => ["troll"],
+          "hostile" => true,
+          "health" => 15,
+          "attack" => 4,
+          "talk_text" => "The troll grunts.",
+          "attack_condition" => { "on_talk" => true }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    ps = game.player_state(USER_ID)
+    assert_nil ps.dig("combat", "active"), "Combat should not be active on non-talk actions"
+  end
+
+  test "non-hostile creature never auto-attacks" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room", "description" => "A room.", "exits" => {},
+          "creatures" => ["bunny"]
+        }
+      },
+      creatures: {
+        "bunny" => {
+          "name" => "Bunny",
+          "keywords" => ["bunny"],
+          "hostile" => false,
+          "health" => 5,
+          "attack" => 1
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    5.times { ClassicGame::Engine.execute(game: game, user: user, command_text: "look") }
+
+    ps = game.player_state(USER_ID)
+    assert_nil ps.dig("combat", "active"), "Non-hostile creature should never initiate combat"
+  end
+
+  test "hostile creature with room_entries condition attacks after N entries" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Room 1", "description" => "First room.",
+          "exits" => { "east" => "room2" }
+        },
+        "room2" => {
+          "name" => "Room 2", "description" => "Second room.",
+          "exits" => { "west" => "room1" },
+          "creatures" => ["ghost"]
+        }
+      },
+      creatures: {
+        "ghost" => {
+          "name" => "Ghost",
+          "keywords" => ["ghost"],
+          "hostile" => true,
+          "health" => 12,
+          "attack" => 3,
+          "attack_condition" => { "room_entries" => 2 }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID)
+    game.define_singleton_method(:starting_hp) { 10 }
+    user = OpenStruct.new(id: USER_ID)
+
+    # Entry 1: move to room2
+    result1 = ClassicGame::Engine.execute(game: game, user: user, command_text: "go east")
+    assert_not_includes result1[:response].downcase, "attacks you"
+
+    # Move back to room1
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "go west")
+
+    # Entry 2: move to room2 again — should trigger
+    result2 = ClassicGame::Engine.execute(game: game, user: user, command_text: "go east")
+    assert_includes result2[:response].downcase, "attacks you"
+  end
+end

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -94,6 +94,10 @@ module ClassicGameTestHelper
       @game_state["container_states"][container_id.to_s]["removed_items"].uniq!
     end
 
+    def starting_hp
+      10
+    end
+
     def save!
       # no-op — state is stored in-memory
     end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -57,7 +57,8 @@ module TestSupport
         "description" => "A cozy inn with a roaring fireplace. The smell of ale fills the air.",
         "exits" => { "west" => "town_square" },
         "items" => %w[chest lockpick],
-        "npcs" => ["innkeeper"]
+        "npcs" => ["innkeeper"],
+        "creatures" => ["tavern_rat"]
       }
     end
 
@@ -287,10 +288,23 @@ module TestSupport
           "health" => 8,
           "attack" => 3,
           "defense" => 1,
+          "hostile" => true,
+          "talk_text" => "The spider hisses at you menacingly.",
+          "aggro_text" => "The Cave Spider lunges at you!",
+          "attack_condition" => { "moves" => 3 },
           "loot" => ["shield"],
           "on_defeat_msg" => "The cave spider crumples to the ground!",
           "on_flee_msg" => "The spider hisses as you retreat.",
           "sets_flag_on_defeat" => "spider_slain"
+        },
+        "tavern_rat" => {
+          "name" => "Tavern Rat",
+          "keywords" => ["rat", "tavern rat"],
+          "description" => "A fat, lazy rat lounging near the fireplace.",
+          "health" => 3,
+          "attack" => 1,
+          "hostile" => false,
+          "talk_text" => "The rat squeaks and twitches its whiskers at you."
         }
       }
     end

--- a/test/system/qa_world/creature_interaction_test.rb
+++ b/test/system/qa_world/creature_interaction_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class CreatureInteractionTest < ApplicationSystemTestCase
+    test "talk to cave spider shows talk_text" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+
+      find(".terminal-input").send_keys("talk to spider", :return)
+      assert_text "hisses"
+    end
+
+    test "talk to friendly rat shows talk_text" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("talk to rat", :return)
+      assert_text "squeaks"
+    end
+
+    test "hostile cave spider with moves condition attacks after threshold" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go south", :return)
+      assert_text "The Cave"
+
+      # First two looks should not trigger combat
+      find(".terminal-input").send_keys("look", :return)
+      find(".terminal-input").send_keys("look", :return)
+
+      # Third action should trigger the spider's aggression
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "lunges at you"
+    end
+  end
+end


### PR DESCRIPTION
## Description

Currently creatures only attack when the player attempts to attack them. A new option should be available for creatures that indicates if they are immediately hostile or if they will leave the player alone unless attacked. This could be in form of a key "aggressive: true/false" and an additional key: "attackcondition": { moves: 5 }. The attack condition can be anything from number of "actions" taken in a room, number of time the room was entered, attempting to talk to the creature, etc.

Additionally for non-aggressive creatures there should be some text when a player attempts to talk to it. For example if a player talks to a rat the game could say: "The rat looks at you with disdain." or as a fallback it could be "It has no clue what you're saying".

## Acceptance Criteria

- New keys are handled for creatures "aggression" and "attack_condition"
- Player can talk to any creature and get flavor text

Kind: feature