### PR TITLE
Player Turn Management

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -5,7 +5,7 @@ class MessagesController < ApplicationController
   before_action :require_game_participant
 
   def index
-    @pagy, @messages = pagy(Message.for_game(@game), items: 10)
+    @pagy, @messages = pagy(Message.for_game(@game).visible_to(current_user), items: 10)
   end
 
   def create

--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -28,6 +28,8 @@ class ClassicCommandJob
         content: result[:response]
         # NOTE: no game_user_id, so it's a "host" message from the game engine
       )
+
+      create_multiplayer_messages(game, user, result)
     end
   end
 
@@ -43,6 +45,43 @@ class ClassicCommandJob
         event_data: result[:dice_roll],
         content: ""
       )
+    end
+
+    def create_multiplayer_messages(game, user, result)
+      events = result[:multiplayer_events]
+      return unless events
+
+      # Observer messages — players in same room who see the action
+      (events[:observer_messages] || []).each do |event|
+        Message.create!(
+          game: game,
+          content: event[:content],
+          visible_to_user_ids: event[:user_ids].map(&:to_i)
+        )
+      end
+
+      # Global event messages — remote players affected by flag changes
+      (events[:global_event_messages] || []).each do |event|
+        Message.create!(
+          game: game,
+          content: event[:content],
+          visible_to_user_ids: event[:user_ids].map(&:to_i)
+        )
+      end
+
+      # Arrival messages when a player moves into a room with others
+      if result.dig(:state_changes, :arrived_in_room)
+        arrival = ClassicGame::MultiplayerNotifier.arrival_message(
+          game, user.id, result.dig(:state_changes, :arrived_in_room)
+        )
+        if arrival
+          Message.create!(
+            game: game,
+            content: arrival[:content],
+            visible_to_user_ids: arrival[:user_ids].map(&:to_i)
+          )
+        end
+      end
     end
 
     def sync_classic_sidebar(game, user, game_user)

--- a/app/lib/classic_game/base_handler.rb
+++ b/app/lib/classic_game/base_handler.rb
@@ -189,6 +189,45 @@ module ClassicGame
         current_room_state["creatures"]&.include?(creature_id)
       end
 
+      # Returns user_id strings of other players in this player's current room.
+      def players_in_same_room
+        room_id = player_state["current_room"]
+        game.players_in_room(room_id).reject { |uid| uid == user_id.to_s }
+      end
+
+      # Find a player by character name. Checks game_state["player_names"] first
+      # (for FakeGame tests), then falls back to GameUser records.
+      # Returns [user_id_string, player_state_hash] or [nil, nil].
+      def find_player(name_or_id)
+        return [nil, nil] if name_or_id.blank?
+
+        player_names = game.game_state["player_names"] || {}
+        player_names.each do |uid, char_name|
+          next unless char_name.downcase.include?(name_or_id.downcase) ||
+                      name_or_id.downcase.include?(char_name.downcase)
+
+          return [uid, game.player_state(uid)]
+        end
+
+        if game.respond_to?(:game_users)
+          game.game_users.each do |gu|
+            char = gu.character_name
+            next unless char.downcase.include?(name_or_id.downcase) ||
+                        name_or_id.downcase.include?(char.downcase)
+
+            return [gu.user_id.to_s, game.player_state(gu.user_id)]
+          end
+        end
+
+        [nil, nil]
+      end
+
+      # Returns true if the given player is in the same room as the current player.
+      def player_in_room?(target_user_id)
+        target_state = game.player_state(target_user_id)
+        target_state["current_room"] == player_state["current_room"]
+      end
+
       # Check if player is in active combat
       def in_combat?
         player_state.dig("combat", "active") == true

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -15,6 +15,18 @@ module ClassicGame
           )
         end
 
+        # Turn order guard — reject commands from off-turn players
+        unless ClassicGame::TurnManager.can_act?(game, user.id)
+          return {
+            success: false,
+            response: ClassicGame::TurnManager.waiting_message(game, user.id),
+            state_changes: {}
+          }
+        end
+
+        # Snapshot global flags before action to detect changes
+        flags_before = (game.game_state["global_flags"] || {}).dup
+
         # Parse the command
         command = CommandParser.parse(command_text)
 
@@ -28,7 +40,25 @@ module ClassicGame
                  end
 
         # Check for aggressive creatures after the player acts
-        check_aggressive_creatures(game, user, command, result)
+        result = check_aggressive_creatures(game, user, command, result)
+
+        # Advance turn order after the full action (including creature reactions)
+        ClassicGame::TurnManager.advance(game)
+
+        # Compute flag changes and attach multiplayer events
+        flags_after = game.game_state["global_flags"] || {}
+        flag_changes = flags_after.reject { |k, v| flags_before[k] == v }
+
+        multiplayer_events = {
+          observer_messages: ClassicGame::MultiplayerNotifier.observer_messages(
+            game, user.id, command_text, result
+          ),
+          global_event_messages: ClassicGame::MultiplayerNotifier.global_event_messages(
+            game, flag_changes, user.id
+          )
+        }
+
+        result.merge(multiplayer_events: multiplayer_events)
       rescue StandardError => e
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -157,6 +157,8 @@ module ClassicGame
           new_player_state["combat"] = nil
           update_player_state(new_player_state)
 
+          ClassicGame::TurnManager.handle_flee(game, user_id)
+
           lines = []
           lines << "You flee from combat!"
           flee_msg = creature_def["on_flee_msg"] || "The #{creature_def['name']} watches you retreat."
