### PR TITLE
Player Turn Management

### DIFF
--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -22,16 +22,41 @@ class ClassicCommandJob
       broadcast_dice_roll(game, message, result)
       sync_classic_sidebar(game, user, message.game_user)
 
-      # Create response message (will auto-broadcast via callback)
+      # Determine which players should see the primary response
+      primary_visible_to = players_in_acting_room(game, user)
+
+      # Create primary response message
       Message.create!(
         game: game,
-        content: result[:response]
+        content: result[:response],
+        visible_to_user_ids: primary_visible_to,
+        room_id: game.player_state(user.id)["current_room"]
         # NOTE: no game_user_id, so it's a "host" message from the game engine
       )
+
+      # Process secondary messages (arrival/departure notices, give notifications, etc.)
+      (result[:secondary_messages] || []).each do |sec|
+        Message.create!(
+          game: game,
+          content: sec[:text],
+          visible_to_user_ids: Array(sec[:visible_to]).map(&:to_s)
+        )
+      end
     end
   end
 
   private
+
+    def players_in_acting_room(game, user)
+      current_room = game.player_state(user.id)["current_room"]
+      return [] unless current_room
+
+      player_states = game.game_state["player_states"] || {}
+      uids = player_states.filter_map { |uid, state| uid if state["current_room"] == current_room }
+
+      # Empty array means "visible to all" — preserve single-player backward compatibility
+      uids.size <= 1 ? [] : uids.map(&:to_s)
+    end
 
     def broadcast_dice_roll(game, message, result)
       return unless result[:dice_roll]

--- a/app/lib/classic_game/base_handler.rb
+++ b/app/lib/classic_game/base_handler.rb
@@ -199,6 +199,38 @@ module ClassicGame
         in_combat? && player_state.dig("combat", "creature_id") == creature_id
       end
 
+      # Returns user_id strings for all players currently in the same room as the acting player.
+      def players_in_current_room
+        current_room = player_state["current_room"]
+        return [] unless current_room
+
+        (game.game_state["player_states"] || {}).filter_map do |uid, state|
+          uid if state["current_room"] == current_room
+        end
+      end
+
+      # All players in the current room except the acting player.
+      def other_players_in_room
+        players_in_current_room - [user_id.to_s]
+      end
+
+      # Find a player character by name (case-insensitive substring match).
+      # Returns [user_id_string, character_name] or [nil, nil].
+      def find_player_character(name)
+        return [nil, nil] if name.blank?
+        return [nil, nil] unless game.respond_to?(:game_users)
+
+        name_lower = name.downcase
+        game.game_users.each do |gu|
+          char_name = gu.character_name.to_s
+          if char_name.downcase.include?(name_lower) || name_lower.include?(char_name.downcase)
+            return [gu.user_id.to_s, char_name]
+          end
+        end
+
+        [nil, nil]
+      end
+
       # Get total weapon damage from inventory
       def get_weapon_damage(inventory)
         max_damage = 0

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -7,12 +7,19 @@ module ClassicGame
         # Check if we're waiting for restart confirmation
         return handle_restart_confirmation(game, command_text) if game.game_state["pending_restart"]
 
+        # Enforce turn order — reject out-of-turn commands
+        unless TurnManager.user_can_act?(game, user.id)
+          return { success: false, response: TurnManager.waiting_message(game), state_changes: {} }
+        end
+
         # Check if a dice roll is pending — route all input to RollHandler
         ps = game.player_state(user.id)
         if ps["pending_roll"]
-          return ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
+          result = ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
             ClassicGame::CommandParser.parse(command_text)
           )
+          TurnManager.advance(game)
+          return result
         end
 
         # Parse the command
@@ -28,7 +35,12 @@ module ClassicGame
                  end
 
         # Check for aggressive creatures after the player acts
-        check_aggressive_creatures(game, user, command, result)
+        result = check_aggressive_creatures(game, user, command, result)
+
+        # Advance to next player's turn
+        TurnManager.advance(game)
+
+        result
       rescue StandardError => e
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -153,9 +153,16 @@ module ClassicGame
           end
 
           # Successfully fled
+          current_room = player_state["current_room"]
           new_player_state = player_state.dup
           new_player_state["combat"] = nil
           update_player_state(new_player_state)
+
+          # If other players are still in this room (possibly in combat), mark this player
+          # as waiting so the turn manager skips them until combat ends.
+          if other_players_in_room.any?
+            ClassicGame::TurnManager.add_combat_waiter(game, user_id, current_room)
+          end
 
           lines = []
           lines << "You flee from combat!"
@@ -288,9 +295,13 @@ module ClassicGame
           update_room_state(player_state["current_room"], new_room_state)
 
           # Clear combat state
+          defeat_room = player_state["current_room"]
           new_player_state = player_state.dup
           new_player_state["combat"] = nil
           update_player_state(new_player_state)
+
+          # Unblock any players who fled from this combat's room
+          ClassicGame::TurnManager.clear_combat_waiters_for_room(game, defeat_room)
 
           # Set defeat flag if specified
           if creature_def["sets_flag_on_defeat"]

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -160,9 +160,7 @@ module ClassicGame
 
           # If other players are still in this room (possibly in combat), mark this player
           # as waiting so the turn manager skips them until combat ends.
-          if other_players_in_room.any?
-            ClassicGame::TurnManager.add_combat_waiter(game, user_id, current_room)
-          end
+          ClassicGame::TurnManager.add_combat_waiter(game, user_id, current_room) if other_players_in_room.any?
 
           lines = []
           lines << "You flee from combat!"

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -148,6 +148,12 @@ module ClassicGame
           return failure("You don't have that item.") unless item_def
           return failure("You don't have that item.") unless item?(item_id)
 
+          # Check for player-character target before NPC lookup
+          target_user_id, target_char_name = find_player_character(npc_target)
+          if target_user_id
+            return handle_give_to_player(item_id, item_def, target_user_id, target_char_name)
+          end
+
           # Find the NPC
           npc_id, npc_def = find_npc(npc_target)
           return failure("You don't see anyone like that here.") unless npc_def
