### PR TITLE
Moving NPCs & Creatures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ Add any of these if they help clarify intent:
 2. **`/plan-feature`** — reads the spec, explores the codebase, writes an implementation plan
 3. **`/implement-feature`** — writes tests first, implements, runs full suite, marks PR ready
 
+## Full-Game System Test
+
+The file `test/lib/classic_game/full_game_system_test.rb` is a comprehensive end-to-end playthrough test that exercises every game mechanic. When adding or modifying classic game features, update this test to cover the new behavior. Run it with:
+
+    bin/rails test test/lib/classic_game/full_game_system_test.rb
+
 ## Preferences
 > **Important:** Every shell command must be a single, simple call — no `$()`,
 > no `&&` chains. Use separate tool calls and carry values between them.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
-    rack-session (2.1.1)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)
@@ -518,7 +518,7 @@ CHECKSUMS
   puma (6.6.1) sha256=b9b56e4a4ea75d1bfa6d9e1972ee2c9f43d0883f011826d914e8e37b3694ea1e
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
-  rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.3) sha256=6d017ba5348c98fc909753a8169b21d44de14d2a0b92d140d1a966834c3c9cd3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.2.0)
@@ -428,7 +428,7 @@ CHECKSUMS
   activerecord (8.1.3) sha256=8003be7b2466ba0a2a670e603eeb0a61dd66058fccecfc49901e775260ac70ab
   activestorage (8.1.3) sha256=0564ce9309143951a67615e1bb4e090ee54b8befed417133cae614479b46384d
   activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
-  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.2.0) sha256=0f25e9b21a02a0cc0cea8ef92b2041035d39350946e8789c562b2d1a3da01507
   bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -28,7 +28,16 @@ module ClassicGame
                  end
 
         # Check for aggressive creatures after the player acts
-        check_aggressive_creatures(game, user, command, result)
+        result = check_aggressive_creatures(game, user, command, result)
+
+        # Process NPC/creature movement after the player acts
+        movement_messages = MovementProcessor.process(game: game, user_id: user.id)
+        if movement_messages.any?
+          combined = [result[:response], *movement_messages].join("\n\n")
+          result = result.merge(response: combined)
+        end
+
+        result
       rescue StandardError => e
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))
@@ -54,6 +63,26 @@ module ClassicGame
           error_text += " (must be: #{VALID_CONSUME_ON.join(', ')})."
           errors << error_text
         end
+
+        %w[npcs creatures].each do |collection|
+          (world_data[collection] || {}).each do |entity_id, entity_def|
+            next unless entity_def.is_a?(Hash) && entity_def["movement"]
+
+            movement = entity_def["movement"]
+            unless %w[patrol triggered].include?(movement["type"])
+              errors << "#{collection.singularize.capitalize} '#{entity_id}' has unknown movement type '#{movement['type']}'."
+            end
+
+            if movement["type"] == "patrol" && (movement["route"].blank? || !movement["route"].is_a?(Array))
+              errors << "#{collection.singularize.capitalize} '#{entity_id}' patrol movement requires a non-empty route array."
+            end
+
+            if movement["type"] == "triggered" && movement["destination"].blank?
+              errors << "#{collection.singularize.capitalize} '#{entity_id}' triggered movement requires a destination."
+            end
+          end
+        end
+
         errors
       end
 
@@ -175,7 +204,8 @@ module ClassicGame
                            "player_states" => {},
                            "room_states" => {},
                            "global_flags" => {},
-                           "container_states" => {}
+                           "container_states" => {},
+                           "movement_states" => {}
                          })
 
             # Generate fresh starting room description

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -64,21 +64,25 @@ module ClassicGame
           errors << error_text
         end
 
+        valid_movement_types = %w[patrol triggered]
         %w[npcs creatures].each do |collection|
+          label = collection.singularize.capitalize
           (world_data[collection] || {}).each do |entity_id, entity_def|
             next unless entity_def.is_a?(Hash) && entity_def["movement"]
 
             movement = entity_def["movement"]
-            unless %w[patrol triggered].include?(movement["type"])
-              errors << "#{collection.singularize.capitalize} '#{entity_id}' has unknown movement type '#{movement['type']}'."
+            unless valid_movement_types.include?(movement["type"])
+              errors << "#{label} '#{entity_id}' has unknown movement type " \
+                        "'#{movement['type']}'."
             end
 
             if movement["type"] == "patrol" && (movement["route"].blank? || !movement["route"].is_a?(Array))
-              errors << "#{collection.singularize.capitalize} '#{entity_id}' patrol movement requires a non-empty route array."
+              errors << "#{label} '#{entity_id}' patrol movement " \
+                        "requires a non-empty route array."
             end
 
             if movement["type"] == "triggered" && movement["destination"].blank?
-              errors << "#{collection.singularize.capitalize} '#{entity_id}' triggered movement requires a destination."
+              errors << "#{label} '#{entity_id}' triggered movement requires a destination."
             end
           end
         end

--- a/app/lib/classic_game/movement_processor.rb
+++ b/app/lib/classic_game/movement_processor.rb
@@ -11,16 +11,16 @@ module ClassicGame
         (world["npcs"] || {}).each do |npc_id, npc_def|
           next unless npc_def.is_a?(Hash) && npc_def["movement"]
 
-          msg = process_entity(game: game, entity_type: "npc", entity_id: npc_id,
-                               entity_def: npc_def, player_room: player_room)
+          ctx = build_context(game, "npc", npc_id, npc_def, player_room)
+          msg = process_entity(ctx)
           messages << msg if msg
         end
 
         (world["creatures"] || {}).each do |creature_id, creature_def|
           next unless creature_def.is_a?(Hash) && creature_def["movement"]
 
-          msg = process_entity(game: game, entity_type: "creature", entity_id: creature_id,
-                               entity_def: creature_def, player_room: player_room)
+          ctx = build_context(game, "creature", creature_id, creature_def, player_room)
+          msg = process_entity(ctx)
           messages << msg if msg
         end
 
@@ -29,23 +29,31 @@ module ClassicGame
 
       private
 
-        def process_entity(game:, entity_type:, entity_id:, entity_def:, player_room:)
-          movement = entity_def["movement"]
+        def build_context(game, entity_type, entity_id, entity_def, player_room)
+          {
+            game: game, entity_type: entity_type, entity_id: entity_id,
+            entity_def: entity_def, movement: entity_def["movement"],
+            player_room: player_room
+          }
+        end
 
-          case movement["type"]
+        def process_entity(ctx)
+          case ctx[:movement]["type"]
           when "patrol"
-            process_patrol(game: game, entity_type: entity_type, entity_id: entity_id,
-                           entity_def: entity_def, movement: movement, player_room: player_room)
+            process_patrol(ctx)
           when "triggered"
-            process_triggered(game: game, entity_type: entity_type, entity_id: entity_id,
-                              entity_def: entity_def, movement: movement, player_room: player_room)
+            process_triggered(ctx)
           end
         end
 
-        def process_patrol(game:, entity_type:, entity_id:, entity_def:, movement:, player_room:)
+        def process_patrol(ctx)
+          game = ctx[:game]
+          entity_type = ctx[:entity_type]
+          entity_id = ctx[:entity_id]
+          movement = ctx[:movement]
+
           # Skip if entity no longer exists in any room (e.g. defeated creature)
-          current_entity_room = find_entity_room(game, entity_type, entity_id)
-          return nil unless current_entity_room
+          return nil unless find_entity_room(game, entity_type, entity_id)
 
           state = game.movement_state(entity_type, entity_id)
           route = movement["route"]
@@ -61,19 +69,16 @@ module ClassicGame
 
           if counter >= stay_duration
             unless_rooms = movement["unless_player_in"] || []
-            if unless_rooms.include?(player_room) && current_room == player_room
+            if unless_rooms.include?(ctx[:player_room]) && current_room == ctx[:player_room]
               game.update_movement_state(entity_type, entity_id,
                                          { "step" => step, "move_counter" => counter })
               return nil
             end
 
             next_step = (step + 1) % route.length
-            next_stop = route[next_step]
-            destination = next_stop["room"]
+            destination = route[next_step]["room"]
 
-            message = move_entity(game: game, entity_type: entity_type, entity_id: entity_id,
-                                  entity_def: entity_def, from_room: current_room,
-                                  to_room: destination, player_room: player_room, movement: movement)
+            message = move_entity(ctx, from_room: current_room, to_room: destination)
 
             game.update_movement_state(entity_type, entity_id,
                                        { "step" => next_step, "move_counter" => 0 })
@@ -85,7 +90,12 @@ module ClassicGame
           nil
         end
 
-        def process_triggered(game:, entity_type:, entity_id:, entity_def:, movement:, player_room:)
+        def process_triggered(ctx)
+          game = ctx[:game]
+          entity_type = ctx[:entity_type]
+          entity_id = ctx[:entity_id]
+          movement = ctx[:movement]
+
           state = game.movement_state(entity_type, entity_id)
           return nil if state["triggered"]
 
@@ -97,9 +107,7 @@ module ClassicGame
           return nil unless current_room
           return nil if current_room == destination
 