@@ -291,6 +293,8 @@ module ClassicGame
           new_player_state = player_state.dup
           new_player_state["combat"] = nil
           update_player_state(new_player_state)
+
+          ClassicGame::TurnManager.handle_combat_end(game)
 
           # Set defeat flag if specified
           if creature_def["sets_flag_on_defeat"]

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -211,6 +211,15 @@ module ClassicGame
             lines << "Creatures: #{creature_names.join(', ')}"
           end
 
+          # List other players present in the room
+          other_player_ids = game.players_in_room(player_state["current_room"]).reject { |uid| uid == user_id.to_s }
+          if other_player_ids.any?
+            player_names_map = game.game_state["player_names"] || {}
+            other_names = other_player_ids.map { |uid| player_names_map[uid] || "Player #{uid}" }
+            lines << ""
+            lines << "Also here: #{other_names.join(', ')}"
+          end
+
           # List exits (filter out hidden unrevealed exits)
           exits = room_def["exits"] || {}
           room_id = player_state["current_room"]

--- a/app/lib/classic_game/handlers/give_handler.rb
+++ b/app/lib/classic_game/handlers/give_handler.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module Handlers
+    # Handles GIVE <item> TO <player> — transfers an item between two players
+    # who are in the same room. Distinct from InteractHandler's NPC give logic.
+    class GiveHandler < BaseHandler
+      def handle(command)
+        item_target = command[:target]
+        recipient_name = command[:modifier]
+
+        return failure("Give what to whom?") unless item_target && recipient_name
+
+        item_id, item_def = find_item(item_target)
+        return failure("You don't have that item.") unless item_def
+        return failure("You don't have that item.") unless item?(item_id)
+
+        recipient_user_id, = find_player(recipient_name)
+        return failure("You don't see #{recipient_name} here.") unless recipient_user_id
+        return failure("You don't see #{recipient_name} here.") unless player_in_room?(recipient_user_id)
+
+        transfer_item(item_id, recipient_user_id)
+
+        recipient_display = player_display_name(recipient_user_id)
+        success("You give the #{item_def['name']} to #{recipient_display}.")
+      end
+
+      private
+
+        def transfer_item(item_id, recipient_user_id)
+          new_state = player_state.dup
+          new_state["inventory"] = (new_state["inventory"] || []) - [item_id]
+          update_player_state(new_state)
+
+          recipient_state = game.player_state(recipient_user_id).dup
+          recipient_state["inventory"] ||= []
+          recipient_state["inventory"] << item_id
+          game.update_player_state(recipient_user_id, recipient_state)
+        end
+
+        def player_display_name(user_id)
+          game.game_state.dig("player_names", user_id.to_s) || "Player #{user_id}"
+        end
+    end
+  end
+end

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -143,6 +143,13 @@ module ClassicGame
         def handle_give(item_target, npc_target)
           return failure("Give what to whom?") unless item_target && npc_target
 
+          # Check if the target resolves to another player in the same room first
+          recipient_user_id, = find_player(npc_target)
+          if recipient_user_id && player_in_room?(recipient_user_id)
+            command = { verb: :give, target: item_target, modifier: npc_target, raw: "give #{item_target} to #{npc_target}" }
+            return ClassicGame::Handlers::GiveHandler.new(game: game, user_id: user_id).handle(command)
+          end
+
           # Find the item
           item_id, item_def = find_item(item_target)
           return failure("You don't have that item.") unless item_def

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -83,7 +83,7 @@ module ClassicGame
           # Generate room description
           description = generate_room_description(room_id, new_room_def, first_visit)
 
-          success(description, state_changes: { moved: true, room: room_id })
+          success(description, state_changes: { moved: true, room: room_id, arrived_in_room: room_id })
         end
 
         def generate_room_description(room_id, room_def, first_visit)
@@ -130,6 +130,15 @@ module ClassicGame
               world_snapshot.dig("creatures", creature_id, "name") || creature_id
             end
             lines << "Creatures: #{creature_names.join(', ')}"
+          end
+
+          # List other players present in the room
+          other_player_ids = game.players_in_room(room_id).reject { |uid| uid == user_id.to_s }
+          if other_player_ids.any?
+            player_names_map = game.game_state["player_names"] || {}
+            other_names = other_player_ids.map { |uid| player_names_map[uid] || "Player #{uid}" }
+            lines << ""
+            lines << "Also here: #{other_names.join(', ')}"
           end
 
           # List exits (filter out hidden unrevealed exits)