@@ -184,6 +190,41 @@ module ClassicGame
           end
 
           failure("#{npc_def['name']} doesn't want that.")
+        end
+
+        def handle_give_to_player(item_id, item_def, target_user_id, target_name)
+          # Target must be in the same room
+          unless other_players_in_room.include?(target_user_id.to_s)
+            return failure("#{target_name} is not here.")
+          end
+
+          # Remove item from giver
+          new_giver_state = player_state.dup
+          new_giver_state["inventory"] = (new_giver_state["inventory"] || []) - [item_id]
+          update_player_state(new_giver_state)
+
+          # Add item to receiver
+          receiver_state = game.player_state(target_user_id).dup
+          receiver_state["inventory"] ||= []
+          receiver_state["inventory"] << item_id
+          game.update_player_state(target_user_id, receiver_state)
+
+          # Resolve giver's character name for secondary message
+          giver_name = acting_character_name || "Someone"
+          item_name = item_def["name"]
+
+          result = success("You give the #{item_name} to #{target_name}.")
+          result[:secondary_messages] = [
+            { text: "#{giver_name} gives you a #{item_name}.", visible_to: [target_user_id.to_s] }
+          ]
+          result
+        end
+
+        def acting_character_name
+          return nil unless game.respond_to?(:game_users)
+
+          gu = game.game_users.find { |u| u.user_id.to_s == user_id.to_s }
+          gu&.character_name
         end
 
         def handle_talk_to_creature(name)

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -150,9 +150,7 @@ module ClassicGame
 
           # Check for player-character target before NPC lookup
           target_user_id, target_char_name = find_player_character(npc_target)
-          if target_user_id
-            return handle_give_to_player(item_id, item_def, target_user_id, target_char_name)
-          end
+          return handle_give_to_player(item_id, item_def, target_user_id, target_char_name) if target_user_id
 
           # Find the NPC
           npc_id, npc_def = find_npc(npc_target)
@@ -194,9 +192,7 @@ module ClassicGame
 
         def handle_give_to_player(item_id, item_def, target_user_id, target_name)
           # Target must be in the same room
-          unless other_players_in_room.include?(target_user_id.to_s)
-            return failure("#{target_name} is not here.")
-          end
+          return failure("#{target_name} is not here.") unless other_players_in_room.include?(target_user_id.to_s)
 
           # Remove item from giver
           new_giver_state = player_state.dup

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -68,6 +68,10 @@ module ClassicGame
           return failure("Error: Room '#{room_id}' not found.") unless new_room_def
 
           first_visit = !player_state["visited_rooms"]&.include?(room_id)
+          old_room_id = player_state["current_room"]
+
+          # Collect players in old room before moving (to notify of departure)
+          old_room_others = other_players_in_room
 
           # Update player state
           new_state = player_state.dup
@@ -80,10 +84,18 @@ module ClassicGame
 
           update_player_state(new_state)
 
+          # Collect players in new room after moving (to notify of arrival)
+          new_room_others = other_players_in_room
+
           # Generate room description
           description = generate_room_description(room_id, new_room_def, first_visit)
 
-          success(description, state_changes: { moved: true, room: room_id })
+          # Build secondary messages for room transition notifications
+          secondary = build_movement_notifications(old_room_id, old_room_others, room_id, new_room_others)
+
+          result = success(description, state_changes: { moved: true, room: room_id })
+          result[:secondary_messages] = secondary if secondary.any?
+          result
         end
 
         def generate_room_description(room_id, room_def, first_visit)
@@ -132,6 +144,19 @@ module ClassicGame
             lines << "Creatures: #{creature_names.join(', ')}"
           end
 
+          # List other players in the room
+          other_player_ids = other_players_in_room
+          if other_player_ids.any? && game.respond_to?(:game_users)
+            player_names = other_player_ids.filter_map do |pid|
+              gu = game.game_users.find { |u| u.user_id.to_s == pid.to_s }
+              gu&.character_name
+            end
+            if player_names.any?
+              lines << ""
+              lines << "Also here: #{player_names.join(', ')}"
+            end
+          end
+
           # List exits (filter out hidden unrevealed exits)
           exits = room_def["exits"] || {}
           visible_exits = exits.select do |direction, exit_data|
@@ -172,6 +197,28 @@ module ClassicGame
           end
 
           lines.join("\n")
+        end
+
+        def acting_character_name
+          return nil unless game.respond_to?(:game_users)
+
+          gu = game.game_users.find { |u| u.user_id.to_s == user_id.to_s }
+          gu&.character_name
+        end
+
+        def build_movement_notifications(old_room_id, old_room_others, _new_room_id, new_room_others)
+          secondary = []
+          char_name = acting_character_name
+
+          if char_name && old_room_others.any?
+            secondary << { text: "#{char_name} has left.", visible_to: old_room_others }
+          end
+
+          if char_name && new_room_others.any?
+            secondary << { text: "#{char_name} has arrived.", visible_to: new_room_others }
+          end
+
+          secondary
         end
     end
   end

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -157,46 +157,45 @@ module ClassicGame
             end
           end
 
-          # List exits (filter out hidden unrevealed exits)
+          lines.concat(generate_exits_lines(room_id, room_def))
+
+          lines.join("\n")
+        end
+
+        def generate_exits_lines(room_id, room_def)
           exits = room_def["exits"] || {}
           visible_exits = exits.select do |direction, exit_data|
             if exit_data.is_a?(Hash) && exit_data["hidden"]
-              # Check if revealed
               game.exit_revealed?(room_id, direction.to_s)
             else
               true
             end
           end
 
-          if visible_exits.any?
-            lines << ""
+          return [] unless visible_exits.any?
 
-            # Check if any exits have descriptive messages to show
-            exit_descriptions = []
-            visible_exits.each do |direction, exit_data|
-              next unless exit_data.is_a?(Hash)
+          lines = [""]
 