-          message = move_entity(game: game, entity_type: entity_type, entity_id: entity_id,
-                                entity_def: entity_def, from_room: current_room,
-                                to_room: destination, player_room: player_room, movement: movement)
+          message = move_entity(ctx, from_room: current_room, to_room: destination)
 
           game.update_movement_state(entity_type, entity_id, { "triggered" => true })
           message
@@ -117,25 +125,27 @@ module ClassicGame
           nil
         end
 
-        def move_entity(game:, entity_type:, entity_id:, entity_def:, from_room:, to_room:, player_room:, movement:)
+        def move_entity(ctx, from_room:, to_room:)
+          game = ctx[:game]
+          entity_type = ctx[:entity_type]
           collection_key = entity_type == "npc" ? "npcs" : "creatures"
-          entity_name = entity_def["name"] || entity_id
+          entity_name = ctx[:entity_def]["name"] || ctx[:entity_id]
 
           old_room_state = game.room_state(from_room).dup
-          old_room_state[collection_key] = (old_room_state[collection_key] || []) - [entity_id]
+          old_room_state[collection_key] = (old_room_state[collection_key] || []) - [ctx[:entity_id]]
           old_room_state["modified"] = true
           game.update_room_state(from_room, old_room_state)
 
           new_room_state = game.room_state(to_room).dup
           new_room_state[collection_key] ||= []
-          new_room_state[collection_key] << entity_id
+          new_room_state[collection_key] << ctx[:entity_id]
           new_room_state["modified"] = true
           game.update_room_state(to_room, new_room_state)
 
-          if from_room == player_room
-            movement["depart_text"] || "#{entity_name} leaves."
-          elsif to_room == player_room
-            movement["arrive_text"] || "#{entity_name} arrives."
+          if from_room == ctx[:player_room]
+            ctx[:movement]["depart_text"] || "#{entity_name} leaves."
+          elsif to_room == ctx[:player_room]
+            ctx[:movement]["arrive_text"] || "#{entity_name} arrives."
           end
         end
     end

--- a/app/lib/classic_game/movement_processor.rb
+++ b/app/lib/classic_game/movement_processor.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  class MovementProcessor
+    class << self
+      def process(game:, user_id:)
+        messages = []
+        player_room = game.player_state(user_id)["current_room"]
+        world = game.world_snapshot
+
+        (world["npcs"] || {}).each do |npc_id, npc_def|
+          next unless npc_def.is_a?(Hash) && npc_def["movement"]
+
+          msg = process_entity(game: game, entity_type: "npc", entity_id: npc_id,
+                               entity_def: npc_def, player_room: player_room)
+          messages << msg if msg
+        end
+
+        (world["creatures"] || {}).each do |creature_id, creature_def|
+          next unless creature_def.is_a?(Hash) && creature_def["movement"]
+
+          msg = process_entity(game: game, entity_type: "creature", entity_id: creature_id,
+                               entity_def: creature_def, player_room: player_room)
+          messages << msg if msg
+        end
+
+        messages
+      end
+
+      private
+
+        def process_entity(game:, entity_type:, entity_id:, entity_def:, player_room:)
+          movement = entity_def["movement"]
+
+          case movement["type"]
+          when "patrol"
+            process_patrol(game: game, entity_type: entity_type, entity_id: entity_id,
+                           entity_def: entity_def, movement: movement, player_room: player_room)
+          when "triggered"
+            process_triggered(game: game, entity_type: entity_type, entity_id: entity_id,
+                              entity_def: entity_def, movement: movement, player_room: player_room)
+          end
+        end
+
+        def process_patrol(game:, entity_type:, entity_id:, entity_def:, movement:, player_room:)
+          # Skip if entity no longer exists in any room (e.g. defeated creature)
+          current_entity_room = find_entity_room(game, entity_type, entity_id)
+          return nil unless current_entity_room
+
+          state = game.movement_state(entity_type, entity_id)
+          route = movement["route"]
+          return nil if route.blank?
+
+          step = state["step"] || 0
+          counter = state["move_counter"] || 0
+          current_stop = route[step % route.length]
+          current_room = current_stop["room"]
+          stay_duration = current_stop["stay"] || 1
+
+          counter += 1
+
+          if counter >= stay_duration
+            unless_rooms = movement["unless_player_in"] || []
+            if unless_rooms.include?(player_room) && current_room == player_room
+              game.update_movement_state(entity_type, entity_id,
+                                         { "step" => step, "move_counter" => counter })
+              return nil
+            end
+
+            next_step = (step + 1) % route.length
+            next_stop = route[next_step]
+            destination = next_stop["room"]
+
+            message = move_entity(game: game, entity_type: entity_type, entity_id: entity_id,
+                                  entity_def: entity_def, from_room: current_room,
+                                  to_room: destination, player_room: player_room, movement: movement)
+
+            game.update_movement_state(entity_type, entity_id,
+                                       { "step" => next_step, "move_counter" => 0 })
+            return message
+          end
+
+          game.update_movement_state(entity_type, entity_id,
+                                     { "step" => step, "move_counter" => counter })
+          nil
+        end
+
+        def process_triggered(game:, entity_type:, entity_id:, entity_def:, movement:, player_room:)
+          state = game.movement_state(entity_type, entity_id)
+          return nil if state["triggered"]
+
+          flag = movement["trigger_flag"]
+          return nil unless flag && game.get_flag(flag)
+
+          destination = movement["destination"]
+          current_room = find_entity_room(game, entity_type, entity_id)
+          return nil unless current_room
+          return nil if current_room == destination
+
+          message = move_entity(game: game, entity_type: entity_type, entity_id: entity_id,
+                                entity_def: entity_def, from_room: current_room,
+                                to_room: destination, player_room: player_room, movement: movement)
+
+          game.update_movement_state(entity_type, entity_id, { "triggered" => true })
+          message
+        end
+
+        def find_entity_room(game, entity_type, entity_id)
+          collection_key = entity_type == "npc" ? "npcs" : "creatures"
+          rooms = game.world_snapshot["rooms"] || {}
+
+          rooms.each_key do |room_id|
+            room_state = game.room_state(room_id)
+            return room_id if (room_state[collection_key] || []).include?(entity_id)
+          end
+
+          nil
+        end
+
+        def move_entity(game:, entity_type:, entity_id:, entity_def:, from_room:, to_room:, player_room:, movement:)
+          collection_key = entity_type == "npc" ? "npcs" : "creatures"
+          entity_name = entity_def["name"] || entity_id
+
+          old_room_state = game.room_state(from_room).dup
+          old_room_state[collection_key] = (old_room_state[collection_key] || []) - [entity_id]
+          old_room_state["modified"] = true
+          game.update_room_state(from_room, old_room_state)
+
+          new_room_state = game.room_state(to_room).dup
+          new_room_state[collection_key] ||= []
+          new_room_state[collection_key] << entity_id
+          new_room_state["modified"] = true
+          game.update_room_state(to_room, new_room_state)
+
+          if from_room == player_room
+            movement["depart_text"] || "#{entity_name} leaves."
+          elsif to_room == player_room
+            movement["arrive_text"] || "#{entity_name} arrives."
+          end
+        end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -172,6 +172,19 @@ class Game < ApplicationRecord
     save!
   end
 
+  # Movement state methods
+  def movement_state(entity_type, entity_id)
+    game_state.dig("movement_states", "#{entity_type}_#{entity_id}") ||
+      { "step" => 0, "move_counter" => 0, "triggered" => false }
+  end
+
+  def update_movement_state(entity_type, entity_id, new_state)
+    self.game_state ||= {}
+    self.game_state["movement_states"] ||= {}
+    self.game_state["movement_states"]["#{entity_type}_#{entity_id}"] = new_state
+    save!
+  end
+
   def add_to_container(container_id, item_id)
     self.game_state ||= {}
     self.game_state["container_states"] ||= {}
@@ -238,7 +251,8 @@ class Game < ApplicationRecord
                 "player_states" => {},
                 "room_states" => {},
                 "global_flags" => {},