--- a/app/lib/classic_game/multiplayer_notifier.rb
+++ b/app/lib/classic_game/multiplayer_notifier.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  # Generates secondary messages for players who are affected by another
+  # player's action but are not the one who issued the command.
+  class MultiplayerNotifier
+    class << self
+      # Returns an array of { user_ids:, content: } hashes for players who are
+      # in the same room as the acting player and should see their command + result.
+      def observer_messages(game, acting_user_id, command_text, result)
+        room_id = game.player_state(acting_user_id)["current_room"]
+        others = game.players_in_room(room_id).reject { |uid| uid == acting_user_id.to_s }
+        return [] if others.empty?
+
+        actor_name = player_name(game, acting_user_id)
+        content = "[#{actor_name}]: #{command_text}\n\n#{result[:response]}"
+        [{ user_ids: others, content: content }]
+      end
+
+      # Returns a single { user_ids:, content: } hash for players already in
+      # the destination room when another player arrives, or nil if the room
+      # is empty.
+      def arrival_message(game, arriving_user_id, room_id)
+        others = game.players_in_room(room_id).reject { |uid| uid == arriving_user_id.to_s }
+        return nil if others.empty?
+
+        name = player_name(game, arriving_user_id)
+        { user_ids: others, content: "[#{name}] has arrived." }
+      end
+
+      # Returns an array of { user_ids:, content: } hashes for players in rooms
+      # whose exits reference a flag that just changed.
+      def global_event_messages(game, flag_changes, acting_user_id)
+        return [] if flag_changes.empty?
+
+        messages = []
+        world = game.world_snapshot
+
+        flag_changes.each_key do |flag_name|
+          world["rooms"]&.each do |room_id, room_def|
+            (room_def["exits"] || {}).each_value do |exit_data|
+              next unless exit_data.is_a?(Hash)
+              next unless exit_data["requires_flag"] == flag_name
+
+              room_players = game.players_in_room(room_id).reject { |uid| uid == acting_user_id.to_s }
+              next if room_players.empty?
+
+              content = exit_data["remote_event_msg"] || "Something changes in the distance..."
+              messages << { user_ids: room_players, content: content }
+            end
+          end
+        end
+
+        messages
+      end
+
+      # Returns a turn-status string shown in the player's UI.
+      def waiting_indicator(game, user_id)
+        if ClassicGame::TurnManager.can_act?(game, user_id)
+          "It's your turn!"
+        else
+          current_id = game.current_turn_user_id
+          name = player_name(game, current_id)
+          "Waiting for #{name}'s turn..."
+        end
+      end
+
+      private
+
+        def player_name(game, user_id)
+          stored = game.game_state.dig("player_names", user_id.to_s)
+          return stored if stored
+
+          if game.respond_to?(:game_users)
+            gu = game.game_users.find_by(user_id: user_id)
+            return gu.character_name if gu
+          end
+
+          "Player #{user_id}"
+        end
+    end
+  end
+end

--- a/app/lib/classic_game/turn_manager.rb
+++ b/app/lib/classic_game/turn_manager.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  class TurnManager
+    class << self
+      # Returns true when it is this player's turn, or when there is no turn
+      # state (single-player / legacy games — always allow).
+      def can_act?(game, user_id)
+        ts = game.game_state["turn_state"]
+        return true unless ts
+
+        game.current_turn_user_id == user_id.to_s
+      end
+
+      # Initialise turn order from the game's joined players (DB only).
+      # Called from GameUser after_create_commit for classic games.
+      def initialize_for_game(game)
+        user_ids = game.game_users.order(:id).pluck(:user_id).map(&:to_s)
+        game.initialize_turn_order(user_ids)
+      end
+
+      # Advance the game to the next player's turn.
+      def advance(game)
+        game.advance_turn
+      end
+
+      # Returns a human-readable message telling the waiting player whose
+      # turn it currently is.
+      def waiting_message(game, _user_id)
+        current_id = game.current_turn_user_id
+        name = player_name(game, current_id)
+        "It's #{name}'s turn. Please wait..."
+      end
+
+      # Mark a player as having fled combat so they are skipped in turn order
+      # until combat ends.
+      def handle_flee(game, user_id)
+        game.player_fled_combat(user_id)
+      end
+
+      # Re-enable all fled players once combat is over.
+      def handle_combat_end(game)
+        game.combat_ended
+      end
+
+      private
+
+        def player_name(game, user_id)
+          stored = game.game_state.dig("player_names", user_id.to_s)
+          return stored if stored
+
+          if game.respond_to?(:game_users)
+            gu = game.game_users.find_by(user_id: user_id)
+            return gu.character_name if gu
+          end
+
+          "Player #{user_id}"
+        end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -172,6 +172,76 @@ class Game < ApplicationRecord
     save!
   end
 
+  # Turn management methods
+  def turn_order
+    game_state.dig("turn_state", "order") || []
+  end
+
+  def current_turn_user_id
+    game_state.dig("turn_state", "current_user_id")
+  end
+
+  def initialize_turn_order(user_ids)
+    self.game_state ||= {}
+    self.game_state["turn_state"] = {
+      "order" => user_ids.map(&:to_s),
+      "current_user_id" => user_ids.first&.to_s,
+      "combat_waiting" => []
+    }
+    save!
+  end
+
+  def advance_turn
+    ts = game_state["turn_state"]
+    return unless ts
+
+    order = ts["order"]
+    return if order.empty?
+
+    combat_waiting = ts["combat_waiting"] || []
+    current = ts["current_user_id"].to_s
+    current_index = order.index(current) || 0
+
+    next_index = (current_index + 1) % order.length
+    attempts = 0
+
+    while attempts < order.length
+      candidate = order[next_index]
+      dead = game_state.dig("player_states", candidate, "pending_restart")
+      break unless combat_waiting.include?(candidate) || dead
+
+      next_index = (next_index + 1) % order.length
+      attempts += 1
+    end
+
+    ts["current_user_id"] = order[next_index]
+    save!
+  end
+
+  def player_fled_combat(user_id)
+    ts = game_state["turn_state"]
+    return unless ts
+
+    ts["combat_waiting"] ||= []
+    ts["combat_waiting"] << user_id.to_s
+    ts["combat_waiting"].uniq!
+    advance_turn
+  end
+
+  def combat_ended
+    ts = game_state["turn_state"]
+    return unless ts
+
+    ts["combat_waiting"] = []
+    save!
+  end
+
+  def players_in_room(room_id)
+    (game_state["player_states"] || {}).select do |_uid, state|
+      state["current_room"] == room_id.to_s
+    end.keys
+  end
+
   def add_to_container(container_id, item_id)
     self.game_state ||= {}
     self.game_state["container_states"] ||= {}