-              # Show reveal_msg for revealed hidden exits
-              if exit_data["hidden"] && exit_data["reveal_msg"].present? && game.exit_revealed?(room_id, direction.to_s)
-                exit_descriptions << exit_data["reveal_msg"]
-              end
+          exit_descriptions = []
+          visible_exits.each do |direction, exit_data|
+            next unless exit_data.is_a?(Hash)
 
-              # Show unlocked_msg for unlocked exits
-              if exit_data["unlocked_msg"].present? && game.exit_unlocked?(room_id, direction.to_s)
-                exit_descriptions << exit_data["unlocked_msg"]
-              end
+            if exit_data["hidden"] && exit_data["reveal_msg"].present? && game.exit_revealed?(room_id, direction.to_s)
+              exit_descriptions << exit_data["reveal_msg"]
             end
 
-            # Show exit descriptions if any
-            if exit_descriptions.any?
-              exit_descriptions.each { |desc| lines << desc }
-              lines << ""
+            if exit_data["unlocked_msg"].present? && game.exit_unlocked?(room_id, direction.to_s)
+              exit_descriptions << exit_data["unlocked_msg"]
             end
-
-            lines << "Exits: #{visible_exits.keys.map { |k| k.to_s.upcase }.join(', ')}"
           end
 
-          lines.join("\n")
+          if exit_descriptions.any?
+            exit_descriptions.each { |desc| lines << desc }
+            lines << ""
+          end
+
+          lines << "Exits: #{visible_exits.keys.map { |k| k.to_s.upcase }.join(', ')}"
+          lines
         end
 
         def acting_character_name
@@ -206,7 +205,7 @@ module ClassicGame
           gu&.character_name
         end
 
-        def build_movement_notifications(old_room_id, old_room_others, _new_room_id, new_room_others)
+        def build_movement_notifications(_old_room_id, old_room_others, _new_room_id, new_room_others)
           secondary = []
           char_name = acting_character_name
 

--- a/app/lib/classic_game/turn_manager.rb
+++ b/app/lib/classic_game/turn_manager.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  class TurnManager
+    class << self
+      # Set up turn order for a freshly started game.
+      def initialize_turns(game, user_ids)
+        game.game_state["turn_state"] = {
+          "order" => user_ids.map(&:to_s),
+          "current_index" => 0,
+          "combat_waiters" => {}
+        }
+        game.save!
+      end
+
+      # Returns the user_id string for whoever holds the current turn,
+      # or nil when no turn state has been initialized.
+      def current_player(game)
+        ts = turn_state(game)
+        return nil unless ts
+
+        ts["order"][ts["current_index"]]
+      end
+
+      # True when the given user is allowed to act right now.
+      # Single-player games (no turn_state, or only one player) always return true.
+      def user_can_act?(game, user_id)
+        ts = turn_state(game)
+        return true unless ts
+        return true if ts["order"].size <= 1
+
+        current_player(game) == user_id.to_s
+      end
+
+      # Move to the next non-waiting player. Wraps around.
+      # No-op when no turn state exists.
+      def advance(game)
+        ts = turn_state(game)
+        return unless ts
+
+        order = ts["order"]
+        return if order.empty?
+
+        waiters = ts["combat_waiters"] || {}
+        current_index = ts["current_index"]
+        steps = 0
+
+        loop do
+          current_index = (current_index + 1) % order.size
+          steps += 1
+          break unless waiters.key?(order[current_index])
+          break if steps >= order.size # all players waiting — stop at next anyway
+        end
+
+        ts["current_index"] = current_index
+        game.save!
+      end
+
+      # Mark a player as waiting for combat in a given room to end.
+      def add_combat_waiter(game, user_id, room_id)
+        ts = turn_state(game)
+        return unless ts
+
+        ts["combat_waiters"] ||= {}
+        ts["combat_waiters"][user_id.to_s] = room_id.to_s
+        game.save!
+      end
+
+      # Remove a single combat waiter.
+      def remove_combat_waiter(game, user_id)
+        ts = turn_state(game)
+        return unless ts
+
+        ts["combat_waiters"]&.delete(user_id.to_s)
+        game.save!
+      end
+
+      # Remove all combat waiters associated with a specific room.
+      def clear_combat_waiters_for_room(game, room_id)
+        ts = turn_state(game)
+        return unless ts
+
+        waiters = ts["combat_waiters"] || {}
+        waiters.delete_if { |_uid, rid| rid == room_id.to_s }
+        game.save!
+      end
+
+      # Returns a human-readable "waiting for X's turn" message.
+      def waiting_message(game)
+        player_id = current_player(game)
+        name = character_name_for(game, player_id) || "another player"
+        "It's #{name}'s turn. Please wait."
+      end
+
+      private
+
+        def turn_state(game)
+          game.game_state["turn_state"]
+        end
+
+        def character_name_for(game, user_id)
+          return nil unless user_id
+          return nil unless game.respond_to?(:game_users)
+
+          gu = game.game_users.find { |u| u.user_id.to_s == user_id.to_s }
+          gu&.character_name
+        end
+    end
+  end
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -181,6 +181,32 @@ class Game < ApplicationRecord
     save!
   end
 
+  # Turn state helpers
+  def add_player_to_turn_order(user_id)
+    self.game_state ||= {}
+    self.game_state["turn_state"] ||= { "order" => [], "current_index" => 0, "combat_waiters" => {} }
+    self.game_state["turn_state"]["order"] << user_id.to_s
+    self.game_state["turn_state"]["order"].uniq!
+    save!
+  end
+
+  def player_waiting_for_combat?(user_id)
+    game_state.dig("turn_state", "combat_waiters", user_id.to_s).present?
+  end
+
+  def set_player_waiting_for_combat(user_id, room_id)
+    self.game_state ||= {}
+    self.game_state["turn_state"] ||= { "order" => [], "current_index" => 0, "combat_waiters" => {} }
+    self.game_state["turn_state"]["combat_waiters"] ||= {}
+    self.game_state["turn_state"]["combat_waiters"][user_id.to_s] = room_id.to_s
+    save!
+  end
+
+  def clear_player_waiting_for_combat(user_id)
+    self.game_state.dig("turn_state", "combat_waiters")&.delete(user_id.to_s)
+    save!
+  end
+
   private
 
     def initialize_player_state(_user_id)