-                "container_states" => {}
+                "container_states" => {},
+                "movement_states" => {}
               })
 
       # Generate starting room description

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -1,0 +1,450 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Comprehensive end-to-end playthrough of a purpose-built 5-room world.
+# Routes every command through ClassicGame::Engine to exercise the full stack:
+# aggressive-creature checks, pending-roll routing, and all handler dispatch paths.
+#
+# Design choices for determinism:
+#   - Troll HP: 1  (dies on any hit; min player damage is 1)
+#   - Dice roll DC: 1  (1d20 minimum is 1, so roll always succeeds)
+#   - srand(42) wraps the test for repeatable rand sequences
+class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
+  include ClassicGameTestHelper
+
+  FakeUser = Struct.new(:id)
+  USER_ID = 42
+
+  test "full game playthrough" do
+    world = build_full_game_world
+    game  = build_game(world_data: world)
+    user  = FakeUser.new(USER_ID)
+
+    with_deterministic_rand(42) do
+      phase_orientation(game, user)
+      phase_dialogue(game, user)
+      phase_items_containers(game, user)
+      phase_dice_rolls(game, user)
+      phase_movement(game, user)
+      phase_combat(game, user)
+      phase_npc_exchange(game, user)
+      phase_final_room(game, user)
+      phase_verification(game, user)
+    end
+  end
+
+  private
+
+    # Convenience wrapper so phase methods stay concise
+    def ex(game, user, cmd)
+      execute_engine(game, user, cmd)
+    end
+
+    # ─── World builders ─────────────────────────────────────────────────────
+
+    def build_full_game_world
+      build_world(
+        starting_room: "entrance",
+        rooms: rooms_data,
+        items: items_data,
+        npcs: npcs_data,
+        creatures: creatures_data
+      )
+    end
+
+    def rooms_data
+      {
+        "entrance" => {
+          "name" => "Entrance Hall",
+          "description" => "A grand entrance hall. A guide stands nearby.",
+          "items" => ["old_key"],
+          "npcs" => ["guide"],
+          "exits" => {
+            "east" => "storeroom",
+            "south" => "cave",
+            "north" => { "to" => "tower", "requires_flag" => "tower_unlocked",
+                         "locked_msg" => "The tower door is sealed." }
+          }
+        },
+        "storeroom" => {
+          "name" => "Storeroom",
+          "description" => "A dusty storeroom with shelves.",
+          "items" => %w[supply_crate lockpick],
+          "exits" => { "west" => "entrance" }
+        },
+        "cave" => {
+          "name" => "Dark Cave",
+          "description" => "A damp, dimly lit cave.",
+          "creatures" => ["troll"],
+          "exits" => {
+            "north" => "entrance",
+            "west" => { "to" => "alcove", "hidden" => true, "requires_flag" => "troll_slain",
+                        "reveal_msg" => "A passage to the west is now visible!" }
+          }
+        },
+        "tower" => {
+          "name" => "Wizard's Tower",
+          "description" => "A tall tower filled with arcane artifacts.",
+          "items" => ["scroll"],
+          "npcs" => ["wizard"],
+          "exits" => { "south" => "entrance" }
+        },
+        "alcove" => {
+          "name" => "Hidden Alcove",
+          "description" => "A small, secret alcove.",
+          "items" => ["victory_crown"],
+          "exits" => { "east" => "cave" },
+          "on_enter" => { "type" => "message",
+                          "text" => "You squeeze through a hidden passage into a forgotten alcove!" }
+        }
+      }
+    end
+
+    def items_data
+      basic_items.merge(complex_items)
+    end
+
+    def basic_items
+      {
+        "old_key" => {
+          "name" => "Old Key", "keywords" => ["key"],
+          "takeable" => true, "description" => "A tarnished old key."
+        },
+        "gem" => {
+          "name" => "Glowing Gem", "keywords" => %w[gem glowing],
+          "takeable" => true, "description" => "It pulsates with inner light."
+        },
+        "enchanted_blade" => {
+          "name" => "Enchanted Blade", "keywords" => %w[blade sword enchanted],
+          "takeable" => true, "weapon_damage" => 3,
+          "description" => "A blade humming with magic."
+        },
+        "scroll" => {
+          "name" => "Ancient Scroll", "keywords" => %w[scroll ancient],
+          "takeable" => true, "description" => "Yellowed parchment covered in runes.",
+          "on_use" => { "type" => "message", "text" => "The scroll speaks of ancient prophecies." }
+        },
+        "victory_crown" => {
+          "name" => "Victory Crown", "keywords" => %w[crown victory],
+          "takeable" => true, "description" => "The crown of the realm."
+        }
+      }
+    end
+
+    def complex_items
+      {
+        "health_potion" => {
+          "name" => "Health Potion", "keywords" => %w[potion health],
+          "takeable" => true, "consumable" => true,
+          "description" => "A red potion that restores health.",
+          "combat_effect" => { "type" => "heal", "amount" => 5 }
+        },
+        "lockpick" => {
+          "name" => "Lockpick", "keywords" => %w[lockpick pick],
+          "takeable" => true, "description" => "A slender metal pick.",
+          "dice_roll" => {
+            "dc" => 1, "dice" => "1d20",
+            "attempt_message" => "You attempt to pick a lock...",
+            "consume_on" => "failure",
+            "on_success" => { "message" => "The lock clicks open! You've mastered the lockpick.",
+                              "sets_flag" => "lockpick_mastered" },
+            "on_failure" => { "message" => "The lockpick snaps! Better luck next time." }
+          }
+        },
+        "supply_crate" => {
+          "name" => "Supply Crate", "keywords" => %w[crate supply chest],
+          "is_container" => true, "starts_closed" => true,
+          "locked" => true, "unlock_item" => "old_key",
+          "contents" => ["health_potion"],
+          "description" => "A heavy wooden crate.",
+          "closed_description" => "A heavy wooden crate, firmly closed.",
+          "open_description" => "An open supply crate.",
+          "locked_message" => "It's locked tight.",
+          "on_open_message" => "You unlock and open the crate."
+        }
+      }
+    end
+
+    def npcs_data
+      { "guide" => guide_data, "wizard" => wizard_data }
+    end
+
+    def guide_data
+      {
+        "name" => "Guide", "keywords" => ["guide"],
+        "description" => "A helpful traveler who knows the area.",
+        "dialogue" => {
+          "greeting" => "Welcome, adventurer! Ask me about 'directions' to learn more.",
+          "sets_flag" => "spoke_to_guide",
+          "topics" => {
+            "directions" => {
+              "keywords" => %w[directions direction],
+              "text" => "Head north for the tower, south for the cave.",
+              "leads_to" => ["secret"]
+            },
+            "secret" => {
+              "keywords" => ["secret"],
+              "text" => "There is a hidden alcove beyond the cave.",
+              "locked_text" => "I have nothing more to share."
+            },
+            "tower" => {
+              "keywords" => ["tower"],
+              "text" => "The wizard will trade rare gems for powerful weapons.",
+              "sets_flag" => "tower_unlocked",
+              "requires_flag" => "spoke_to_guide",
+              "locked_text" => "I wouldn't know anything about that."
+            }
+          }
+        }
+      }
+    end
+
+    def wizard_data
+      {
+        "name" => "Wizard", "keywords" => ["wizard"],
+        "description" => "A robed figure with a long beard.",
+        "accepts_item" => "gem", "gives_item" => "enchanted_blade",
+        "accept_message" => "Ah, a Glowing Gem! Just what I needed.",
+        "dialogue" => { "greeting" => "I am the wizard. Bring me a gem and I shall reward you." }
+      }
+    end
+
+    def creatures_data
+      {
+        "troll" => {
+          "name" => "Troll", "keywords" => ["troll"],
+          "hostile" => true, "health" => 1, "attack" => 3, "defense" => 0,
+          # attack_condition moves:4 allows go-south + talk + look before the 2nd look triggers aggro
+          "attack_condition" => { "moves" => 4 },
+          "loot" => ["gem"], "sets_flag_on_defeat" => "troll_slain",
+          "on_defeat_msg" => "The troll collapses with a thunderous crash!",
+          "aggro_text" => "The troll snarls and charges at you!",
+          "talk_text" => "The troll growls menacingly."
+        }
+      }
+    end
+
+    # ─── Phase helpers ───────────────────────────────────────────────────────
+
+    # Phase 1: basic observation commands from the starting room
+    def phase_orientation(game, user)
+      r = ex(game, user, "look")
+      assert r[:success], "PHASE 1: look should succeed"
+      assert_includes r[:response], "Entrance Hall"
+      assert_includes r[:response], "Old Key"
+      assert_includes r[:response], "Guide"
+      # north exit is visible (not hidden, just flag-gated); no west exit on this room
+      assert_includes r[:response], "NORTH"
+      assert_not_includes r[:response], "WEST"
+
+      r = ex(game, user, "help")
+      assert_includes r[:response], "Available commands"
+
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "carrying nothing"
+
+      r = ex(game, user, "examine guide")
+      assert_includes r[:response], "helpful traveler"
+    end
+
+    # Phase 2: NPC dialogue — greeting, leads_to chain, requires_flag topic
+    def phase_dialogue(game, user)
+      r = ex(game, user, "talk to guide")
+      assert r[:success], "PHASE 2: greeting should succeed"
+      assert_includes r[:response], "Welcome, adventurer"
+      assert game.get_flag("spoke_to_guide"), "spoke_to_guide flag should be set after greeting"
+
+      r = ex(game, user, "talk to guide about directions")
+      assert_includes r[:response], "Head north for the tower"
+      assert_includes r[:response], "secret", "leads_to hint should mention the unlocked topic"
+
+      r = ex(game, user, "talk to guide about secret")
+      assert r[:success], "secret topic should be unlocked after asking about directions"
+      assert_includes r[:response], "hidden alcove"
+
+      r = ex(game, user, "talk to guide about tower")
+      assert r[:success], "tower topic requires spoke_to_guide flag, which is set"
+      assert_includes r[:response], "wizard"
+      assert game.get_flag("tower_unlocked"), "tower_unlocked flag should be set after tower topic"
+    end
+
+    # Phase 3: take, container locking, open with key, close, drop/take, use absent item
+    def phase_items_containers(game, user)
+      r = ex(game, user, "go east")
+      assert_includes r[:response], "Storeroom", "PHASE 3: should move to storeroom"
+
+      r = ex(game, user, "open crate")
+      assert_not r[:success], "crate should be locked before player has the key"
+      assert_includes r[:response].downcase, "locked"
+
+      ex(game, user, "go west")
+
+      r = ex(game, user, "take key")
+      assert r[:success], "should be able to take the old key from the entrance"
+      assert_includes game.player_state(USER_ID)["inventory"], "old_key"
+
+      ex(game, user, "go east")
+
+      r = ex(game, user, "open crate")
+      assert r[:success], "crate should open with key in inventory"
+      assert_includes r[:response], "Health Potion"
+
+      r = ex(game, user, "take potion")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "health_potion"
+
+      r = ex(game, user, "close crate")
+      assert r[:success]
+
+      r = ex(game, user, "examine crate")
+      assert_includes r[:response], "firmly closed"
+
+      r = ex(game, user, "take lockpick")
+      assert r[:success]
+
+      r = ex(game, user, "drop lockpick")
+      assert r[:success]
+      assert_not_includes game.player_state(USER_ID)["inventory"], "lockpick"
+
+      r = ex(game, user, "take lockpick")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "lockpick"
+
+      r = ex(game, user, "use scroll")
+      assert_not r[:success], "scroll is in the tower, not in inventory"
+    end
+
+    # Phase 4: dice roll trigger, pending-roll guard, roll resolution
+    def phase_dice_rolls(game, user)
+      r = ex(game, user, "use lockpick")
+      assert r[:success], "PHASE 4: using lockpick should trigger a pending roll"
+      assert_includes r[:response], "ROLL"
+      assert game.player_state(USER_ID)["pending_roll"].present?, "pending_roll should be set"
+
+      r = ex(game, user, "look")
+      assert_not r[:success], "non-roll commands should be blocked while roll is pending"
+      assert_includes r[:response].upcase, "ROLL"
+
+      r = ex(game, user, "roll")
+      assert r[:success], "roll should succeed (DC 1 guarantees success)"
+      assert_includes r[:response], "Success"
+      assert_includes r[:response], "lock clicks open"
+      assert_nil game.player_state(USER_ID)["pending_roll"], "pending_roll should be cleared"
+      assert game.get_flag("lockpick_mastered"), "on_success sets_flag should fire"
+    end
+
+    # Phase 5: flag-gated north exit, use scroll (on_use message), examine, return
+    def phase_movement(game, user)
+      r = ex(game, user, "go west")
+      assert_includes r[:response], "Entrance Hall", "PHASE 5: should return to entrance"
+
+      r = ex(game, user, "go north")
+      assert r[:success], "north exit should be traversable now that tower_unlocked is set"
+      assert_includes r[:response], "Wizard's Tower"
+
+      r = ex(game, user, "take scroll")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "scroll"
+
+      r = ex(game, user, "use scroll")
+      assert r[:success]
+      assert_includes r[:response], "ancient prophecies"
+
+      r = ex(game, user, "examine scroll")
+      assert_includes r[:response], "parchment"
+
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Entrance Hall"
+    end
+
+    # Phase 6: enter cave, talk (no aggro), two looks (aggro on 4th action), combat, loot
+    def phase_combat(game, user)
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Dark Cave", "PHASE 6: should enter the cave"
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat yet after entering"
+
+      r = ex(game, user, "talk to troll")
+      assert_includes r[:response], "growls menacingly"
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat after talking (moves:4)"
+
+      # 3rd room action — still below threshold
+      ex(game, user, "look")
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat on 3rd action"
+
+      # 4th room action — troll attacks!
+      r = ex(game, user, "look")
+      assert_includes r[:response], "troll snarls", "aggro_text should appear on 4th action"
+      assert game.player_state(USER_ID).dig("combat", "active"), "troll should have initiated combat"
+
+      # One-hit kill: troll has 1 HP, min player damage is 1
+      r = ex(game, user, "attack")
+      assert_includes r[:response], "thunderous crash", "defeat message should appear"
+      assert_includes r[:response], "drops: Glowing Gem", "loot should be dropped"
+      assert_includes r[:response], "passage to the west is now visible", "hidden exit should be revealed"
+      assert game.get_flag("troll_slain"), "troll_slain flag should be set"
+      assert_nil game.player_state(USER_ID)["combat"], "combat should be cleared after victory"
+
+      r = ex(game, user, "look")
+      assert_not_includes game.room_state("cave")["creatures"] || [], "troll"
+      assert_includes r[:response], "Glowing Gem", "dropped gem should be visible"
+      assert_includes r[:response], "WEST", "revealed west exit should appear"
+
+      r = ex(game, user, "take gem")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "gem"
+    end
+
+    # Phase 7: navigate to wizard and exchange gem for enchanted blade
+    def phase_npc_exchange(game, user)
+      r = ex(game, user, "go north")
+      assert_includes r[:response], "Entrance Hall", "PHASE 7: cave → entrance"
+
+      r = ex(game, user, "go north")
+      assert_includes r[:response], "Wizard's Tower"
+
+      r = ex(game, user, "give gem to wizard")
+      assert r[:success], "give should succeed — wizard accepts the gem"
+      assert_includes r[:response], "Glowing Gem"
+      assert_includes r[:response], "Enchanted Blade"
+      assert_includes game.player_state(USER_ID)["inventory"], "enchanted_blade"
+      assert_not_includes game.player_state(USER_ID)["inventory"], "gem"
+
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "Enchanted Blade"
+    end
+
+    # Phase 8: traverse the now-revealed hidden exit and pick up the victory crown
+    def phase_final_room(game, user)
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Entrance Hall", "PHASE 8: tower → entrance"
+
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Dark Cave"
+
+      r = ex(game, user, "go west")
+      assert r[:success], "hidden west exit should be traversable after troll defeated"
+      assert_includes r[:response], "Hidden Alcove"
+      assert_includes r[:response], "squeeze through", "on_enter message should show on first visit"
+
+      r = ex(game, user, "take crown")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "victory_crown"
+    end
+
+    # Phase 9: final state verification
+    def phase_verification(game, user)
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
+      assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
+      assert_includes r[:response], "Old Key",         "old key should still be in inventory"
+      assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+
+      assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
+      assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"
+      assert game.get_flag("troll_slain"),     "troll_slain flag should be set"
+
+      assert_not_includes game.room_state("cave")["creatures"] || [], "troll"
+      assert game.exit_revealed?("cave", "west"), "west exit from cave should be permanently revealed"
+    end
+end