--- a/app/models/game_user.rb
+++ b/app/models/game_user.rb
@@ -12,6 +12,7 @@ class GameUser < ApplicationRecord
   before_create :set_starting_health
 
   after_create_commit :broadcast_new_player
+  after_create_commit :initialize_classic_turn_order, if: -> { game.classic? }
 
   after_update_commit :create_health_change_event_message, if: :saved_change_to_current_health?
   after_update_commit :broadcast_updated_player_health, if: :saved_change_to_current_health?
@@ -32,6 +33,10 @@ class GameUser < ApplicationRecord
 
       self.max_health = game.starting_hp
       self.current_health = game.starting_hp
+    end
+
+    def initialize_classic_turn_order
+      ClassicGame::TurnManager.initialize_for_game(game)
     end
 
     def broadcast_new_player

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,9 +9,12 @@ class Message < ApplicationRecord
   scope :latest, -> { order(id: :desc) }
   scope :oldest, -> { order(id: :asc) }
   scope :for_game, ->(game) { where(game_id: game.id, is_system_message: false).latest }
+  scope :visible_to, ->(user) {
+    where("visible_to_user_ids = '[]'::jsonb OR visible_to_user_ids @> ?", [user.id].to_json)
+  }
   before_create :parse_dice_rolls
 
-  after_create_commit -> { broadcast_append_to(game, :messages) }, unless: proc { is_system_message? }
+  after_create_commit :broadcast_new_message, unless: proc { is_system_message? }
   after_update_commit -> { broadcast_replace_to(game, :messages) }, unless: proc { is_system_message? }
   after_create_commit :set_user_active_at, unless: proc { is_system_message? }
   after_create_commit :enqueue_classic_command, if: proc { game.classic? && player_message? }
@@ -52,5 +55,13 @@ class Message < ApplicationRecord
 
     def enqueue_classic_command
       ClassicCommandJob.perform_async(id)
+    end
+
+    def broadcast_new_message
+      if visible_to_user_ids.any?
+        visible_to_user_ids.each { |uid| broadcast_append_to(game, :messages, uid) }
+      else
+        broadcast_append_to(game, :messages)
+      end
     end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,7 +2,9 @@
   <%= render "debug_bar", game: @game %>
 <% end %>
 <%= turbo_stream_from(@game, :messages) %>
+<%= turbo_stream_from(@game, :messages, current_user.id) %>
 <%= turbo_stream_from(@game, :state) %>
+<div id="turn-indicator"></div>
 <% if @game.host?(current_user) %>
   <%= turbo_stream_from(@game, :host_players) %>
 <% else %>

--- a/db/migrate/20260404000001_add_visibility_to_messages.rb
+++ b/db/migrate/20260404000001_add_visibility_to_messages.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVisibilityToMessages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :messages, :visible_to_user_ids, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_01_234724) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_04_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_234724) do
     t.boolean "is_system_message", default: false
     t.string "sender_name"
     t.datetime "updated_at", null: false
+    t.jsonb "visible_to_user_ids", default: [], null: false
     t.index ["game_id"], name: "index_messages_on_game_id"
     t.index ["game_user_id"], name: "index_messages_on_game_user_id"
   end