@@ -238,7 +264,8 @@ class Game < ApplicationRecord
                 "player_states" => {},
                 "room_states" => {},
                 "global_flags" => {},
-                "container_states" => {}
+                "container_states" => {},
+                "turn_state" => { "order" => [created_by.to_s], "current_index" => 0, "combat_waiters" => {} }
               })
 
       # Generate starting room description

--- a/app/models/game_user.rb
+++ b/app/models/game_user.rb
@@ -12,6 +12,7 @@ class GameUser < ApplicationRecord
   before_create :set_starting_health
 
   after_create_commit :broadcast_new_player
+  after_create_commit :join_classic_turn_order, if: -> { game.classic? }
 
   after_update_commit :create_health_change_event_message, if: :saved_change_to_current_health?
   after_update_commit :broadcast_updated_player_health, if: :saved_change_to_current_health?
@@ -32,6 +33,10 @@ class GameUser < ApplicationRecord
 
       self.max_health = game.starting_hp
       self.current_health = game.starting_hp
+    end
+
+    def join_classic_turn_order
+      game.add_player_to_turn_order(user_id)
     end
 
     def broadcast_new_player

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,12 +9,19 @@ class Message < ApplicationRecord
   scope :latest, -> { order(id: :desc) }
   scope :oldest, -> { order(id: :asc) }
   scope :for_game, ->(game) { where(game_id: game.id, is_system_message: false).latest }
+  scope :visible_to, ->(user) {
+    where("visible_to_user_ids = '[]'::jsonb OR visible_to_user_ids @> ?", [user.id].to_json)
+  }
   before_create :parse_dice_rolls
 
-  after_create_commit -> { broadcast_append_to(game, :messages) }, unless: proc { is_system_message? }
+  after_create_commit :broadcast_message, unless: proc { is_system_message? }
   after_update_commit -> { broadcast_replace_to(game, :messages) }, unless: proc { is_system_message? }
   after_create_commit :set_user_active_at, unless: proc { is_system_message? }
   after_create_commit :enqueue_classic_command, if: proc { game.classic? && player_message? }
+
+  def private?
+    visible_to_user_ids.present?
+  end
 
   def event?
     event_type.present?
@@ -35,6 +42,16 @@ class Message < ApplicationRecord
   end
 
   private
+
+    def broadcast_message
+      if private?
+        visible_to_user_ids.each do |user_id|
+          broadcast_append_to(game, :messages, user_id)
+        end
+      else
+        broadcast_append_to(game, :messages)
+      end
+    end
 
     def parse_dice_rolls
       return unless content&.downcase&.starts_with?("/roll ")

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,7 +9,7 @@ class Message < ApplicationRecord
   scope :latest, -> { order(id: :desc) }
   scope :oldest, -> { order(id: :asc) }
   scope :for_game, ->(game) { where(game_id: game.id, is_system_message: false).latest }
-  scope :visible_to, ->(user) {
+  scope :visible_to, lambda { |user|
     where("visible_to_user_ids = '[]'::jsonb OR visible_to_user_ids @> ?", [user.id].to_json)
   }
   before_create :parse_dice_rolls

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,6 +2,7 @@
   <%= render "debug_bar", game: @game %>
 <% end %>
 <%= turbo_stream_from(@game, :messages) %>
+<%= turbo_stream_from(@game, :messages, current_user.id) %>
 <%= turbo_stream_from(@game, :state) %>
 <% if @game.host?(current_user) %>
   <%= turbo_stream_from(@game, :host_players) %>

--- a/db/migrate/20260404000001_add_visibility_to_messages.rb
+++ b/db/migrate/20260404000001_add_visibility_to_messages.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddVisibilityToMessages < ActiveRecord::Migration[8.1]
+  def change
+    add_column :messages, :visible_to_user_ids, :jsonb, default: [], null: false
+    add_column :messages, :room_id, :string
+  end
+end

--- a/db/migrate/20260404000001_add_visibility_to_messages.rb
+++ b/db/migrate/20260404000001_add_visibility_to_messages.rb
@@ -2,7 +2,9 @@
 
 class AddVisibilityToMessages < ActiveRecord::Migration[8.1]
   def change
-    add_column :messages, :visible_to_user_ids, :jsonb, default: [], null: false
-    add_column :messages, :room_id, :string
+    change_table :messages, bulk: true do |t|
+      t.jsonb :visible_to_user_ids, default: [], null: false
+      t.string :room_id
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_01_234724) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_04_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -66,8 +66,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_01_234724) do
     t.bigint "game_id", null: false
     t.bigint "game_user_id"
     t.boolean "is_system_message", default: false
+    t.string "room_id"
     t.string "sender_name"
     t.datetime "updated_at", null: false
+    t.jsonb "visible_to_user_ids", default: [], null: false
     t.index ["game_id"], name: "index_messages_on_game_id"
     t.index ["game_user_id"], name: "index_messages_on_game_user_id"
   end