--- a/test/lib/classic_game/movement_processor_advanced_test.rb
+++ b/test/lib/classic_game/movement_processor_advanced_test.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MovementProcessorAdvancedTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+  FakeUser = Struct.new(:id)
+
+  # ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  def build_patrol_world(stay_durations: [2, 1], unless_player_in: nil)
+    movement = {
+      "type" => "patrol",
+      "route" => [
+        { "room" => "tavern", "stay" => stay_durations[0] },
+        { "room" => "storage_room", "stay" => stay_durations[1] }
+      ]
+    }
+    movement["unless_player_in"] = unless_player_in if unless_player_in
+
+    build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A long hallway.",
+          "exits" => { "north" => "tavern" }
+        },
+        "tavern" => {
+          "name" => "The Tavern", "description" => "A cozy tavern.",
+          "exits" => { "south" => "hallway", "east" => "storage_room" },
+          "npcs" => ["barkeep"]
+        },
+        "storage_room" => {
+          "name" => "Storage Room", "description" => "Dusty shelves.",
+          "exits" => { "west" => "tavern" }
+        }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "keywords" => ["barkeep"],
+          "description" => "A burly bartender.",
+          "movement" => movement
+        }
+      }
+    )
+  end
+
+  def build_triggered_world
+    build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A hallway.",
+          "exits" => { "north" => "guard_room" }
+        },
+        "guard_room" => {
+          "name" => "Guard Room", "description" => "A room with a guard.",
+          "exits" => { "south" => "hallway", "east" => "dungeon" },
+          "npcs" => ["guard"]
+        },
+        "dungeon" => {
+          "name" => "Dungeon", "description" => "A dark dungeon.",
+          "exits" => { "west" => "guard_room" }
+        }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "keywords" => ["guard"],
+          "description" => "A vigilant guard.",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm_raised",
+            "destination" => "dungeon",
+            "depart_text" => "The guard rushes out!",
+            "arrive_text" => "A guard arrives, looking alarmed!"
+          }
+        }
+      }
+    )
+  end
+
+  def process(game)
+    ClassicGame::MovementProcessor.process(game: game, user_id: USER_ID)
+  end
+
+  # ─── AC: One-time triggered movement ───────────────────────────────────────
+
+  test "triggered NPC does not move when flag is not set" do
+    game = build_game(world_data: build_triggered_world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    process(game)
+
+    assert_includes game.room_state("guard_room")["npcs"], "guard"
+  end
+
+  test "triggered NPC moves when flag is set" do
+    game = build_game(world_data: build_triggered_world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+    game.set_flag("alarm_raised", true)
+
+    process(game)
+
+    assert_not_includes game.room_state("guard_room")["npcs"], "guard"
+    assert_includes game.room_state("dungeon")["npcs"], "guard"
+  end
+
+  test "triggered NPC moves only once even with repeated processing" do
+    world = build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => { "name" => "Hallway", "description" => "A hallway.", "exits" => {} },
+        "guard_room" => {
+          "name" => "Guard Room", "description" => "A room with a guard.",
+          "exits" => { "east" => "dungeon" }, "npcs" => ["guard"]
+        },
+        "dungeon" => {
+          "name" => "Dungeon", "description" => "A dark dungeon.",
+          "exits" => { "west" => "guard_room" }
+        }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard", "keywords" => ["guard"],
+          "description" => "A vigilant guard.",
+          "movement" => {
+            "type" => "triggered", "trigger_flag" => "alarm_raised",
+            "destination" => "dungeon"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+    game.set_flag("alarm_raised", true)
+
+    process(game)
+    process(game)
+
+    assert_includes game.room_state("dungeon")["npcs"], "guard"
+    state = game.movement_state("npc", "guard")
+    assert state["triggered"]
+  end
+
+  # ─── AC: Player-location-aware movement ────────────────────────────────────
+
+  test "patrol NPC skips move when player is in same room and unless_player_in matches" do
+    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    process(game)
+
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  test "patrol NPC moves normally when player is not in restricted room" do
+    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    process(game)
+
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  # ─── Narration tests ──────────────────────────────────────────────────────
+
+  test "returns depart narration when NPC leaves player's room" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    messages = process(game)
+
+    assert_includes messages, "Barkeep leaves."
+  end
+
+  test "returns arrive narration when NPC arrives in player's room" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("storage_room"))
+
+    messages = process(game)
+
+    assert_includes messages, "Barkeep arrives."
+  end
+
+  test "returns custom depart_text from movement definition" do
+    movement = {
+      "type" => "patrol",
+      "route" => [
+        { "room" => "tavern", "stay" => 1 },
+        { "room" => "storage_room", "stay" => 1 }
+      ],
+      "depart_text" => "The barkeep heads to the back."
+    }
+    world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern", "description" => "A cozy tavern.",
+          "exits" => { "east" => "storage_room" }, "npcs" => ["barkeep"]
+        },
+        "storage_room" => {
+          "name" => "Storage Room", "description" => "Dusty shelves.",
+          "exits" => { "west" => "tavern" }
+        }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep", "keywords" => ["barkeep"],
+          "description" => "A burly bartender.", "movement" => movement
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    messages = process(game)
+
+    assert_includes messages, "The barkeep heads to the back."
+  end
+
+  test "returns nil narration when player cannot see the move" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    messages = process(game)
+
+    assert_empty messages
+  end
+
+  # ─── Engine integration narration test ─────────────────────────────────────
+
+  test "Engine.execute appends movement narration to command response" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+    user = FakeUser.new(USER_ID)
+
+    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    assert_includes result[:response], "Barkeep leaves."
+  end
+
+  # ─── Validation tests ─────────────────────────────────────────────────────
+
+  test "validate_world_data rejects NPC with unknown movement type" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "wander" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert(errors.any? { |e| e.include?("unknown movement type") })
+  end
+
+  test "validate_world_data rejects patrol with no route" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "patrol" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert(errors.any? { |e| e.include?("route") })
+  end
+
+  test "validate_world_data rejects triggered with no destination" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "triggered", "trigger_flag" => "alarm" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert(errors.any? { |e| e.include?("destination") })
+  end
+end

--- a/test/lib/classic_game/movement_processor_test.rb
+++ b/test/lib/classic_game/movement_processor_test.rb
@@ -6,6 +6,7 @@ class MovementProcessorTest < ActiveSupport::TestCase
   include ClassicGameTestHelper
 
   USER_ID = 1
+  FakeUser = Struct.new(:id)
 
   # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -58,11 +59,9 @@ class MovementProcessorTest < ActiveSupport::TestCase
     game = build_game(world_data: world, player_id: USER_ID,
                       player_state: player_state_in("hallway"))
 
-    # First call: counter goes to 1, stay is 2 — no move yet
     process(game)
     assert_includes game.room_state("tavern")["npcs"], "barkeep"
 
-    # Second call: counter reaches 2 — move happens
     process(game)
     assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
     assert_includes game.room_state("storage_room")["npcs"], "barkeep"
@@ -72,14 +71,10 @@ class MovementProcessorTest < ActiveSupport::TestCase
     world = build_world(
       starting_room: "hallway",
       rooms: {
-        "hallway" => {
-          "name" => "Hallway", "description" => "A hallway.",
-          "exits" => {}
-        },
+        "hallway" => { "name" => "Hallway", "description" => "A hallway.", "exits" => {} },
         "cave" => {
           "name" => "Cave", "description" => "A dark cave.",
-          "exits" => { "east" => "tunnel" },
-          "creatures" => ["bat"]
+          "exits" => { "east" => "tunnel" }, "creatures" => ["bat"]
         },
         "tunnel" => {
           "name" => "Tunnel", "description" => "A narrow tunnel.",
@@ -88,10 +83,8 @@ class MovementProcessorTest < ActiveSupport::TestCase
       },
       creatures: {
         "bat" => {
-          "name" => "Bat",
-          "keywords" => ["bat"],
-          "description" => "A screeching bat.",
-          "health" => 2, "attack" => 1,
+          "name" => "Bat", "keywords" => ["bat"],
+          "description" => "A screeching bat.", "health" => 2, "attack" => 1,
           "movement" => {
             "type" => "patrol",
             "route" => [
@@ -117,7 +110,7 @@ class MovementProcessorTest < ActiveSupport::TestCase
     world = build_patrol_world(stay_durations: [1, 1])
     game = build_game(world_data: world, player_id: USER_ID,
                       player_state: player_state_in("hallway"))
-    user = OpenStruct.new(id: USER_ID)
+    user = FakeUser.new(USER_ID)
 
     ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
 
@@ -132,16 +125,13 @@ class MovementProcessorTest < ActiveSupport::TestCase
     game = build_game(world_data: world, player_id: USER_ID,
                       player_state: player_state_in("hallway"))
 
-    # Call 1: move from tavern (stop 0) to storage_room (stop 1)
     process(game)
     assert_includes game.room_state("storage_room")["npcs"], "barkeep"
 
-    # Call 2: move from storage_room (stop 1) back to tavern (stop 0)
     process(game)
     assert_includes game.room_state("tavern")["npcs"], "barkeep"
     assert_not_includes game.room_state("storage_room")["npcs"], "barkeep"
 
-    # Call 3: move from tavern (stop 0) to storage_room (stop 1) again
     process(game)
     assert_includes game.room_state("storage_room")["npcs"], "barkeep"
   end
@@ -151,300 +141,12 @@ class MovementProcessorTest < ActiveSupport::TestCase
     game = build_game(world_data: world, player_id: USER_ID,
                       player_state: player_state_in("hallway"))
 
-    # After 2 calls, NPC should still be in tavern (stay is 3)
     process(game)
     process(game)
     assert_includes game.room_state("tavern")["npcs"], "barkeep"
 
-    # Third call triggers the move
     process(game)
     assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
     assert_includes game.room_state("storage_room")["npcs"], "barkeep"
-  end
-
-  # ─── AC: One-time triggered movement ───────────────────────────────────────
-
-  test "triggered NPC does not move when flag is not set" do
-    world = build_world(
-      starting_room: "hallway",
-      rooms: {
-        "hallway" => {
-          "name" => "Hallway", "description" => "A hallway.",
-          "exits" => { "north" => "guard_room" }
-        },
-        "guard_room" => {
-          "name" => "Guard Room", "description" => "A room with a guard.",
-          "exits" => { "south" => "hallway", "east" => "dungeon" },
-          "npcs" => ["guard"]
-        },
-        "dungeon" => {
-          "name" => "Dungeon", "description" => "A dark dungeon.",
-          "exits" => { "west" => "guard_room" }
-        }
-      },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "keywords" => ["guard"],
-          "description" => "A vigilant guard.",
-          "movement" => {
-            "type" => "triggered",
-            "trigger_flag" => "alarm_raised",
-            "destination" => "dungeon",
-            "depart_text" => "The guard rushes out!",
-            "arrive_text" => "A guard arrives, looking alarmed!"
-          }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("hallway"))
-
-    process(game)
-
-    assert_includes game.room_state("guard_room")["npcs"], "guard"
-  end
-
-  test "triggered NPC moves when flag is set" do
-    world = build_world(
-      starting_room: "hallway",
-      rooms: {
-        "hallway" => {
-          "name" => "Hallway", "description" => "A hallway.",
-          "exits" => { "north" => "guard_room" }
-        },
-        "guard_room" => {
-          "name" => "Guard Room", "description" => "A room with a guard.",
-          "exits" => { "south" => "hallway", "east" => "dungeon" },
-          "npcs" => ["guard"]
-        },
-        "dungeon" => {
-          "name" => "Dungeon", "description" => "A dark dungeon.",
-          "exits" => { "west" => "guard_room" }
-        }
-      },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "keywords" => ["guard"],
-          "description" => "A vigilant guard.",
-          "movement" => {
-            "type" => "triggered",
-            "trigger_flag" => "alarm_raised",
-            "destination" => "dungeon",
-            "depart_text" => "The guard rushes out!",
-            "arrive_text" => "A guard arrives, looking alarmed!"
-          }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("hallway"))
-    game.set_flag("alarm_raised", true)
-
-    process(game)
-
-    assert_not_includes game.room_state("guard_room")["npcs"], "guard"
-    assert_includes game.room_state("dungeon")["npcs"], "guard"
-  end
-
-  test "triggered NPC moves only once even with repeated processing" do
-    world = build_world(
-      starting_room: "hallway",
-      rooms: {
-        "hallway" => {
-          "name" => "Hallway", "description" => "A hallway.",
-          "exits" => {}
-        },
-        "guard_room" => {
-          "name" => "Guard Room", "description" => "A room with a guard.",
-          "exits" => { "east" => "dungeon" },
-          "npcs" => ["guard"]
-        },
-        "dungeon" => {
-          "name" => "Dungeon", "description" => "A dark dungeon.",
-          "exits" => { "west" => "guard_room" }
-        }
-      },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "keywords" => ["guard"],
-          "description" => "A vigilant guard.",
-          "movement" => {
-            "type" => "triggered",
-            "trigger_flag" => "alarm_raised",
-            "destination" => "dungeon"
-          }
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("hallway"))
-    game.set_flag("alarm_raised", true)
-
-    process(game)
-    process(game)
-
-    assert_includes game.room_state("dungeon")["npcs"], "guard"
-    state = game.movement_state("npc", "guard")
-    assert state["triggered"]
-  end
-
-  # ─── AC: Player-location-aware movement ────────────────────────────────────
-
-  test "patrol NPC skips move when player is in same room and unless_player_in matches" do
-    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("tavern"))
-
-    process(game)
-
-    assert_includes game.room_state("tavern")["npcs"], "barkeep"
-  end
-
-  test "patrol NPC moves normally when player is not in restricted room" do
-    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("hallway"))
-
-    process(game)
-
-    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
-    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
-  end
-
-  # ─── Narration tests ──────────────────────────────────────────────────────
-
-  test "returns depart narration when NPC leaves player's room" do
-    world = build_patrol_world(stay_durations: [1, 1])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("tavern"))
-
-    messages = process(game)
-
-    assert_includes messages, "Barkeep leaves."
-  end
-
-  test "returns arrive narration when NPC arrives in player's room" do
-    world = build_patrol_world(stay_durations: [1, 1])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("storage_room"))
-
-    messages = process(game)
-
-    assert_includes messages, "Barkeep arrives."
-  end
-
-  test "returns custom depart_text from movement definition" do
-    movement = {
-      "type" => "patrol",
-      "route" => [
-        { "room" => "tavern", "stay" => 1 },
-        { "room" => "storage_room", "stay" => 1 }
-      ],
-      "depart_text" => "The barkeep heads to the back."
-    }
-    world = build_world(
-      starting_room: "tavern",
-      rooms: {
-        "tavern" => {
-          "name" => "The Tavern", "description" => "A cozy tavern.",
-          "exits" => { "east" => "storage_room" },
-          "npcs" => ["barkeep"]
-        },
-        "storage_room" => {
-          "name" => "Storage Room", "description" => "Dusty shelves.",
-          "exits" => { "west" => "tavern" }
-        }
-      },
-      npcs: {
-        "barkeep" => {
-          "name" => "Barkeep",
-          "keywords" => ["barkeep"],
-          "description" => "A burly bartender.",
-          "movement" => movement
-        }
-      }
-    )
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("tavern"))
-
-    messages = process(game)
-
-    assert_includes messages, "The barkeep heads to the back."
-  end
-
-  test "returns nil narration when player cannot see the move" do
-    world = build_patrol_world(stay_durations: [1, 1])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("hallway"))
-
-    messages = process(game)
-
-    assert_empty messages
-  end
-
-  # ─── Engine integration narration test ─────────────────────────────────────
-
-  test "Engine.execute appends movement narration to command response" do
-    world = build_patrol_world(stay_durations: [1, 1])
-    game = build_game(world_data: world, player_id: USER_ID,
-                      player_state: player_state_in("tavern"))
-    user = OpenStruct.new(id: USER_ID)
-
-    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
-
-    assert_includes result[:response], "Barkeep leaves."
-  end
-
-  # ─── Validation tests ─────────────────────────────────────────────────────
-
-  test "validate_world_data rejects NPC with unknown movement type" do
-    world = build_world(
-      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "movement" => { "type" => "wander" }
-        }
-      }
-    )
-
-    errors = ClassicGame::Engine.validate_world_data(world)
-
-    assert errors.any? { |e| e.include?("unknown movement type") }
-  end
-
-  test "validate_world_data rejects patrol with no route" do
-    world = build_world(
-      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "movement" => { "type" => "patrol" }
-        }
-      }
-    )
-
-    errors = ClassicGame::Engine.validate_world_data(world)
-
-    assert errors.any? { |e| e.include?("route") }
-  end
-
-  test "validate_world_data rejects triggered with no destination" do
-    world = build_world(
-      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
-      npcs: {
-        "guard" => {
-          "name" => "Guard",
-          "movement" => { "type" => "triggered", "trigger_flag" => "alarm" }
-        }
-      }
-    )
-
-    errors = ClassicGame::Engine.validate_world_data(world)
-
-    assert errors.any? { |e| e.include?("destination") }
   end
 end