--- a/test/lib/classic_game/handlers/give_handler_test.rb
+++ b/test/lib/classic_game/handlers/give_handler_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GiveHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  PLAYER_1 = 1
+  PLAYER_2 = 2
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern",
+          "description" => "A cozy inn.",
+          "exits" => { "east" => "market" }
+        },
+        "market" => {
+          "name" => "The Market",
+          "description" => "Busy stalls.",
+          "exits" => { "west" => "tavern" }
+        }
+      },
+      items: {
+        "iron_sword" => {
+          "name" => "Iron Sword",
+          "keywords" => %w[sword iron],
+          "takeable" => true
+        },
+        "potion" => {
+          "name" => "Red Potion",
+          "keywords" => %w[potion red],
+          "takeable" => true
+        }
+      }
+    )
+  end
+
+  # ─── successful give ─────────────────────────────────────────────────────────
+
+  test "gives item from player 1 to player 2 in same room" do
+    game = same_room_game(p1_inventory: ["iron_sword"])
+    command = ClassicGame::CommandParser.parse("give sword to Bob")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "Iron Sword"
+    assert_includes result[:response], "Bob"
+    assert_not_includes game.player_state(PLAYER_1)["inventory"], "iron_sword"
+    assert_includes game.player_state(PLAYER_2)["inventory"], "iron_sword"
+  end
+
+  test "response says 'You give the [item] to [player]'" do
+    game = same_room_game(p1_inventory: ["iron_sword"])
+    command = ClassicGame::CommandParser.parse("give sword to Bob")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_match(/You give the Iron Sword to Bob/, result[:response])
+  end
+
+  test "works with full item name" do
+    game = same_room_game(p1_inventory: ["iron_sword"])
+    command = ClassicGame::CommandParser.parse("give iron sword to Bob")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert result[:success]
+  end
+
+  # ─── failures ────────────────────────────────────────────────────────────────
+
+  test "fails when item not in player inventory" do
+    game = same_room_game(p1_inventory: [])
+    command = ClassicGame::CommandParser.parse("give sword to Bob")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_not result[:success]
+    assert_includes result[:response].downcase, "don't have"
+  end
+
+  test "fails when recipient player is in a different room" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      players: {
+        PLAYER_1 => player_state_in("tavern", inventory: ["iron_sword"]),
+        PLAYER_2 => player_state_in("market")
+      }
+    )
+    game.game_state["player_names"] = { PLAYER_1.to_s => "Alice", PLAYER_2.to_s => "Bob" }
+
+    command = ClassicGame::CommandParser.parse("give sword to Bob")
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_not result[:success]
+    assert_match(/don't see/i, result[:response])
+  end
+
+  test "fails when recipient player name not found" do
+    game = same_room_game(p1_inventory: ["iron_sword"])
+    command = ClassicGame::CommandParser.parse("give sword to Charlie")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_not result[:success]
+  end
+
+  test "fails when no item or recipient specified" do
+    game = same_room_game(p1_inventory: [])
+    command = ClassicGame::CommandParser.parse("give")
+
+    result = ClassicGame::Handlers::GiveHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_not result[:success]
+  end
+
+  # ─── InteractHandler delegation ──────────────────────────────────────────────
+
+  test "InteractHandler delegates give to player to GiveHandler" do
+    game = same_room_game(p1_inventory: ["iron_sword"])
+    command = ClassicGame::CommandParser.parse("give sword to Bob")
+
+    result = ClassicGame::Handlers::InteractHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert result[:success]
+    assert_includes game.player_state(PLAYER_2)["inventory"], "iron_sword"
+  end
+
+  private
+
+    def same_room_game(p1_inventory: [])
+      game = build_multiplayer_game(
+        world_data: @world,
+        players: {
+          PLAYER_1 => player_state_in("tavern", inventory: p1_inventory),
+          PLAYER_2 => player_state_in("tavern")
+        }
+      )
+      game.game_state["player_names"] = {
+        PLAYER_1.to_s => "Alice",
+        PLAYER_2.to_s => "Bob"
+      }
+      game
+    end
+end

--- a/test/lib/classic_game/multiplayer_notifier_test.rb
+++ b/test/lib/classic_game/multiplayer_notifier_test.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MultiplayerNotifierTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  PLAYER_1 = 1
+  PLAYER_2 = 2
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern",
+          "description" => "A cozy inn.",
+          "exits" => { "east" => "library" }
+        },
+        "library" => {
+          "name" => "The Library",
+          "description" => "Shelves of books.",
+          "exits" => { "west" => "tavern" }
+        }
+      }
+    )
+  end
+
+  # ─── observer_messages ──────────────────────────────────────────────────────
+
+  test "observer_messages returns message for co-located player" do
+    game = two_player_game(p1_room: "tavern", p2_room: "tavern")
+    result = { success: true, response: "You look around the tavern." }
+
+    msgs = ClassicGame::MultiplayerNotifier.observer_messages(game, PLAYER_1, "look", result)
+
+    assert_equal 1, msgs.length
+    assert_includes msgs.first[:user_ids], PLAYER_2.to_s
+    assert_includes msgs.first[:content], "Alice"
+    assert_includes msgs.first[:content], "look"
+    assert_includes msgs.first[:content], "You look around the tavern."
+  end
+
+  test "observer_messages returns empty array when players are in different rooms" do
+    game = two_player_game(p1_room: "tavern", p2_room: "library")
+    result = { success: true, response: "You look around." }
+
+    msgs = ClassicGame::MultiplayerNotifier.observer_messages(game, PLAYER_1, "look", result)
+
+    assert_empty msgs
+  end
+
+  test "observer_messages excludes the acting player" do
+    game = two_player_game(p1_room: "tavern", p2_room: "tavern")
+    result = { success: true, response: "You look around." }
+
+    msgs = ClassicGame::MultiplayerNotifier.observer_messages(game, PLAYER_1, "look", result)
+
+    assert_not_includes msgs.flat_map { |m| m[:user_ids] }, PLAYER_1.to_s
+  end
+
+  # ─── arrival_message ────────────────────────────────────────────────────────
+
+  test "arrival_message returns message for players already in destination room" do
+    game = two_player_game(p1_room: "tavern", p2_room: "library")
+
+    msg = ClassicGame::MultiplayerNotifier.arrival_message(game, PLAYER_2, "tavern")
+
+    assert_not_nil msg
+    assert_includes msg[:user_ids], PLAYER_1.to_s
+    assert_includes msg[:content], "Bob"
+    assert_includes msg[:content], "arrived"
+  end
+
+  test "arrival_message returns nil when destination room is empty" do
+    game = two_player_game(p1_room: "tavern", p2_room: "library")
+
+    msg = ClassicGame::MultiplayerNotifier.arrival_message(game, PLAYER_1, "library")
+
+    assert_nil msg
+  end
+
+  # ─── global_event_messages ──────────────────────────────────────────────────
+
+  test "global_event_messages notifies player in room affected by flag change" do
+    world = build_world(
+      starting_room: "lever_room",
+      rooms: {
+        "lever_room" => {
+          "name" => "Lever Room",
+          "description" => "A lever is here.",
+          "exits" => {}
+        },
+        "door_room" => {
+          "name" => "Door Room",
+          "description" => "A heavy stone door.",
+          "exits" => {
+            "north" => {
+              "to" => "beyond",
+              "requires_flag" => "door_open",
+              "remote_event_msg" => "The stone door grinds open!"
+            }
+          }
+        },
+        "beyond" => { "name" => "Beyond", "description" => "Freedom.", "exits" => {} }
+      }
+    )
+    game = build_multiplayer_game(
+      world_data: world,
+      players: {
+        PLAYER_1 => player_state_in("lever_room"),
+        PLAYER_2 => player_state_in("door_room")
+      }
+    )
+    game.game_state["player_names"] = { PLAYER_1.to_s => "Alice", PLAYER_2.to_s => "Bob" }
+
+    msgs = ClassicGame::MultiplayerNotifier.global_event_messages(
+      game, { "door_open" => true }, PLAYER_1
+    )
+
+    assert_equal 1, msgs.length
+    assert_includes msgs.first[:user_ids], PLAYER_2.to_s
+    assert_equal "The stone door grinds open!", msgs.first[:content]
+  end
+
+  test "global_event_messages uses fallback message when remote_event_msg absent" do
+    world = build_world(
+      starting_room: "lever_room",
+      rooms: {
+        "lever_room" => { "name" => "Lever Room", "description" => ".", "exits" => {} },
+        "door_room" => {
+          "name" => "Door Room", "description" => ".",
+          "exits" => {
+            "north" => { "to" => "beyond", "requires_flag" => "door_open" }
+          }
+        },
+        "beyond" => { "name" => "Beyond", "description" => ".", "exits" => {} }
+      }
+    )
+    game = build_multiplayer_game(
+      world_data: world,
+      players: {
+        PLAYER_1 => player_state_in("lever_room"),
+        PLAYER_2 => player_state_in("door_room")
+      }
+    )
+
+    msgs = ClassicGame::MultiplayerNotifier.global_event_messages(
+      game, { "door_open" => true }, PLAYER_1
+    )
+
+    assert_equal 1, msgs.length
+    assert_includes msgs.first[:content], "distance"
+  end
+
+  test "global_event_messages returns empty when no flag changes" do
+    game = two_player_game(p1_room: "tavern", p2_room: "library")
+
+    msgs = ClassicGame::MultiplayerNotifier.global_event_messages(game, {}, PLAYER_1)
+
+    assert_empty msgs
+  end
+
+  # ─── room description lists other players ───────────────────────────────────
+
+  test "room description includes other players present when using look" do
+    game = two_player_game(p1_room: "tavern", p2_room: "tavern")
+    command = ClassicGame::CommandParser.parse("look")
+
+    result = ClassicGame::Handlers::ExamineHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_includes result[:response], "Bob"
+    assert_includes result[:response], "Also here"
+  end
+
+  test "room description does not list other players in different rooms" do
+    game = two_player_game(p1_room: "tavern", p2_room: "library")
+    command = ClassicGame::CommandParser.parse("look")
+
+    result = ClassicGame::Handlers::ExamineHandler.new(game: game, user_id: PLAYER_1).handle(command)
+
+    assert_not_includes result[:response], "Bob"
+  end
+
+  # ─── waiting_indicator ──────────────────────────────────────────────────────
+
+  test "waiting_indicator shows your turn message for current player" do
+    game = two_player_game(p1_room: "tavern", p2_room: "tavern")
+    game.initialize_turn_order([PLAYER_1.to_s, PLAYER_2.to_s])
+    game.game_state["turn_state"]["current_user_id"] = PLAYER_1.to_s
+
+    msg = ClassicGame::MultiplayerNotifier.waiting_indicator(game, PLAYER_1)
+
+    assert_includes msg, "your turn"
+  end
+
+  test "waiting_indicator shows waiting message for off-turn player" do
+    game = two_player_game(p1_room: "tavern", p2_room: "tavern")
+    game.initialize_turn_order([PLAYER_1.to_s, PLAYER_2.to_s])
+    game.game_state["turn_state"]["current_user_id"] = PLAYER_1.to_s
+    game.game_state["player_names"] = { PLAYER_1.to_s => "Alice", PLAYER_2.to_s => "Bob" }
+
+    msg = ClassicGame::MultiplayerNotifier.waiting_indicator(game, PLAYER_2)
+
+    assert_includes msg, "Alice"
+  end
+
+  private
+
+    def two_player_game(p1_room:, p2_room:)
+      game = build_multiplayer_game(
+        world_data: @world,
+        players: {
+          PLAYER_1 => player_state_in(p1_room),
+          PLAYER_2 => player_state_in(p2_room)
+        }
+      )
+      game.game_state["player_names"] = {
+        PLAYER_1.to_s => "Alice",
+        PLAYER_2.to_s => "Bob"
+      }
+      game
+    end
+end