--- a/test/lib/classic_game/handlers/give_to_player_handler_test.rb
+++ b/test/lib/classic_game/handlers/give_to_player_handler_test.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GiveToPlayerHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_1 = 1
+  USER_2 = 2
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern",
+          "description" => "A cozy inn.",
+          "exits" => { "north" => "library" },
+          "npcs" => ["innkeeper"]
+        },
+        "library" => {
+          "name" => "The Library",
+          "description" => "Books everywhere.",
+          "exits" => { "south" => "tavern" }
+        }
+      },
+      items: {
+        "sword" => { "name" => "Sword", "keywords" => ["sword"] },
+        "potion" => { "name" => "Potion", "keywords" => ["potion"] }
+      },
+      npcs: {
+        "innkeeper" => {
+          "name" => "Innkeeper",
+          "keywords" => ["innkeeper"],
+          "accepts_item" => "potion",
+          "accept_message" => "Thanks for the potion!"
+        }
+      }
+    )
+
+    @game_users = [
+      OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
+      OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+    ]
+  end
+
+  # ─── GIVE to co-located player ─────────────────────────────────────────────
+
+  test "give item to co-located player succeeds" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["sword"]),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to Aragorn")
+
+    assert result[:success]
+    assert_match(/Aragorn/i, result[:response])
+    assert_match(/give/i, result[:response])
+    assert_not_includes game.player_state(USER_1)["inventory"], "sword"
+    assert_includes game.player_state(USER_2)["inventory"], "sword"
+  end
+
+  test "give item to player generates secondary message to receiver" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["sword"]),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to Aragorn")
+
+    secondary = result[:secondary_messages]
+    assert secondary.present?
+    receiver_msg = secondary.find { |m| m[:visible_to] == [USER_2.to_s] }
+    assert receiver_msg, "Expected secondary message visible to player 2"
+    assert_match(/gives you/i, receiver_msg[:text])
+    assert_match(/Sword/i, receiver_msg[:text])
+  end
+
+  test "give item to player in different room fails" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["sword"]),
+        USER_2 => player_state_in("library")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to Aragorn")
+
+    assert_not result[:success]
+    assert_match(/not here/i, result[:response])
+    assert_includes game.player_state(USER_1)["inventory"], "sword"
+  end
+
+  test "give item to player when item not in inventory fails" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: []),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to Aragorn")
+
+    assert_not result[:success]
+  end
+
+  # ─── GIVE falls through to NPC when no player matches ─────────────────────
+
+  test "give to NPC name still delegates to NPC logic" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["potion"]),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give potion to innkeeper")
+
+    assert result[:success]
+    assert_match(/Thanks for the potion!/i, result[:response])
+    assert_not_includes game.player_state(USER_1)["inventory"], "potion"
+  end
+
+  test "give with unknown target fails gracefully" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["sword"]),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to wizard")
+
+    assert_not result[:success]
+  end
+
+  # ─── Case insensitivity ────────────────────────────────────────────────────
+
+  test "give matches player name case-insensitively" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern", inventory: ["sword"]),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = execute(game, USER_1, "give sword to aragorn")
+
+    assert result[:success]
+  end
+
+  private
+
+    def execute(game, user_id, input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::InteractHandler.new(game: game, user_id: user_id).handle(command)
+    end
+end

--- a/test/lib/classic_game/handlers/give_to_player_handler_test.rb
+++ b/test/lib/classic_game/handlers/give_to_player_handler_test.rb
@@ -39,8 +39,8 @@ class GiveToPlayerHandlerTest < ActiveSupport::TestCase
     )
 
     @game_users = [
-      OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
-      OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+      FakeGameUser.new(USER_1, "Gandalf"),
+      FakeGameUser.new(USER_2, "Aragorn")
     ]
   end
 

--- a/test/lib/classic_game/multiplayer_integration_test.rb
+++ b/test/lib/classic_game/multiplayer_integration_test.rb
@@ -29,8 +29,8 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
     )
 
     @game_users = [
-      OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
-      OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+      FakeGameUser.new(USER_1, "Gandalf"),
+      FakeGameUser.new(USER_2, "Aragorn")
     ]
   end
 
@@ -186,14 +186,14 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
       player_ids: [USER_1, USER_2],
       player_states: {
         USER_1 => player_state_in("arena", combat: {
-                                             "active" => true,
-                                             "creature_id" => "goblin",
-                                             "creature_health" => 5,
-                                             "creature_max_health" => 10,
-                                             "round_number" => 2,
-                                             "defending" => false,
-                                             "turn_order" => "player"
-                                           }),
+          "active" => true,
+          "creature_id" => "goblin",
+          "creature_health" => 5,
+          "creature_max_health" => 10,
+          "round_number" => 2,
+          "defending" => false,
+          "turn_order" => "player"
+        }),
         USER_2 => player_state_in("arena")
       },
       game_users: @game_users
@@ -211,7 +211,7 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
   private
 
     def engine_execute(game, user_id, command_text)
-      user = OpenStruct.new(id: user_id)
+      user = FakeUser.new(user_id)
       ClassicGame::Engine.execute(game: game, user: user, command_text: command_text)
     end
 end