--- a/test/lib/classic_game/movement_processor_test.rb
+++ b/test/lib/classic_game/movement_processor_test.rb
@@ -1,0 +1,450 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MovementProcessorTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  # ─── Helpers ──────────────────────────────────────────────────────────────────
+
+  def build_patrol_world(stay_durations: [2, 1], unless_player_in: nil)
+    movement = {
+      "type" => "patrol",
+      "route" => [
+        { "room" => "tavern", "stay" => stay_durations[0] },
+        { "room" => "storage_room", "stay" => stay_durations[1] }
+      ]
+    }
+    movement["unless_player_in"] = unless_player_in if unless_player_in
+
+    build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A long hallway.",
+          "exits" => { "north" => "tavern" }
+        },
+        "tavern" => {
+          "name" => "The Tavern", "description" => "A cozy tavern.",
+          "exits" => { "south" => "hallway", "east" => "storage_room" },
+          "npcs" => ["barkeep"]
+        },
+        "storage_room" => {
+          "name" => "Storage Room", "description" => "Dusty shelves.",
+          "exits" => { "west" => "tavern" }
+        }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "keywords" => ["barkeep"],
+          "description" => "A burly bartender.",
+          "movement" => movement
+        }
+      }
+    )
+  end
+
+  def process(game)
+    ClassicGame::MovementProcessor.process(game: game, user_id: USER_ID)
+  end
+
+  # ─── AC: Common DSL defines how NPCs and Creatures move ─────────────────────
+
+  test "patrol NPC moves to next room after stay duration expires" do
+    world = build_patrol_world(stay_durations: [2, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    # First call: counter goes to 1, stay is 2 — no move yet
+    process(game)
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+
+    # Second call: counter reaches 2 — move happens
+    process(game)
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+  end
+
+  test "patrol creature follows same DSL as NPC" do
+    world = build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A hallway.",
+          "exits" => {}
+        },
+        "cave" => {
+          "name" => "Cave", "description" => "A dark cave.",
+          "exits" => { "east" => "tunnel" },
+          "creatures" => ["bat"]
+        },
+        "tunnel" => {
+          "name" => "Tunnel", "description" => "A narrow tunnel.",
+          "exits" => { "west" => "cave" }
+        }
+      },
+      creatures: {
+        "bat" => {
+          "name" => "Bat",
+          "keywords" => ["bat"],
+          "description" => "A screeching bat.",
+          "health" => 2, "attack" => 1,
+          "movement" => {
+            "type" => "patrol",
+            "route" => [
+              { "room" => "cave", "stay" => 1 },
+              { "room" => "tunnel", "stay" => 1 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    process(game)
+
+    assert_includes game.room_state("tunnel")["creatures"], "bat"
+    assert_not_includes game.room_state("cave")["creatures"], "bat"
+  end
+
+  # ─── AC: Movement rules checked on every player command ─────────────────────
+
+  test "Engine.execute triggers movement processing after command" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+    user = OpenStruct.new(id: USER_ID)
+
+    ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  # ─── AC: Repetitive route movement ─────────────────────────────────────────
+
+  test "patrol NPC cycles back to first stop after completing route" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    # Call 1: move from tavern (stop 0) to storage_room (stop 1)
+    process(game)
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+
+    # Call 2: move from storage_room (stop 1) back to tavern (stop 0)
+    process(game)
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+    assert_not_includes game.room_state("storage_room")["npcs"], "barkeep"
+
+    # Call 3: move from tavern (stop 0) to storage_room (stop 1) again
+    process(game)
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+  end
+
+  test "patrol NPC stays in room for correct number of ticks" do
+    world = build_patrol_world(stay_durations: [3, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    # After 2 calls, NPC should still be in tavern (stay is 3)
+    process(game)
+    process(game)
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+
+    # Third call triggers the move
+    process(game)
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+  end
+
+  # ─── AC: One-time triggered movement ───────────────────────────────────────
+
+  test "triggered NPC does not move when flag is not set" do
+    world = build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A hallway.",
+          "exits" => { "north" => "guard_room" }
+        },
+        "guard_room" => {
+          "name" => "Guard Room", "description" => "A room with a guard.",
+          "exits" => { "south" => "hallway", "east" => "dungeon" },
+          "npcs" => ["guard"]
+        },
+        "dungeon" => {
+          "name" => "Dungeon", "description" => "A dark dungeon.",
+          "exits" => { "west" => "guard_room" }
+        }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "keywords" => ["guard"],
+          "description" => "A vigilant guard.",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm_raised",
+            "destination" => "dungeon",
+            "depart_text" => "The guard rushes out!",
+            "arrive_text" => "A guard arrives, looking alarmed!"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    process(game)
+
+    assert_includes game.room_state("guard_room")["npcs"], "guard"
+  end
+
+  test "triggered NPC moves when flag is set" do
+    world = build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A hallway.",
+          "exits" => { "north" => "guard_room" }
+        },
+        "guard_room" => {
+          "name" => "Guard Room", "description" => "A room with a guard.",
+          "exits" => { "south" => "hallway", "east" => "dungeon" },
+          "npcs" => ["guard"]
+        },
+        "dungeon" => {
+          "name" => "Dungeon", "description" => "A dark dungeon.",
+          "exits" => { "west" => "guard_room" }
+        }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "keywords" => ["guard"],
+          "description" => "A vigilant guard.",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm_raised",
+            "destination" => "dungeon",
+            "depart_text" => "The guard rushes out!",
+            "arrive_text" => "A guard arrives, looking alarmed!"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+    game.set_flag("alarm_raised", true)
+
+    process(game)
+
+    assert_not_includes game.room_state("guard_room")["npcs"], "guard"
+    assert_includes game.room_state("dungeon")["npcs"], "guard"
+  end
+
+  test "triggered NPC moves only once even with repeated processing" do
+    world = build_world(
+      starting_room: "hallway",
+      rooms: {
+        "hallway" => {
+          "name" => "Hallway", "description" => "A hallway.",
+          "exits" => {}
+        },
+        "guard_room" => {
+          "name" => "Guard Room", "description" => "A room with a guard.",
+          "exits" => { "east" => "dungeon" },
+          "npcs" => ["guard"]
+        },
+        "dungeon" => {
+          "name" => "Dungeon", "description" => "A dark dungeon.",
+          "exits" => { "west" => "guard_room" }
+        }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "keywords" => ["guard"],
+          "description" => "A vigilant guard.",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm_raised",
+            "destination" => "dungeon"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+    game.set_flag("alarm_raised", true)
+
+    process(game)
+    process(game)
+
+    assert_includes game.room_state("dungeon")["npcs"], "guard"
+    state = game.movement_state("npc", "guard")
+    assert state["triggered"]
+  end
+
+  # ─── AC: Player-location-aware movement ────────────────────────────────────
+
+  test "patrol NPC skips move when player is in same room and unless_player_in matches" do
+    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    process(game)
+
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  test "patrol NPC moves normally when player is not in restricted room" do
+    world = build_patrol_world(stay_durations: [1, 1], unless_player_in: ["tavern"])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    process(game)
+
+    assert_includes game.room_state("storage_room")["npcs"], "barkeep"
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  # ─── Narration tests ──────────────────────────────────────────────────────
+
+  test "returns depart narration when NPC leaves player's room" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    messages = process(game)
+
+    assert_includes messages, "Barkeep leaves."
+  end
+
+  test "returns arrive narration when NPC arrives in player's room" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("storage_room"))
+
+    messages = process(game)
+
+    assert_includes messages, "Barkeep arrives."
+  end
+
+  test "returns custom depart_text from movement definition" do
+    movement = {
+      "type" => "patrol",
+      "route" => [
+        { "room" => "tavern", "stay" => 1 },
+        { "room" => "storage_room", "stay" => 1 }
+      ],
+      "depart_text" => "The barkeep heads to the back."
+    }
+    world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern", "description" => "A cozy tavern.",
+          "exits" => { "east" => "storage_room" },
+          "npcs" => ["barkeep"]
+        },
+        "storage_room" => {
+          "name" => "Storage Room", "description" => "Dusty shelves.",
+          "exits" => { "west" => "tavern" }
+        }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "keywords" => ["barkeep"],
+          "description" => "A burly bartender.",
+          "movement" => movement
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    messages = process(game)
+
+    assert_includes messages, "The barkeep heads to the back."
+  end
+
+  test "returns nil narration when player cannot see the move" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hallway"))
+
+    messages = process(game)
+
+    assert_empty messages
+  end
+
+  # ─── Engine integration narration test ─────────────────────────────────────
+
+  test "Engine.execute appends movement narration to command response" do
+    world = build_patrol_world(stay_durations: [1, 1])
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+    user = OpenStruct.new(id: USER_ID)
+
+    result = ClassicGame::Engine.execute(game: game, user: user, command_text: "look")
+
+    assert_includes result[:response], "Barkeep leaves."
+  end
+
+  # ─── Validation tests ─────────────────────────────────────────────────────
+
+  test "validate_world_data rejects NPC with unknown movement type" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "wander" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert errors.any? { |e| e.include?("unknown movement type") }
+  end
+
+  test "validate_world_data rejects patrol with no route" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "patrol" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert errors.any? { |e| e.include?("route") }
+  end
+
+  test "validate_world_data rejects triggered with no destination" do
+    world = build_world(
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.", "exits" => {} } },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => { "type" => "triggered", "trigger_flag" => "alarm" }
+        }
+      }
+    )
+
+    errors = ClassicGame::Engine.validate_world_data(world)
+
+    assert errors.any? { |e| e.include?("destination") }
+  end
+end

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -151,6 +151,25 @@ module ClassicGameTestHelper
       end
   end
 
+  FakeUser = Struct.new(:id)
+
+  # ─── Engine helper ─────────────────────────────────────────────────────────
+
+  # Route a command through the full Engine (handles pending rolls, aggro checks,
+  # restart confirmation, and handler dispatch). Accepts any object that responds
+  # to #id — use FakeUser.new(some_id) as the user argument.
+  def execute_engine(game, user, command_text)
+    ClassicGame::Engine.execute(game: game, user: user, command_text: command_text)
+  end
+
+  # Seed the PRNG for deterministic outcomes, then restore the previous seed.
+  def with_deterministic_rand(seed = 42)
+    old_seed = srand(seed)
+    yield
+  ensure
+    srand(old_seed)
+  end
+
   # ─── Builders ──────────────────────────────────────────────────────────────
 
   def build_world(rooms: {}, items: {}, npcs: {}, creatures: {}, starting_room: nil)

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -14,7 +14,8 @@ module ClassicGameTestHelper
         "global_flags" => {},
         "container_states" => {},
         "unlocked_exits" => {},
-        "revealed_exits" => {}
+        "revealed_exits" => {},
+        "movement_states" => {}
       }
     end
 
@@ -94,6 +95,16 @@ module ClassicGameTestHelper
       @game_state["container_states"][container_id.to_s]["removed_items"].uniq!
     end
 
+    def movement_state(entity_type, entity_id)
+      @game_state.dig("movement_states", "#{entity_type}_#{entity_id}") ||
+        { "step" => 0, "move_counter" => 0, "triggered" => false }
+    end
+
+    def update_movement_state(entity_type, entity_id, new_state)
+      @game_state["movement_states"] ||= {}
+      @game_state["movement_states"]["#{entity_type}_#{entity_id}"] = new_state
+    end
+
     def starting_hp
       10
     end
@@ -153,10 +164,11 @@ module ClassicGameTestHelper
   end
 
   # Returns a FakeGame pre-populated with optional player/room state overrides.
-  def build_game(world_data:, player_id: 1, player_state: nil, room_states: {})
+  def build_game(world_data:, player_id: 1, player_state: nil, room_states: {}, movement_states: {})
     game = FakeGame.new(world_data: world_data)
     game.game_state["player_states"][player_id.to_s] = player_state if player_state
     room_states.each { |id, state| game.game_state["room_states"][id.to_s] = state }
+    movement_states.each { |id, state| game.game_state["movement_states"][id.to_s] = state }
     game
   end
 

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -203,6 +203,13 @@ module TestSupport
           "name" => "Town Crier",
           "keywords" => ["crier", "town crier"],
           "description" => "A loud man in official garb.",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "spider_slain",
+            "destination" => "cave",
+            "depart_text" => "The Town Crier rushes off to investigate the cave!",
+            "arrive_text" => "The Town Crier arrives, looking curious."
+          },
           "dialogue" => {
             "greeting" => "Hear ye! The innkeeper at the tavern knows many secrets. " \
                           "The tower is locked by ancient magic!",
@@ -221,6 +228,16 @@ module TestSupport
         "name" => "Innkeeper",
         "keywords" => %w[innkeeper keeper],
         "description" => "A jovial woman behind the bar.",
+        "movement" => {
+          "type" => "patrol",
+          "route" => [
+            { "room" => "tavern", "stay" => 3 },
+            { "room" => "town_square", "stay" => 2 }
+          ],
+          "unless_player_in" => ["tavern"],
+          "depart_text" => "The innkeeper steps out for some fresh air.",
+          "arrive_text" => "The innkeeper strolls in."
+        },
         "dialogue" => {
           "greeting" => "Welcome to the tavern! What would you like to know?",
           "default" => "Welcome to the tavern! What would you like to know?",

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+# Full end-to-end browser playthrough of the QA Test World.
+#
+# Exercises every game mechanic through the actual UI — typing commands into the
+# terminal input and verifying responses render on the page.
+#
+# Mechanics covered: look, help, inventory, examine, take, drop, use (consumable),
+# open/close containers (key-locked), dice rolls (pending/blocking/resolution),
+# NPC dialogue (greeting, flag-gated, item-gated, leads_to chains),
+# creature interaction (hostile + friendly), combat (attack, defeat, loot),
+# flag-gated navigation, hidden-exit reveal, NPC item exchange.
+module QaWorld
+  class FullPlaythroughTest < ApplicationSystemTestCase
+    test "complete playthrough of QA world" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      phase_orientation
+      phase_item_basics
+      phase_dialogue
+      phase_containers
+      phase_dice_roll
+      phase_navigation
+      phase_npc_exchange
+      phase_consumable
+      phase_combat
+      phase_hidden_exit
+      phase_final_verification
+    end
+
+    private
+
+      def cmd(text)
+        find(".terminal-input").send_keys(text, :return)
+      end
+
+      # Send a command and wait for new response messages to appear.
+      # Use when the next assertion text already exists on the page,
+      # or when no assertion follows and we just need to sync.
+      def cmd_and_wait(text)
+        count = all(".game-message", wait: false).count
+        find(".terminal-input").send_keys(text, :return)
+        assert_selector ".game-message", minimum: count + 2, wait: 10
+      end
+
+      # ─── Phase 1: Orientation ─────────────────────────────────────
+      # Basic observation commands in the starting room.
+      def phase_orientation
+        assert_text "Town Square"
+
+        cmd "look"
+        assert_text "Town Crier"
+
+        cmd "help"
+        assert_text "Available commands"
+
+        cmd "inventory"
+        assert_text "carrying nothing"
+
+        cmd "examine crier"
+        assert_text "loud man"
+      end
+
+      # ─── Phase 2: Item Basics ─────────────────────────────────────
+      # Take, examine, drop, retake — and verify via inventory.
+      def phase_item_basics
+        cmd "take key"
+        assert_text "You take the Rusty Key"
+
+        cmd "examine key"
+        assert_text "rusty iron key"
+
+        cmd "drop key"
+        assert_text "You drop the Rusty Key"
+
+        cmd_and_wait "take key"
+
+        cmd "inventory"
+        assert_text "You are carrying"
+      end
+
+      # ─── Phase 3: Dialogue ────────────────────────────────────────
+      # NPC conversations: greeting, flag-gated topics, item-gated topics,
+      # leads_to chains, and friendly creature interaction.
+      def phase_dialogue
+        # Crier greeting sets spoke_to_crier flag
+        cmd "talk to crier"
+        assert_text "Hear ye"
+
+        # Move to tavern for innkeeper dialogue
+        cmd "go east"
+        assert_text "The Tavern"
+
+        # Innkeeper greeting
+        cmd "talk to innkeeper"
+        assert_text "Welcome to the tavern"
+
+        # Flag-gated topic (requires spoke_to_crier) — sets tower_unlocked
+        cmd "talk to innkeeper about tower"
+        assert_text "tower can be unlocked"
+
+        # Regular topic
+        cmd "talk to innkeeper about rooms"
+        assert_text "five main areas"
+
+        # Item-gated topic (requires rusty_key in inventory)
+        cmd "talk to innkeeper about supplies"
+        assert_text "chest in the corner"
+
+        # leads_to chain: rumors unlocks cellar subtopic
+        cmd "talk to innkeeper about rumors"
+        assert_text "lurking in the cellar"
+        assert_text "You could ask about: cellar."
+
+        cmd "talk to innkeeper about cellar"
+        assert_text "cellar entrance"
+
+        # Friendly creature interaction
+        cmd "talk to rat"
+        assert_text "squeaks"
+      end
+
+      # ─── Phase 4: Containers ──────────────────────────────────────
+      # Open locked container with key, take contents, close.
+      def phase_containers
+        cmd "open chest"
+        assert_text "unlock the chest"
+
+        cmd "take potion"
+        assert_text "You take the Health Potion"
+
+        cmd "close chest"
+        assert_text "You close the Wooden Chest"
+
+        cmd "take lockpick"
+        assert_text "You take the Lockpick"
+      end
+
+      # ─── Phase 5: Dice Roll ───────────────────────────────────────
+      # Trigger pending roll, verify it blocks other commands, resolve.
+      def phase_dice_roll
+        cmd "use lockpick"
+        assert_text "Type ROLL"
+
+        # Non-roll commands are blocked while a roll is pending
+        cmd "look"
+        assert_text "You need to ROLL first"
+
+        # Resolve the roll (outcome varies — DC 12 on d20)
+        cmd "roll"
+        assert_text(/Success!|Failed\./)
+        assert_text "TOTAL:"
+      end
+
+      # ─── Phase 6: Navigation ──────────────────────────────────────
+      # Flag-gated exit to tower (tower_unlocked set via dialogue).
+      def phase_navigation
+        cmd_and_wait "go west" # return to Town Square (text already on page)
+
+        # North exit was locked; tower_unlocked flag was set by innkeeper
+        cmd "go north"
+        assert_text "Tower Top"
+        assert_text "wind howls"
+
+        cmd "take gem"
+        assert_text "You take the Sparkling Gem"
+
+        cmd "examine gem"
+        assert_text "glows faintly"
+
+        cmd_and_wait "go south" # return to Town Square
+      end
+
+      # ─── Phase 7: NPC Exchange ────────────────────────────────────
+      # Give gem to merchant, receive enchanted sword.
+      def phase_npc_exchange
+        cmd "go west"
+        assert_text "The Market"
+
+        cmd "talk to merchant"
+        assert_text "sparkling gem"
+
+        cmd "give gem to merchant"
+        assert_text "enchanted sword in return"
+
+        cmd_and_wait "go east" # return to Town Square
+      end
+
+      # ─── Phase 8: Consumable ──────────────────────────────────────
+      # Use health potion outside of combat.
+      def phase_consumable
+        cmd "use potion"
+        assert_text "revitalized"
+      end
+
+      # ─── Phase 9: Combat ──────────────────────────────────────────
+      # Fight cave spider to defeat; collect loot.
+      def phase_combat
+        cmd "go south"
+        assert_text "The Cave"
+
+        # Talk to hostile creature before fighting
+        cmd "talk to spider"
+        assert_text "hisses"
+
+        # Initiate combat
+        cmd "attack spider"
+        assert_text "engage"
+
+        # Fight until victory (player has 50 HP + enchanted sword; spider has 8 HP)
+        10.times do
+          cmd "attack"
+          break if page.has_text?("crumples", wait: 2)
+        end
+
+        assert_text "crumples"
+        assert_text "narrow passage"
+
+        cmd "take shield"
+        assert_text "You take the Iron Shield"
+      end
+
+      # ─── Phase 10: Hidden Exit ────────────────────────────────────
+      # Traverse the exit revealed by defeating the cave spider.
+      def phase_hidden_exit
+        cmd "go east"
+        assert_text "Secret Alcove"
+        assert_text "crystals"
+
+        cmd_and_wait "go west" # return to The Cave
+      end
+
+      # ─── Phase 11: Final Verification ─────────────────────────────
+      # Return home and verify final inventory state.
+      def phase_final_verification
+        cmd_and_wait "go north" # return to Town Square
+
+        cmd "inventory"
+        assert_text "Enchanted Sword"
+        assert_text "Iron Shield"
+      end
+  end
+end

--- a/test/system/qa_world/npc_movement_test.rb
+++ b/test/system/qa_world/npc_movement_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class NpcMovementTest < ApplicationSystemTestCase
+    test "innkeeper patrol: arrives in town_square after enough ticks" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern — tick 1
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+      assert_text "Innkeeper"
+
+      # Look around — tick 2
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "The Tavern"
+
+      # Go back to town square — tick 3, innkeeper moves to town_square
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "Town Square"
+      assert_text "The innkeeper strolls in."
+    end
+
+    test "innkeeper patrol: stays put while player is in tavern" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Go to tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      # Do several actions in tavern — innkeeper should stay because of unless_player_in
+      find(".terminal-input").send_keys("look", :return)
+      find(".terminal-input").send_keys("look", :return)
+      find(".terminal-input").send_keys("look", :return)
+      find(".terminal-input").send_keys("look", :return)
+
+      # Innkeeper should still be present
+      find(".terminal-input").send_keys("examine innkeeper", :return)
+      assert_text "jovial woman"
+    end
+  end
+end


### PR DESCRIPTION
## Description

# Moving NPCs & Creatures
The game should support NPCs and Creatures that can move about from room to room in the game.

# Acceptance Criteria
- Create a common DSL that defines how NPCs and Creatures move
- NPC and Creature movement rules need to be checked on every player command
- Movement can be a repitive route (eg. every six moves the barkeep moves to the storage room for 2 turns then comes back)
- Movement can be a one-time thing triggered by player action
- Movement should have the option to be configurable based on player location (e.g. the barkeep doesn't go in the storage room while the player is in the tavern)

Kind: feature