--- a/test/lib/classic_game/turn_manager_test.rb
+++ b/test/lib/classic_game/turn_manager_test.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TurnManagerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  PLAYER_1 = 1
+  PLAYER_2 = 2
+
+  FakeUser = Struct.new(:id)
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern",
+          "description" => "A cozy inn.",
+          "exits" => {}
+        }
+      }
+    )
+  end
+
+  # ─── can_act? ───────────────────────────────────────────────────────────────
+
+  test "can_act? returns true when no turn state exists (single-player compat)" do
+    game = build_game(world_data: @world, player_id: PLAYER_1)
+
+    assert ClassicGame::TurnManager.can_act?(game, PLAYER_1)
+  end
+
+  test "can_act? returns true when it is player's turn" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+
+    assert ClassicGame::TurnManager.can_act?(game, PLAYER_1)
+  end
+
+  test "can_act? returns false when it is not player's turn" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+
+    assert_not ClassicGame::TurnManager.can_act?(game, PLAYER_2)
+  end
+
+  # ─── engine-level guard ─────────────────────────────────────────────────────
+
+  test "engine rejects command when not player's turn" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+    user2 = FakeUser.new(PLAYER_2)
+
+    result = ClassicGame::Engine.execute(game: game, user: user2, command_text: "look")
+
+    assert_not result[:success]
+    assert_match(/Alice/, result[:response])
+    assert_match(/turn/i, result[:response])
+  end
+
+  test "engine allows command when it is player's turn" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+    user1 = FakeUser.new(PLAYER_1)
+
+    result = ClassicGame::Engine.execute(game: game, user: user1, command_text: "look")
+
+    assert result[:success]
+    assert_includes result[:response], "Tavern"
+  end
+
+  # ─── advance_turn ───────────────────────────────────────────────────────────
+
+  test "advance cycles to next player" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+
+    ClassicGame::TurnManager.advance(game)
+
+    assert_equal PLAYER_2.to_s, game.current_turn_user_id
+  end
+
+  test "advance wraps around to first player" do
+    game = multiplayer_game(current_turn: PLAYER_2)
+
+    ClassicGame::TurnManager.advance(game)
+
+    assert_equal PLAYER_1.to_s, game.current_turn_user_id
+  end
+
+  test "advance with single player cycles back to same player" do
+    game = build_game(world_data: @world, player_id: PLAYER_1)
+    game.initialize_turn_order([PLAYER_1.to_s])
+
+    ClassicGame::TurnManager.advance(game)
+
+    assert_equal PLAYER_1.to_s, game.current_turn_user_id
+  end
+
+  # ─── waiting_message ────────────────────────────────────────────────────────
+
+  test "waiting_message includes current player's name" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+
+    msg = ClassicGame::TurnManager.waiting_message(game, PLAYER_2)
+
+    assert_match(/Alice/, msg)
+    assert_match(/turn/i, msg)
+  end
+
+  # ─── combat flee / end ──────────────────────────────────────────────────────
+
+  test "handle_flee adds player to combat_waiting and advances turn" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+
+    ClassicGame::TurnManager.handle_flee(game, PLAYER_1)
+
+    assert_includes game.game_state["turn_state"]["combat_waiting"], PLAYER_1.to_s
+    assert_equal PLAYER_2.to_s, game.current_turn_user_id
+  end
+
+  test "handle_combat_end clears combat_waiting list" do
+    game = multiplayer_game(current_turn: PLAYER_2)
+    game.player_fled_combat(PLAYER_1)
+
+    ClassicGame::TurnManager.handle_combat_end(game)
+
+    assert_empty game.game_state["turn_state"]["combat_waiting"]
+  end
+
+  test "advance skips players in combat_waiting" do
+    game = multiplayer_game(current_turn: PLAYER_1)
+    game.game_state["turn_state"]["combat_waiting"] = [PLAYER_2.to_s]
+
+    ClassicGame::TurnManager.advance(game)
+
+    # Player 2 is skipped; wraps back to player 1
+    assert_equal PLAYER_1.to_s, game.current_turn_user_id
+  end
+
+  private
+
+    def multiplayer_game(current_turn:)
+      game = build_multiplayer_game(
+        world_data: @world,
+        players: {
+          PLAYER_1 => player_state_in("tavern"),
+          PLAYER_2 => player_state_in("tavern")
+        }
+      )
+      game.initialize_turn_order([PLAYER_1.to_s, PLAYER_2.to_s])
+      game.game_state["turn_state"]["current_user_id"] = current_turn.to_s
+      game.game_state["player_names"] = {
+        PLAYER_1.to_s => "Alice",
+        PLAYER_2.to_s => "Bob"
+      }
+      game
+    end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -3,7 +3,29 @@
 require "test_helper"
 
 class MessageTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  # ─── visible_to scope ───────────────────────────────────────────────────────