--- a/test/lib/classic_game/multiplayer_integration_test.rb
+++ b/test/lib/classic_game/multiplayer_integration_test.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MultiplayerIntegrationTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_1 = 1
+  USER_2 = 2
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => {
+          "name" => "The Tavern",
+          "description" => "A cozy inn.",
+          "exits" => { "north" => "library" }
+        },
+        "library" => {
+          "name" => "The Library",
+          "description" => "Books everywhere.",
+          "exits" => { "south" => "tavern" }
+        }
+      },
+      items: {
+        "sword" => { "name" => "Sword", "keywords" => ["sword"] }
+      }
+    )
+
+    @game_users = [
+      OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
+      OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+    ]
+  end
+
+  # ─── Turn enforcement ─────────────────────────────────────────────────────
+
+  test "player 2 cannot act on player 1s turn" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      game_users: @game_users
+    )
+
+    result = engine_execute(game, USER_2, "look")
+
+    assert_not result[:success]
+    assert_match(/turn/i, result[:response])
+  end
+
+  test "player 1 can act on their own turn" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      game_users: @game_users
+    )
+
+    result = engine_execute(game, USER_1, "look")
+
+    assert result[:success]
+  end
+
+  test "turn advances to next player after command" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      game_users: @game_users
+    )
+
+    engine_execute(game, USER_1, "look")
+
+    assert_equal "2", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "turn wraps around after both players act" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      game_users: @game_users
+    )
+
+    engine_execute(game, USER_1, "look")
+    engine_execute(game, USER_2, "look")
+
+    assert_equal "1", ClassicGame::TurnManager.current_player(game)
+  end
+
+  # ─── Room presence notifications ─────────────────────────────────────────
+
+  test "entering a room with another player shows also-here line" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("library"),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = engine_execute(game, USER_2, "go north")
+
+    assert result[:success]
+    assert_match(/Also here/i, result[:response])
+    assert_match(/Gandalf/i, result[:response])
+  end
+
+  test "entering a room triggers arrival secondary message for existing occupants" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("library"),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = engine_execute(game, USER_2, "go north")
+
+    secondary = result[:secondary_messages] || []
+    arrival_msg = secondary.find { |m| m[:text]&.match?(/arrived/i) }
+    assert arrival_msg, "Expected arrival secondary message"
+    assert_equal [USER_1.to_s], arrival_msg[:visible_to]
+    assert_match(/Aragorn/i, arrival_msg[:text])
+  end
+
+  test "leaving a room triggers departure secondary message for remaining occupants" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("tavern"),
+        USER_2 => player_state_in("tavern")
+      },
+      game_users: @game_users
+    )
+
+    result = engine_execute(game, USER_1, "go north")
+
+    secondary = result[:secondary_messages] || []
+    departure_msg = secondary.find { |m| m[:text]&.match?(/left/i) }
+    assert departure_msg, "Expected departure secondary message"
+    assert_equal [USER_2.to_s], departure_msg[:visible_to]
+    assert_match(/Gandalf/i, departure_msg[:text])
+  end
+
+  # ─── Single player mode (no turn state) ──────────────────────────────────
+
+  test "single player game always allows acting" do
+    game = build_game(world_data: @world, player_id: USER_1)
+
+    result = engine_execute(game, USER_1, "look")
+
+    assert result[:success]
+  end
+
+  # ─── Fled player waiting ──────────────────────────────────────────────────
+
+  test "fled player is marked as waiting for combat end" do
+    world_with_creature = build_world(
+      starting_room: "arena",
+      rooms: {
+        "arena" => {
+          "name" => "Arena",
+          "description" => "A fighting pit.",
+          "exits" => {}
+        }
+      },
+      creatures: {
+        "goblin" => {
+          "name" => "Goblin",
+          "health" => 10,
+          "attack" => 3,
+          "defense" => 0,
+          "keywords" => ["goblin"]
+        }
+      }
+    )
+
+    game = build_multiplayer_game(
+      world_data: world_with_creature,
+      player_ids: [USER_1, USER_2],
+      player_states: {
+        USER_1 => player_state_in("arena", combat: {
+                                             "active" => true,
+                                             "creature_id" => "goblin",
+                                             "creature_health" => 5,
+                                             "creature_max_health" => 10,
+                                             "round_number" => 2,
+                                             "defending" => false,
+                                             "turn_order" => "player"
+                                           }),
+        USER_2 => player_state_in("arena")
+      },
+      game_users: @game_users
+    )
+
+    # rand(1..100) > 50 fails the flee; returning 1 means flee succeeds
+    handler = ClassicGame::Handlers::CombatHandler.new(game: game, user_id: USER_1)
+    handler.stub(:rand, 1) do
+      command = ClassicGame::CommandParser.parse("flee")
+      handler.handle(command)
+    end
+
+    assert game.player_waiting_for_combat?(USER_1)
+  end
+
+  private
+
+    def engine_execute(game, user_id, command_text)
+      user = OpenStruct.new(id: user_id)
+      ClassicGame::Engine.execute(game: game, user: user, command_text: command_text)
+    end
+end

--- a/test/lib/classic_game/multiplayer_integration_test.rb
+++ b/test/lib/classic_game/multiplayer_integration_test.rb
@@ -181,19 +181,21 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
       }
     )
 
+    combat_state = {
+      "active" => true,
+      "creature_id" => "goblin",
+      "creature_health" => 5,
+      "creature_max_health" => 10,
+      "round_number" => 2,
+      "defending" => false,
+      "turn_order" => "player"
+    }
+
     game = build_multiplayer_game(
       world_data: world_with_creature,
       player_ids: [USER_1, USER_2],
       player_states: {
-        USER_1 => player_state_in("arena", combat: {
-          "active" => true,
-          "creature_id" => "goblin",
-          "creature_health" => 5,
-          "creature_max_health" => 10,
-          "round_number" => 2,
-          "defending" => false,
-          "turn_order" => "player"
-        }),
+        USER_1 => player_state_in("arena", combat: combat_state),
         USER_2 => player_state_in("arena")
       },
       game_users: @game_users

--- a/test/lib/classic_game/multiplayer_integration_test.rb
+++ b/test/lib/classic_game/multiplayer_integration_test.rb
@@ -99,6 +99,7 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
       game_users: @game_users
     )
 
+    engine_execute(game, USER_1, "look") # advance turn to USER_2
     result = engine_execute(game, USER_2, "go north")
 
     assert result[:success]
@@ -117,6 +118,7 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
       game_users: @game_users
     )
 
+    engine_execute(game, USER_1, "look") # advance turn to USER_2
     result = engine_execute(game, USER_2, "go north")
 
     secondary = result[:secondary_messages] || []
@@ -199,10 +201,9 @@ class MultiplayerIntegrationTest < ActiveSupport::TestCase
 
     # rand(1..100) > 50 fails the flee; returning 1 means flee succeeds
     handler = ClassicGame::Handlers::CombatHandler.new(game: game, user_id: USER_1)
-    handler.stub(:rand, 1) do
-      command = ClassicGame::CommandParser.parse("flee")
-      handler.handle(command)
-    end
+    handler.define_singleton_method(:rand) { |*_args| 1 }
+    command = ClassicGame::CommandParser.parse("flee")
+    handler.handle(command)
 
     assert game.player_waiting_for_combat?(USER_1)
   end