+
+  test "visible_to returns message when visible_to_user_ids is empty (global)" do
+    game = games(:one)
+    user = OpenStruct.new(id: 999)
+    msg = Message.create!(game: game, content: "Global message", visible_to_user_ids: [])
+
+    assert_includes Message.visible_to(user), msg
+  end
+
+  test "visible_to returns message when user_id is in visible_to_user_ids" do
+    game = games(:one)
+    user1 = OpenStruct.new(id: 1)
+    msg = Message.create!(game: game, content: "Private message", visible_to_user_ids: [1])
+
+    assert_includes Message.visible_to(user1), msg
+  end
+
+  test "visible_to excludes message when user_id not in visible_to_user_ids" do
+    game = games(:one)
+    user2 = OpenStruct.new(id: 2)
+    msg = Message.create!(game: game, content: "Not for user 2", visible_to_user_ids: [1])
+
+    assert_not_includes Message.visible_to(user2), msg
+  end
 end

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -94,6 +94,71 @@ module ClassicGameTestHelper
       @game_state["container_states"][container_id.to_s]["removed_items"].uniq!
     end
 
+    def turn_order
+      @game_state.dig("turn_state", "order") || []
+    end
+
+    def current_turn_user_id
+      @game_state.dig("turn_state", "current_user_id")
+    end
+
+    def initialize_turn_order(user_ids)
+      @game_state["turn_state"] = {
+        "order" => user_ids.map(&:to_s),
+        "current_user_id" => user_ids.first&.to_s,
+        "combat_waiting" => []
+      }
+    end
+
+    def advance_turn
+      ts = @game_state["turn_state"]
+      return unless ts
+
+      order = ts["order"]
+      return if order.empty?
+
+      combat_waiting = ts["combat_waiting"] || []
+      current = ts["current_user_id"].to_s
+      current_index = order.index(current) || 0
+
+      next_index = (current_index + 1) % order.length
+      attempts = 0
+
+      while attempts < order.length
+        candidate = order[next_index]
+        dead = @game_state.dig("player_states", candidate, "pending_restart")
+        break unless combat_waiting.include?(candidate) || dead
+
+        next_index = (next_index + 1) % order.length
+        attempts += 1
+      end
+
+      ts["current_user_id"] = order[next_index]
+    end
+
+    def player_fled_combat(user_id)
+      ts = @game_state["turn_state"]
+      return unless ts
+
+      ts["combat_waiting"] ||= []
+      ts["combat_waiting"] << user_id.to_s
+      ts["combat_waiting"].uniq!
+      advance_turn
+    end
+
+    def combat_ended
+      ts = @game_state["turn_state"]
+      return unless ts
+
+      ts["combat_waiting"] = []
+    end
+
+    def players_in_room(room_id)
+      (@game_state["player_states"] || {}).select do |_uid, state|
+        state["current_room"] == room_id.to_s
+      end.keys
+    end
+
     def starting_hp
       10
     end