--- a/test/lib/classic_game/turn_manager_test.rb
+++ b/test/lib/classic_game/turn_manager_test.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TurnManagerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_1 = 1
+  USER_2 = 2
+  USER_3 = 3
+
+  setup do
+    @world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => { "name" => "Tavern", "description" => "A cozy tavern.", "exits" => {} }
+      }
+    )
+  end
+
+  # ─── initialize_turns ──────────────────────────────────────────────────────
+
+  test "initialize_turns sets turn order and current_index" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+    ClassicGame::TurnManager.initialize_turns(game, [USER_1, USER_2])
+
+    turn_state = game.game_state["turn_state"]
+    assert_equal ["1", "2"], turn_state["order"]
+    assert_equal 0, turn_state["current_index"]
+    assert_equal({}, turn_state["combat_waiters"])
+  end
+
+  # ─── current_player ────────────────────────────────────────────────────────
+
+  test "current_player returns the first player initially" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+
+    assert_equal "1", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "current_player returns nil when no turn order initialized" do
+    game = build_game(world_data: @world, player_id: USER_1)
+
+    assert_nil ClassicGame::TurnManager.current_player(game)
+  end
+
+  # ─── user_can_act? ─────────────────────────────────────────────────────────
+
+  test "user_can_act? returns true for the current player" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+
+    assert ClassicGame::TurnManager.user_can_act?(game, USER_1)
+    assert_not ClassicGame::TurnManager.user_can_act?(game, USER_2)
+  end
+
+  test "user_can_act? always returns true when no turn order exists (single-player)" do
+    game = build_game(world_data: @world, player_id: USER_1)
+
+    assert ClassicGame::TurnManager.user_can_act?(game, USER_1)
+  end
+
+  test "user_can_act? always returns true when only one player in order" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1])
+
+    assert ClassicGame::TurnManager.user_can_act?(game, USER_1)
+  end
+
+  # ─── advance ───────────────────────────────────────────────────────────────
+
+  test "advance moves to next player" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+
+    ClassicGame::TurnManager.advance(game)
+
+    assert_equal "2", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "advance wraps around to first player" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+
+    ClassicGame::TurnManager.advance(game) # -> player 2
+    ClassicGame::TurnManager.advance(game) # -> player 1
+
+    assert_equal "1", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "advance skips combat waiters" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2, USER_3])
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_2, "tavern")
+
+    ClassicGame::TurnManager.advance(game) # player 1 -> skip player 2 -> player 3
+
+    assert_equal "3", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "advance skips multiple consecutive combat waiters" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2, USER_3])
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_2, "tavern")
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_3, "tavern")
+
+    ClassicGame::TurnManager.advance(game) # should wrap back to player 1
+
+    assert_equal "1", ClassicGame::TurnManager.current_player(game)
+  end
+
+  test "advance is a no-op when no turn order exists" do
+    game = build_game(world_data: @world, player_id: USER_1)
+
+    assert_nothing_raised { ClassicGame::TurnManager.advance(game) }
+  end
+
+  # ─── combat waiters ────────────────────────────────────────────────────────
+
+  test "add_combat_waiter records the room" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_1, "tavern")
+
+    assert game.player_waiting_for_combat?(USER_1)
+  end
+
+  test "remove_combat_waiter clears the player" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_1, "tavern")
+    ClassicGame::TurnManager.remove_combat_waiter(game, USER_1)
+
+    assert_not game.player_waiting_for_combat?(USER_1)
+  end
+
+  test "clear_combat_waiters_for_room removes all waiters in that room" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2, USER_3])
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_1, "tavern")
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_2, "tavern")
+    ClassicGame::TurnManager.add_combat_waiter(game, USER_3, "library")
+
+    ClassicGame::TurnManager.clear_combat_waiters_for_room(game, "tavern")
+
+    assert_not game.player_waiting_for_combat?(USER_1)
+    assert_not game.player_waiting_for_combat?(USER_2)
+    assert game.player_waiting_for_combat?(USER_3)
+  end
+
+  # ─── waiting_message ───────────────────────────────────────────────────────
+
+  test "waiting_message returns a string with the current player name" do
+    game = build_multiplayer_game(
+      world_data: @world,
+      player_ids: [USER_1, USER_2],
+      game_users: [
+        OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
+        OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+      ]
+    )
+
+    msg = ClassicGame::TurnManager.waiting_message(game)
+
+    assert_match(/Gandalf/i, msg)
+    assert_match(/turn/i, msg)
+  end
+
+  test "waiting_message falls back gracefully when no game_users" do
+    game = build_multiplayer_game(world_data: @world, player_ids: [USER_1, USER_2])
+
+    assert_nothing_raised { ClassicGame::TurnManager.waiting_message(game) }
+  end
+end

--- a/test/lib/classic_game/turn_manager_test.rb
+++ b/test/lib/classic_game/turn_manager_test.rb
@@ -25,7 +25,7 @@ class TurnManagerTest < ActiveSupport::TestCase
     ClassicGame::TurnManager.initialize_turns(game, [USER_1, USER_2])
 
     turn_state = game.game_state["turn_state"]
-    assert_equal ["1", "2"], turn_state["order"]
+    assert_equal %w[1 2], turn_state["order"]
     assert_equal 0, turn_state["current_index"]
     assert_equal({}, turn_state["combat_waiters"])
   end
@@ -146,8 +146,8 @@ class TurnManagerTest < ActiveSupport::TestCase
       world_data: @world,
       player_ids: [USER_1, USER_2],
       game_users: [
-        OpenStruct.new(user_id: USER_1, character_name: "Gandalf"),
-        OpenStruct.new(user_id: USER_2, character_name: "Aragorn")
+        FakeGameUser.new(USER_1, "Gandalf"),
+        FakeGameUser.new(USER_2, "Aragorn")
       ]
     )
 

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -3,6 +3,9 @@
 # In-memory game double for testing ClassicGame handlers without hitting the database.
 # Implements all game state methods used by BaseHandler and its subclasses.
 module ClassicGameTestHelper
+  FakeGameUser = Struct.new(:user_id, :character_name)
+  FakeUser = Struct.new(:id)
+
   class FakeGame
     attr_accessor :game_state, :game_users
 
@@ -208,9 +211,7 @@ module ClassicGameTestHelper
     game = FakeGame.new(world_data: world_data, game_users: game_users)
 
     player_ids.each do |pid|
-      if player_states.key?(pid)
-        game.game_state["player_states"][pid.to_s] = player_states[pid]
-      end
+      game.game_state["player_states"][pid.to_s] = player_states[pid] if player_states.key?(pid)
     end
 
     room_states.each { |id, state| game.game_state["room_states"][id.to_s] = state }

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -4,9 +4,10 @@
 # Implements all game state methods used by BaseHandler and its subclasses.
 module ClassicGameTestHelper
   class FakeGame
-    attr_accessor :game_state
+    attr_accessor :game_state, :game_users
 
-    def initialize(world_data:)
+    def initialize(world_data:, game_users: [])
+      @game_users = game_users
       @game_state = {
         "world_snapshot" => world_data,
         "player_states" => {},
@@ -98,6 +99,32 @@ module ClassicGameTestHelper
       10
     end
 
+    # ─── Turn state helpers ──────────────────────────────────────────────────
+
+    def current_turn_user_id
+      @game_state.dig("turn_state", "order", @game_state.dig("turn_state", "current_index") || 0)
+    end
+
+    def add_player_to_turn_order(user_id)
+      @game_state["turn_state"] ||= { "order" => [], "current_index" => 0, "combat_waiters" => {} }
+      @game_state["turn_state"]["order"] << user_id.to_s
+      @game_state["turn_state"]["order"].uniq!
+    end
+
+    def player_waiting_for_combat?(user_id)
+      @game_state.dig("turn_state", "combat_waiters", user_id.to_s).present?
+    end
+
+    def set_player_waiting_for_combat(user_id, room_id)
+      @game_state["turn_state"] ||= { "order" => [], "current_index" => 0, "combat_waiters" => {} }
+      @game_state["turn_state"]["combat_waiters"] ||= {}
+      @game_state["turn_state"]["combat_waiters"][user_id.to_s] = room_id.to_s
+    end
+
+    def clear_player_waiting_for_combat(user_id)
+      @game_state.dig("turn_state", "combat_waiters")&.delete(user_id.to_s)
+    end
+
     def save!
       # no-op — state is stored in-memory
     end
@@ -172,5 +199,25 @@ module ClassicGameTestHelper
     }
     state["combat"] = combat if combat
     state
+  end
+
+  # Build a FakeGame configured for multiplayer with turn order initialized.
+  # player_states: hash of { user_id => state_hash } — omit to use defaults.
+  # game_users: array of OpenStruct/objects with #user_id and #character_name.
+  def build_multiplayer_game(world_data:, player_ids:, player_states: {}, room_states: {}, game_users: [])
+    game = FakeGame.new(world_data: world_data, game_users: game_users)
+
+    player_ids.each do |pid|
+      if player_states.key?(pid)
+        game.game_state["player_states"][pid.to_s] = player_states[pid]
+      end
+    end
+
+    room_states.each { |id, state| game.game_state["room_states"][id.to_s] = state }
+
+    # Initialize turn order
+    ClassicGame::TurnManager.initialize_turns(game, player_ids)
+
+    game
   end
 end


### PR DESCRIPTION
## Summary

- **TurnManager**: new `ClassicGame::TurnManager` orchestrates multiplayer turn order, advances the turn index after each command, skips combat-waiting players, and exposes a `waiting_message` when it's not a player's turn
- **Engine**: enforces turn order at the top of `execute`; advances turn after every successful command; single-player games are unaffected (no turn state = always can act)
- **Message visibility**: added `visible_to_user_ids` (jsonb, default `[]`) and `room_id` columns to `messages`; `Message.visible_to(user)` scope; private messages broadcast only to their intended user streams
- **Room presence**: `MovementHandler` appends "Also here: …" to room descriptions and emits `secondary_messages` for arrival/departure notifications delivered only to co-located players
- **Player-to-player GIVE**: `InteractHandler#handle_give` tries `find_player_character` before NPC lookup; successful gives transfer item between inventories and deliver a secondary message to the receiver
- **Fled-player waiting**: `CombatHandler#handle_flee` marks the player as a combat waiter when other players remain in the room; `handle_creature_defeat` clears all waiters for that room
- **Database**: migration adds `visible_to_user_ids` jsonb and `room_id` string to `messages`; existing rows default to `[]` (visible to all) preserving backward compatibility
- **GameUser**: `after_create_commit` joins the game's classic turn order when a new player joins
- **Views**: added per-user Turbo Stream subscription (`turbo_stream_from(@game, :messages, current_user.id)`) for private message delivery

## Test plan

- [x] `TurnManagerTest`: initialize, advance, wrap-around, skip waiters, combat waiter add/remove/clear, waiting_message
- [x] `GiveToPlayerHandlerTest`: co-located give, receiver secondary message, remote give fails, NPC give still works, case-insensitive name matching
- [x] `MultiplayerIntegrationTest`: turn enforcement (wrong-turn player rejected), turn advances after command, wraps around, "Also here" in room description, arrival/departure secondary messages, single-player always allowed, fled-player waiting state

---

## Fix Notes

**CI fix (7334bcf)** — 3 test failures in `MultiplayerIntegrationTest`:

1. **"also-here line" & "arrival secondary message"** — Tests tried to have USER_2 act without first advancing the turn from USER_1. Added `engine_execute(game, USER_1, "look")` before the USER_2 movement command.
2. **"fled player waiting"** — `handler.stub(:rand, 1)` broke on Minitest 6 which removed `Object#stub`. Replaced with `define_singleton_method(:rand) { |*_args| 1 }`.

**RuboCop fix (8fc0fa2)** — 18 offenses:

- Converted 4 `if`/`unless` blocks to modifier form (combat_handler, interact_handler, classic_game_helper)
- Extracted `generate_exits_lines` from `generate_room_description` to fix `Metrics/MethodLength` (70→~45 lines)
- Prefixed unused `old_room_id` arg with `_` in `build_movement_notifications`
- Used `lambda` method instead of `->` for multiline `visible_to` scope
- Used `change_table :messages, bulk: true` in migration
- Replaced all `OpenStruct` usage in tests with `Struct`-based `FakeGameUser`/`FakeUser`
- Fixed `Layout/FirstHashElementIndentation` in multiplayer integration test
- Used `%w[]` word array for string array assertion

**RuboCop fix (e4c8fa1)** — 2 remaining `Layout/FirstHashElementIndentation` offenses:

- Extracted inline combat hash to `combat_state` local variable in multiplayer integration test to avoid nested indentation issues