@@ -156,6 +221,17 @@ module ClassicGameTestHelper
   def build_game(world_data:, player_id: 1, player_state: nil, room_states: {})
     game = FakeGame.new(world_data: world_data)
     game.game_state["player_states"][player_id.to_s] = player_state if player_state
+    room_states.each { |id, state| game.game_state["room_states"][id.to_s] = state }
+    game
+  end
+
+  # Returns a FakeGame with multiple players pre-populated.
+  # players: { user_id => player_state_hash }
+  def build_multiplayer_game(world_data:, players:, room_states: {})
+    game = FakeGame.new(world_data: world_data)
+    players.each do |user_id, state|
+      game.game_state["player_states"][user_id.to_s] = state
+    end
     room_states.each { |id, state| game.game_state["room_states"][id.to_s] = state }
     game
   end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -82,7 +82,8 @@ module TestSupport
             "to" => "alcove",
             "hidden" => true,
             "requires_flag" => "spider_slain",
-            "reveal_msg" => "With the spider defeated, you notice a narrow passage to the east."
+            "reveal_msg" => "With the spider defeated, you notice a narrow passage to the east.",
+            "remote_event_msg" => "A rumbling echoes from deep within the cave... a passage has opened."
           }
         },
         "items" => [],


### PR DESCRIPTION
## Summary

- **Turn ordering**: `ClassicGame::TurnManager` enforces whose turn it is; off-turn commands receive a waiting message. Single-player and legacy games are unaffected (`can_act?` returns `true` when no `turn_state` exists).
- **Message visibility**: New `visible_to_user_ids` (jsonb) column on `messages`. Per-player broadcasts go to `[game, :messages, user_id]`; global messages continue on `[game, :messages]`.
- **Player-to-player GIVE**: `GiveHandler` transfers items between players in the same room. `InteractHandler` checks for a player match before falling through to NPC GIVE logic.
- **Observer messages**: Co-located players see another player's commands and the engine's response via scoped messages created in `ClassicCommandJob`.
- **Arrival notifications**: When a player moves into a room, players already there receive an arrival message.
- **Global event messages**: Flag changes (e.g. pulling a lever) notify players in affected rooms via `MultiplayerNotifier.global_event_messages`. World data can include a `remote_event_msg` on exits for custom text.
- **Combat integration**: `CombatHandler` calls `TurnManager.handle_flee` on successful flee; `handle_combat_end` on creature defeat. Fled players are skipped in turn order until combat ends.
- **Room presence**: `LOOK` and movement room descriptions include "Also here: [names]" when other players are present.

## New files

| File | Purpose |
|------|---------|
| `app/lib/classic_game/turn_manager.rb` | Turn-order guard, advance, fled-combat tracking |
| `app/lib/classic_game/multiplayer_notifier.rb` | Observer, arrival, and global-event message generation |
| `app/lib/classic_game/handlers/give_handler.rb` | Player-to-player item transfer |
| `db/migrate/20260404000001_add_visibility_to_messages.rb` | Adds `visible_to_user_ids` jsonb column |
| `test/lib/classic_game/turn_manager_test.rb` | Unit tests for TurnManager |
| `test/lib/classic_game/multiplayer_notifier_test.rb` | Unit tests for MultiplayerNotifier + room presence |
| `test/lib/classic_game/handlers/give_handler_test.rb` | Unit tests for GiveHandler + InteractHandler delegation |

## Test plan

- [x] `can_act?` allows/rejects commands based on turn state; returns `true` when no turn state (single-player compat)
- [x] Engine rejects off-turn command with waiting message naming the current player
- [x] `advance_turn` cycles through players and wraps around
- [x] `advance_turn` skips players in `combat_waiting`
- [x] `handle_flee` marks player as waiting, advances turn past them
- [x] `handle_combat_end` clears the fled-player list
- [x] Observer messages returned for co-located players; empty for separated players
- [x] Arrival message generated when player moves into occupied room
- [x] Global event messages generated when a flag change affects an exit in another player's room
- [x] Room description includes "Also here:" for co-located players
- [x] GIVE transfers item between players in same room; fails when in different rooms
- [x] `InteractHandler` delegates GIVE to `GiveHandler` when target is a player character name
- [x] `visible_to` scope: empty array = visible to all; non-empty = filtered to listed user IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)