### PR TITLE
Add Funny Words

### DIFF
--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -252,7 +252,7 @@ module ClassicGame
         def unknown_command_response(command)
           {
             success: false,
-            response: "I don't understand '#{command[:raw]}'. Type HELP for available commands.",
+            response: ClassicGame::FunnyResponses.unknown_command(command[:raw]),
             state_changes: {}
           }
         end

--- a/app/lib/classic_game/funny_responses.rb
+++ b/app/lib/classic_game/funny_responses.rb
@@ -2,127 +2,127 @@
 
 module ClassicGame
   module FunnyResponses
+    UNKNOWN_COMMAND = [
+      "I don't understand '%s'. Did a cat walk across your keyboard? Type HELP for available commands.",
+      "I don't understand '%s'. That's not a spell, a command, or interpretive dance. Type HELP for available commands.",
+      "I don't understand '%s'. The dungeon frowns upon gibberish. Type HELP for available commands.",
+      "I don't understand '%s'. Even the rats look confused. Type HELP for available commands.",
+      "I don't understand '%s'. Try something in the HELP menu next time. Type HELP for available commands."
+    ].freeze
+
+    CANT_GO = [
+      "You can't go that way. There's a wall there, you know.",
+      "You can't go that way. You bonk your head for emphasis.",
+      "You can't go that way. The dungeon politely declines.",
+      "You can't go that way. Try a direction that actually exists.",
+      "You can't go that way. That's just solid stone, friend."
+    ].freeze
+
+    GO_WHERE = [
+      "Go where? You gesture vaguely into the void.",
+      "Go where? The compass spins unhelpfully.",
+      "Go where? Maybe pick a direction first.",
+      "Go where? Even the exits look confused.",
+      "Go where? Specify a direction!"
+    ].freeze
+
+    TAKE_WHAT = [
+      "Take what? Your ambition is admirable but vague.",
+      "Take what? You grab the air. Nothing happens.",
+      "Take what? Be specific — the dungeon contains many things.",
+      "Take what? Name the item you'd like to pocket.",
+      "Take what? Your hands are ready but your words are not."
+    ].freeze
+
+    DROP_WHAT = [
+      "Drop what? Everything stays firmly in your pockets.",
+      "Drop what? Nothing falls to the floor.",
+      "Drop what? Specify which item to drop.",
+      "Drop what? You mime dropping something. Very convincing.",
+      "Drop what? The floor waits patiently for your answer."
+    ].freeze
+
+    USE_WHAT = [
+      "Use what? Your intent is mysterious but the syntax is not.",
+      "Use what? Specify an item.",
+      "Use what? You wave your hands around. Nothing happens.",
+      "Use what? Even the most versatile adventurer needs a target.",
+      "Use what? The item fairies demand specifics."
+    ].freeze
+
+    EXAMINE_WHAT = [
+      "Examine what? You squint at everything and learn nothing.",
+      "Examine what? Your monocle is ready but your words are not.",
+      "Examine what? Name the thing you'd like to scrutinize.",
+      "Examine what? Be specific — curiosity needs a subject.",
+      "Examine what? You peer intently at the air. Still air."
+    ].freeze
+
+    OPEN_WHAT = [
+      "Open what? You tug at the air. It refuses to open.",
+      "Open what? Name the thing you'd like to pry open.",
+      "Open what? Your crowbar stands ready, awaiting a target.",
+      "Open what? Specify something with a lid, door, or flap.",
+      "Open what? The dungeon's containers remain stubbornly closed."
+    ].freeze
+
+    CLOSE_WHAT = [
+      "Close what? You shut nothing very dramatically.",
+      "Close what? Nothing is closed. Yet.",
+      "Close what? Name the thing you'd like to seal.",
+      "Close what? You slam an invisible door. Satisfying.",
+      "Close what? Specify something that can be closed."
+    ].freeze
+
+    TALK_TO_WHOM = [
+      "Talk to whom? The walls don't respond well to conversation.",
+      "Talk to whom? Your monologue needs an audience.",
+      "Talk to whom? Specify who you'd like to chat with.",
+      "Talk to whom? The dungeon is oddly quiet. Name someone.",
+      "Talk to whom? Even NPCs need to be addressed by name."
+    ].freeze
+
+    ATTACK_WHAT = [
+      "Attack what? You swing at the air heroically.",
+      "Attack what? Your battle cry echoes into the void.",
+      "Attack what? Specify a target before you strain something.",
+      "Attack what? Violence needs direction. Name something.",
+      "Attack what? The dungeon awaits your bloodthirsty specifics."
+    ].freeze
+
+    DONT_SEE_THAT = [
+      "You don't see that here. Try looking around first.",
+      "You don't see that here. Maybe it's hiding from you.",
+      "You don't see that here. Either it's gone or it was never here.",
+      "You don't see that here. Your keen eyes find nothing.",
+      "You don't see that here. The room keeps its secrets."
+    ].freeze
+
+    DONT_HAVE_THAT = [
+      "You don't have that. Check your pockets — still nothing.",
+      "You don't have that. Your inventory is disappointingly bare on that front.",
+      "You don't have that. Have you tried picking it up first?",
+      "You don't have that. Perhaps it's somewhere in the dungeon.",
+      "You don't have that. Wishing doesn't make it so."
+    ].freeze
+
+    CANT_USE_HERE = [
+      "You can't use that here. This is not the right place for such things.",
+      "You can't use that here. The dungeon raises an eyebrow.",
+      "You can't use that here. Perhaps there's a better context for it.",
+      "You can't use that here. Nothing happens. How embarrassing.",
+      "You can't use that here. The item sighs with disappointment."
+    ].freeze
+
+    NOTHING_SPECIAL = [
+      "You see nothing special about that. It's remarkably ordinary.",
+      "You see nothing special about that. Your scrutiny reveals only mediocrity.",
+      "You see nothing special about that. Just a perfectly normal thing.",
+      "You see nothing special about that. Your detective instincts find nothing.",
+      "You see nothing special about that. Move along."
+    ].freeze
+
     class << self
-      UNKNOWN_COMMAND = [
-        "I don't understand '%s'. Did a cat walk across your keyboard? Type HELP for available commands.",
-        "I don't understand '%s'. That's not a spell, a command, or interpretive dance. Type HELP for available commands.",
-        "I don't understand '%s'. The dungeon frowns upon gibberish. Type HELP for available commands.",
-        "I don't understand '%s'. Even the rats look confused. Type HELP for available commands.",
-        "I don't understand '%s'. Try something in the HELP menu next time. Type HELP for available commands."
-      ].freeze
-
-      CANT_GO = [
-        "You can't go that way. There's a wall there, you know.",
-        "You can't go that way. You bonk your head for emphasis.",
-        "You can't go that way. The dungeon politely declines.",
-        "You can't go that way. Try a direction that actually exists.",
-        "You can't go that way. That's just solid stone, friend."
-      ].freeze
-
-      GO_WHERE = [
-        "Go where? You gesture vaguely into the void.",
-        "Go where? The compass spins unhelpfully.",
-        "Go where? Maybe pick a direction first.",
-        "Go where? Even the exits look confused.",
-        "Go where? Specify a direction!"
-      ].freeze
-
-      TAKE_WHAT = [
-        "Take what? Your ambition is admirable but vague.",
-        "Take what? You grab the air. Nothing happens.",
-        "Take what? Be specific — the dungeon contains many things.",
-        "Take what? Name the item you'd like to pocket.",
-        "Take what? Your hands are ready but your words are not."
-      ].freeze
-
-      DROP_WHAT = [
-        "Drop what? Everything stays firmly in your pockets.",
-        "Drop what? Nothing falls to the floor.",
-        "Drop what? Specify which item to drop.",
-        "Drop what? You mime dropping something. Very convincing.",
-        "Drop what? The floor waits patiently for your answer."
-      ].freeze
-
-      USE_WHAT = [
-        "Use what? Your intent is mysterious but the syntax is not.",
-        "Use what? Specify an item.",
-        "Use what? You wave your hands around. Nothing happens.",
-        "Use what? Even the most versatile adventurer needs a target.",
-        "Use what? The item fairies demand specifics."
-      ].freeze
-
-      EXAMINE_WHAT = [
-        "Examine what? You squint at everything and learn nothing.",
-        "Examine what? Your monocle is ready but your words are not.",
-        "Examine what? Name the thing you'd like to scrutinize.",
-        "Examine what? Be specific — curiosity needs a subject.",
-        "Examine what? You peer intently at the air. Still air."
-      ].freeze
-
-      OPEN_WHAT = [
-        "Open what? You tug at the air. It refuses to open.",
-        "Open what? Name the thing you'd like to pry open.",
-        "Open what? Your crowbar stands ready, awaiting a target.",
-        "Open what? Specify something with a lid, door, or flap.",
-        "Open what? The dungeon's containers remain stubbornly closed."
-      ].freeze
-
-      CLOSE_WHAT = [
-        "Close what? You shut nothing very dramatically.",
-        "Close what? Nothing is closed. Yet.",
-        "Close what? Name the thing you'd like to seal.",
-        "Close what? You slam an invisible door. Satisfying.",
-        "Close what? Specify something that can be closed."
-      ].freeze
-
-      TALK_TO_WHOM = [
-        "Talk to whom? The walls don't respond well to conversation.",
-        "Talk to whom? Your monologue needs an audience.",
-        "Talk to whom? Specify who you'd like to chat with.",
-        "Talk to whom? The dungeon is oddly quiet. Name someone.",
-        "Talk to whom? Even NPCs need to be addressed by name."
-      ].freeze
-
-      ATTACK_WHAT = [
-        "Attack what? You swing at the air heroically.",
-        "Attack what? Your battle cry echoes into the void.",
-        "Attack what? Specify a target before you strain something.",
-        "Attack what? Violence needs direction. Name something.",
-        "Attack what? The dungeon awaits your bloodthirsty specifics."
-      ].freeze
-
-      DONT_SEE_THAT = [
-        "You don't see that here. Try looking around first.",
-        "You don't see that here. Maybe it's hiding from you.",
-        "You don't see that here. Either it's gone or it was never here.",
-        "You don't see that here. Your keen eyes find nothing.",
-        "You don't see that here. The room keeps its secrets."
-      ].freeze
-
-      DONT_HAVE_THAT = [
-        "You don't have that. Check your pockets — still nothing.",
-        "You don't have that. Your inventory is disappointingly bare on that front.",
-        "You don't have that. Have you tried picking it up first?",
-        "You don't have that. Perhaps it's somewhere in the dungeon.",
-        "You don't have that. Wishing doesn't make it so."
-      ].freeze
-
-      CANT_USE_HERE = [
-        "You can't use that here. This is not the right place for such things.",
-        "You can't use that here. The dungeon raises an eyebrow.",
-        "You can't use that here. Perhaps there's a better context for it.",
-        "You can't use that here. Nothing happens. How embarrassing.",
-        "You can't use that here. The item sighs with disappointment."
-      ].freeze
-
-      NOTHING_SPECIAL = [
-        "You see nothing special about that. It's remarkably ordinary.",
-        "You see nothing special about that. Your scrutiny reveals only mediocrity.",
-        "You see nothing special about that. Just a perfectly normal thing.",
-        "You see nothing special about that. Your detective instincts find nothing.",
-        "You see nothing special about that. Move along."
-      ].freeze
-
       def unknown_command(raw)
         format(UNKNOWN_COMMAND.sample, raw)
       end

--- a/app/lib/classic_game/funny_responses.rb
+++ b/app/lib/classic_game/funny_responses.rb
@@ -61,6 +61,70 @@ module ClassicGame
       "You see nothing special about that. Move along."
     ].freeze
 
+    TAKE_WHAT = [
+      "Take what? Your hands grasp at empty air.",
+      "Take what? Be more specific, adventurer.",
+      "Take what? There's a lot of stuff around. Narrow it down.",
+      "Take what? You mime picking up something invisible.",
+      "Take what? You'll need to say what you want."
+    ].freeze
+
+    DROP_WHAT = [
+      "Drop what? Your hands are already empty on that front.",
+      "Drop what? Specify the item you're tired of carrying.",
+      "Drop what? You need to be more specific.",
+      "Drop what? You pantomime letting go of nothing.",
+      "Drop what? Name the thing you wish to discard."
+    ].freeze
+
+    USE_WHAT = [
+      "Use what? You wiggle your fingers expectantly.",
+      "Use what? Specify the item you'd like to employ.",
+      "Use what? The dungeon awaits further instructions.",
+      "Use what? You need to tell me what to use.",
+      "Use what? Your pockets aren't going to search themselves."
+    ].freeze
+
+    EXAMINE_WHAT = [
+      "Examine what? You squint at nothing in particular.",
+      "Examine what? Your magnifying glass hovers aimlessly.",
+      "Examine what? Be specific about what catches your eye.",
+      "Examine what? You peer around with scholarly intent but no target.",
+      "Examine what? Tell me what deserves your scrutiny."
+    ].freeze
+
+    OPEN_WHAT = [
+      "Open what? You tug at the air expectantly.",
+      "Open what? Specify what you'd like to open.",
+      "Open what? Your hands reach for an imaginary handle.",
+      "Open what? The dungeon has many things — name one.",
+      "Open what? You'll need to be more specific."
+    ].freeze
+
+    CLOSE_WHAT = [
+      "Close what? You push against nothing.",
+      "Close what? Specify what needs shutting.",
+      "Close what? Your arms swing shut on empty air.",
+      "Close what? Name the thing you want closed.",
+      "Close what? The dungeon awaits clarification."
+    ].freeze
+
+    TALK_TO_WHOM = [
+      "Talk to whom? You mumble into the void.",
+      "Talk to whom? Specify who deserves your eloquence.",
+      "Talk to whom? The walls aren't great conversationalists.",
+      "Talk to whom? You clear your throat at nobody.",
+      "Talk to whom? Name your intended audience."
+    ].freeze
+
+    ATTACK_WHAT = [
+      "Attack what? You swing at the air heroically.",
+      "Attack what? Specify your target before you hurt yourself.",
+      "Attack what? Your weapon thirsts for a named foe.",
+      "Attack what? You shadow-box impressively but accomplish nothing.",
+      "Attack what? The dungeon suggests picking a real target."
+    ].freeze
+
     class << self
       def unknown_command(raw)
         format(UNKNOWN_COMMAND.sample, raw)

--- a/app/lib/classic_game/funny_responses.rb
+++ b/app/lib/classic_game/funny_responses.rb
@@ -2,9 +2,12 @@
 
 module ClassicGame
   module FunnyResponses
+    include ObjectPrompts
+
     UNKNOWN_COMMAND = [
       "I don't understand '%s'. Did a cat walk across your keyboard? Type HELP for available commands.",
-      "I don't understand '%s'. That's not a spell, a command, or interpretive dance. Type HELP for available commands.",
+      "I don't understand '%s'. That's not a spell, a command, or interpretive dance. " \
+        "Type HELP for available commands.",
       "I don't understand '%s'. The dungeon frowns upon gibberish. Type HELP for available commands.",
       "I don't understand '%s'. Even the rats look confused. Type HELP for available commands.",
       "I don't understand '%s'. Try something in the HELP menu next time. Type HELP for available commands."
@@ -24,70 +27,6 @@ module ClassicGame
       "Go where? Maybe pick a direction first.",
       "Go where? Even the exits look confused.",
       "Go where? Specify a direction!"
-    ].freeze
-
-    TAKE_WHAT = [
-      "Take what? Your ambition is admirable but vague.",
-      "Take what? You grab the air. Nothing happens.",
-      "Take what? Be specific — the dungeon contains many things.",
-      "Take what? Name the item you'd like to pocket.",
-      "Take what? Your hands are ready but your words are not."
-    ].freeze
-
-    DROP_WHAT = [
-      "Drop what? Everything stays firmly in your pockets.",
-      "Drop what? Nothing falls to the floor.",
-      "Drop what? Specify which item to drop.",
-      "Drop what? You mime dropping something. Very convincing.",
-      "Drop what? The floor waits patiently for your answer."
-    ].freeze
-
-    USE_WHAT = [
-      "Use what? Your intent is mysterious but the syntax is not.",
-      "Use what? Specify an item.",
-      "Use what? You wave your hands around. Nothing happens.",
-      "Use what? Even the most versatile adventurer needs a target.",
-      "Use what? The item fairies demand specifics."
-    ].freeze
-
-    EXAMINE_WHAT = [
-      "Examine what? You squint at everything and learn nothing.",
-      "Examine what? Your monocle is ready but your words are not.",
-      "Examine what? Name the thing you'd like to scrutinize.",
-      "Examine what? Be specific — curiosity needs a subject.",
-      "Examine what? You peer intently at the air. Still air."
-    ].freeze
-
-    OPEN_WHAT = [
-      "Open what? You tug at the air. It refuses to open.",
-      "Open what? Name the thing you'd like to pry open.",
-      "Open what? Your crowbar stands ready, awaiting a target.",
-      "Open what? Specify something with a lid, door, or flap.",
-      "Open what? The dungeon's containers remain stubbornly closed."
-    ].freeze
-
-    CLOSE_WHAT = [
-      "Close what? You shut nothing very dramatically.",
-      "Close what? Nothing is closed. Yet.",
-      "Close what? Name the thing you'd like to seal.",
-      "Close what? You slam an invisible door. Satisfying.",
-      "Close what? Specify something that can be closed."
-    ].freeze
-
-    TALK_TO_WHOM = [
-      "Talk to whom? The walls don't respond well to conversation.",
-      "Talk to whom? Your monologue needs an audience.",
-      "Talk to whom? Specify who you'd like to chat with.",
-      "Talk to whom? The dungeon is oddly quiet. Name someone.",
-      "Talk to whom? Even NPCs need to be addressed by name."
-    ].freeze
-
-    ATTACK_WHAT = [
-      "Attack what? You swing at the air heroically.",
-      "Attack what? Your battle cry echoes into the void.",
-      "Attack what? Specify a target before you strain something.",
-      "Attack what? Violence needs direction. Name something.",
-      "Attack what? The dungeon awaits your bloodthirsty specifics."
     ].freeze
 
     DONT_SEE_THAT = [

--- a/app/lib/classic_game/funny_responses.rb
+++ b/app/lib/classic_game/funny_responses.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module FunnyResponses
+    class << self
+      UNKNOWN_COMMAND = [
+        "I don't understand '%s'. Did a cat walk across your keyboard? Type HELP for available commands.",
+        "I don't understand '%s'. That's not a spell, a command, or interpretive dance. Type HELP for available commands.",
+        "I don't understand '%s'. The dungeon frowns upon gibberish. Type HELP for available commands.",
+        "I don't understand '%s'. Even the rats look confused. Type HELP for available commands.",
+        "I don't understand '%s'. Try something in the HELP menu next time. Type HELP for available commands."
+      ].freeze
+
+      CANT_GO = [
+        "You can't go that way. There's a wall there, you know.",
+        "You can't go that way. You bonk your head for emphasis.",
+        "You can't go that way. The dungeon politely declines.",
+        "You can't go that way. Try a direction that actually exists.",
+        "You can't go that way. That's just solid stone, friend."
+      ].freeze
+
+      GO_WHERE = [
+        "Go where? You gesture vaguely into the void.",
+        "Go where? The compass spins unhelpfully.",
+        "Go where? Maybe pick a direction first.",
+        "Go where? Even the exits look confused.",
+        "Go where? Specify a direction!"
+      ].freeze
+
+      TAKE_WHAT = [
+        "Take what? Your ambition is admirable but vague.",
+        "Take what? You grab the air. Nothing happens.",
+        "Take what? Be specific — the dungeon contains many things.",
+        "Take what? Name the item you'd like to pocket.",
+        "Take what? Your hands are ready but your words are not."
+      ].freeze
+
+      DROP_WHAT = [
+        "Drop what? Everything stays firmly in your pockets.",
+        "Drop what? Nothing falls to the floor.",
+        "Drop what? Specify which item to drop.",
+        "Drop what? You mime dropping something. Very convincing.",
+        "Drop what? The floor waits patiently for your answer."
+      ].freeze
+
+      USE_WHAT = [
+        "Use what? Your intent is mysterious but the syntax is not.",
+        "Use what? Specify an item.",
+        "Use what? You wave your hands around. Nothing happens.",
+        "Use what? Even the most versatile adventurer needs a target.",
+        "Use what? The item fairies demand specifics."
+      ].freeze
+
+      EXAMINE_WHAT = [
+        "Examine what? You squint at everything and learn nothing.",
+        "Examine what? Your monocle is ready but your words are not.",
+        "Examine what? Name the thing you'd like to scrutinize.",
+        "Examine what? Be specific — curiosity needs a subject.",
+        "Examine what? You peer intently at the air. Still air."
+      ].freeze
+
+      OPEN_WHAT = [
+        "Open what? You tug at the air. It refuses to open.",
+        "Open what? Name the thing you'd like to pry open.",
+        "Open what? Your crowbar stands ready, awaiting a target.",
+        "Open what? Specify something with a lid, door, or flap.",
+        "Open what? The dungeon's containers remain stubbornly closed."
+      ].freeze
+
+      CLOSE_WHAT = [
+        "Close what? You shut nothing very dramatically.",
+        "Close what? Nothing is closed. Yet.",
+        "Close what? Name the thing you'd like to seal.",
+        "Close what? You slam an invisible door. Satisfying.",
+        "Close what? Specify something that can be closed."
+      ].freeze
+
+      TALK_TO_WHOM = [
+        "Talk to whom? The walls don't respond well to conversation.",
+        "Talk to whom? Your monologue needs an audience.",
+        "Talk to whom? Specify who you'd like to chat with.",
+        "Talk to whom? The dungeon is oddly quiet. Name someone.",
+        "Talk to whom? Even NPCs need to be addressed by name."
+      ].freeze
+
+      ATTACK_WHAT = [
+        "Attack what? You swing at the air heroically.",
+        "Attack what? Your battle cry echoes into the void.",
+        "Attack what? Specify a target before you strain something.",
+        "Attack what? Violence needs direction. Name something.",
+        "Attack what? The dungeon awaits your bloodthirsty specifics."
+      ].freeze
+
+      DONT_SEE_THAT = [
+        "You don't see that here. Try looking around first.",
+        "You don't see that here. Maybe it's hiding from you.",
+        "You don't see that here. Either it's gone or it was never here.",
+        "You don't see that here. Your keen eyes find nothing.",
+        "You don't see that here. The room keeps its secrets."
+      ].freeze
+
+      DONT_HAVE_THAT = [
+        "You don't have that. Check your pockets — still nothing.",
+        "You don't have that. Your inventory is disappointingly bare on that front.",
+        "You don't have that. Have you tried picking it up first?",
+        "You don't have that. Perhaps it's somewhere in the dungeon.",
+        "You don't have that. Wishing doesn't make it so."
+      ].freeze
+
+      CANT_USE_HERE = [
+        "You can't use that here. This is not the right place for such things.",
+        "You can't use that here. The dungeon raises an eyebrow.",
+        "You can't use that here. Perhaps there's a better context for it.",
+        "You can't use that here. Nothing happens. How embarrassing.",
+        "You can't use that here. The item sighs with disappointment."
+      ].freeze
+
+      NOTHING_SPECIAL = [
+        "You see nothing special about that. It's remarkably ordinary.",
+        "You see nothing special about that. Your scrutiny reveals only mediocrity.",
+        "You see nothing special about that. Just a perfectly normal thing.",
+        "You see nothing special about that. Your detective instincts find nothing.",
+        "You see nothing special about that. Move along."
+      ].freeze
+
+      def unknown_command(raw)
+        format(UNKNOWN_COMMAND.sample, raw)
+      end
+
+      def cant_go = CANT_GO.sample
+      def go_where = GO_WHERE.sample
+      def take_what = TAKE_WHAT.sample
+      def drop_what = DROP_WHAT.sample
+      def use_what = USE_WHAT.sample
+      def examine_what = EXAMINE_WHAT.sample
+      def open_what = OPEN_WHAT.sample
+      def close_what = CLOSE_WHAT.sample
+      def talk_to_whom = TALK_TO_WHOM.sample
+      def attack_what = ATTACK_WHAT.sample
+      def dont_see_that = DONT_SEE_THAT.sample
+      def dont_have_that = DONT_HAVE_THAT.sample
+      def cant_use_here = CANT_USE_HERE.sample
+      def nothing_special = NOTHING_SPECIAL.sample
+    end
+  end
+end

--- a/app/lib/classic_game/funny_responses/object_prompts.rb
+++ b/app/lib/classic_game/funny_responses/object_prompts.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module FunnyResponses
+    module ObjectPrompts
+      TAKE_WHAT = [
+        "Take what? Your ambition is admirable but vague.",
+        "Take what? You grab the air. Nothing happens.",
+        "Take what? Be specific — the dungeon contains many things.",
+        "Take what? Name the item you'd like to pocket.",
+        "Take what? Your hands are ready but your words are not."
+      ].freeze
+
+      DROP_WHAT = [
+        "Drop what? Everything stays firmly in your pockets.",
+        "Drop what? Nothing falls to the floor.",
+        "Drop what? Specify which item to drop.",
+        "Drop what? You mime dropping something. Very convincing.",
+        "Drop what? The floor waits patiently for your answer."
+      ].freeze
+
+      USE_WHAT = [
+        "Use what? Your intent is mysterious but the syntax is not.",
+        "Use what? Specify an item.",
+        "Use what? You wave your hands around. Nothing happens.",
+        "Use what? Even the most versatile adventurer needs a target.",
+        "Use what? The item fairies demand specifics."
+      ].freeze
+
+      EXAMINE_WHAT = [
+        "Examine what? You squint at everything and learn nothing.",
+        "Examine what? Your monocle is ready but your words are not.",
+        "Examine what? Name the thing you'd like to scrutinize.",
+        "Examine what? Be specific — curiosity needs a subject.",
+        "Examine what? You peer intently at the air. Still air."
+      ].freeze
+
+      OPEN_WHAT = [
+        "Open what? You tug at the air. It refuses to open.",
+        "Open what? Name the thing you'd like to pry open.",
+        "Open what? Your crowbar stands ready, awaiting a target.",
+        "Open what? Specify something with a lid, door, or flap.",
+        "Open what? The dungeon's containers remain stubbornly closed."
+      ].freeze
+
+      CLOSE_WHAT = [
+        "Close what? You shut nothing very dramatically.",
+        "Close what? Nothing is closed. Yet.",
+        "Close what? Name the thing you'd like to seal.",
+        "Close what? You slam an invisible door. Satisfying.",
+        "Close what? Specify something that can be closed."
+      ].freeze
+
+      TALK_TO_WHOM = [
+        "Talk to whom? The walls don't respond well to conversation.",
+        "Talk to whom? Your monologue needs an audience.",
+        "Talk to whom? Specify who you'd like to chat with.",
+        "Talk to whom? The dungeon is oddly quiet. Name someone.",
+        "Talk to whom? Even NPCs need to be addressed by name."
+      ].freeze
+
+      ATTACK_WHAT = [
+        "Attack what? You swing at the air heroically.",
+        "Attack what? Your battle cry echoes into the void.",
+        "Attack what? Specify a target before you strain something.",
+        "Attack what? Violence needs direction. Name something.",
+        "Attack what? The dungeon awaits your bloodthirsty specifics."
+      ].freeze
+    end
+  end
+end

--- a/app/lib/classic_game/handlers/combat_handler.rb
+++ b/app/lib/classic_game/handlers/combat_handler.rb
@@ -166,7 +166,7 @@ module ClassicGame
         end
 
         def handle_use_item(item_target)
-          return failure("Use what?") unless item_target
+          return failure(ClassicGame::FunnyResponses.use_what) unless item_target
 
           # Find the item in inventory
           item_id, item_def = find_item(item_target)

--- a/app/lib/classic_game/handlers/container_handler.rb
+++ b/app/lib/classic_game/handlers/container_handler.rb
@@ -17,7 +17,7 @@ module ClassicGame
       private
 
         def handle_open(target)
-          return failure("Open what?") unless target
+          return failure(ClassicGame::FunnyResponses.open_what) unless target
 
           # Find the container
           container_id, container_def = find_item(target)
@@ -73,7 +73,7 @@ module ClassicGame
         end
 
         def handle_close(target)
-          return failure("Close what?") unless target
+          return failure(ClassicGame::FunnyResponses.close_what) unless target
 
           # Find the container
           container_id, container_def = find_item(target)

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -29,7 +29,7 @@ module ClassicGame
         end
 
         def handle_examine(target)
-          return failure("Examine what?") unless target
+          return failure(ClassicGame::FunnyResponses.examine_what) unless target
 
           # Try to find in room items or open containers
           item_id, item_def = find_item(target)
@@ -69,10 +69,10 @@ module ClassicGame
 
           # Check if it's a room feature mentioned in description
           if current_room_def["description"]&.downcase&.include?(target)
-            return success("You see nothing special about that.")
+            return success(ClassicGame::FunnyResponses.nothing_special)
           end
 
-          failure("You don't see that here.")
+          failure(ClassicGame::FunnyResponses.dont_see_that)
         end
 
         def handle_examine_reveals_exit(item_def, base_description)

--- a/app/lib/classic_game/handlers/interact_handler.rb
+++ b/app/lib/classic_game/handlers/interact_handler.rb
@@ -26,7 +26,7 @@ module ClassicGame
           # "talk to X about Y" parses as target="" modifier="X about Y"
           npc_name, topic_name = resolve_talk_target(target, modifier)
 
-          return failure("Talk to whom?") if npc_name.blank?
+          return failure(ClassicGame::FunnyResponses.talk_to_whom) if npc_name.blank?
 
           npc_id, npc_def = find_npc(npc_name)
 
@@ -196,7 +196,7 @@ module ClassicGame
         end
 
         def handle_attack(target)
-          return failure("Attack what?") unless target
+          return failure(ClassicGame::FunnyResponses.attack_what) unless target
 
           # Find creature
           creature_id, creature_def = find_creature(target)

--- a/app/lib/classic_game/handlers/item_handler.rb
+++ b/app/lib/classic_game/handlers/item_handler.rb
@@ -19,14 +19,14 @@ module ClassicGame
       private
 
         def handle_take(target)
-          return failure("Take what?") unless target
+          return failure(ClassicGame::FunnyResponses.take_what) unless target
 
           # Find the item
           item_id, item_def = find_item(target)
-          return failure("You don't see that here.") unless item_def
+          return failure(ClassicGame::FunnyResponses.dont_see_that) unless item_def
 
           # Check if it's in the room (including containers)
-          return failure("You don't see that here.") unless item_in_room?(item_id)
+          return failure(ClassicGame::FunnyResponses.dont_see_that) unless item_in_room?(item_id)
 
           # Check if it's takeable
           return failure(item_def["cant_take_msg"] || "You can't take that.") unless item_def.fetch("takeable", true)
@@ -54,14 +54,14 @@ module ClassicGame
         end
 
         def handle_drop(target)
-          return failure("Drop what?") unless target
+          return failure(ClassicGame::FunnyResponses.drop_what) unless target
 
           # Find the item
           item_id, item_def = find_item(target)
-          return failure("You don't have that.") unless item_def
+          return failure(ClassicGame::FunnyResponses.dont_have_that) unless item_def
 
           # Check if player has it
-          return failure("You don't have that.") unless item?(item_id)
+          return failure(ClassicGame::FunnyResponses.dont_have_that) unless item?(item_id)
 
           # Remove from inventory
           new_player_state = player_state.dup
@@ -79,12 +79,12 @@ module ClassicGame
         end
 
         def handle_use(item_target, modifier)
-          return failure("Use what?") unless item_target
+          return failure(ClassicGame::FunnyResponses.use_what) unless item_target
 
           # Find the item
           item_id, item_def = find_item(item_target)
-          return failure("You don't have that item.") unless item_def
-          return failure("You don't have that item.") unless item?(item_id)
+          return failure(ClassicGame::FunnyResponses.dont_have_that) unless item_def
+          return failure(ClassicGame::FunnyResponses.dont_have_that) unless item?(item_id)
 
           # First check if using item on an exit (by direction or keyword)
           if modifier
@@ -101,7 +101,7 @@ module ClassicGame
           # Check if it has a use action
           use_action = item_def["on_use"]
 
-          return failure("You can't use that here.") if use_action.nil?
+          return failure(ClassicGame::FunnyResponses.cant_use_here) if use_action.nil?
 
           # Handle different types of use actions
           case use_action["type"]
@@ -115,7 +115,7 @@ module ClassicGame
             # For future: custom script execution
             failure("That doesn't do anything right now.")
           else
-            failure("You can't use that here.")
+            failure(ClassicGame::FunnyResponses.cant_use_here)
           end
         end
 

--- a/app/lib/classic_game/handlers/movement_handler.rb
+++ b/app/lib/classic_game/handlers/movement_handler.rb
@@ -5,11 +5,11 @@ module ClassicGame
     class MovementHandler < BaseHandler
       def handle(command)
         direction = command[:target]
-        return failure("Go where?") unless direction
+        return failure(ClassicGame::FunnyResponses.go_where) unless direction
 
         # Get exit from current room
         exit_data = current_room_def.dig("exits", direction.to_s) || current_room_def.dig("exits", direction.to_sym)
-        return failure("You can't go that way.") unless exit_data
+        return failure(ClassicGame::FunnyResponses.cant_go) unless exit_data
 
         # Handle simple string exit vs. complex exit object
         if exit_data.is_a?(String)
@@ -35,7 +35,7 @@ module ClassicGame
           # Check if exit is hidden and not yet revealed
           if hidden && direction && !game.exit_revealed?(player_state["current_room"], direction)
             # Check if it should be auto-revealed by flag
-            return failure("You can't go that way.") unless requires_flag && game.get_flag(requires_flag)
+            return failure(ClassicGame::FunnyResponses.cant_go) unless requires_flag && game.get_flag(requires_flag)
 
             game.reveal_exit(player_state["current_room"], direction)
           end

--- a/test/lib/classic_game/funny_responses_test.rb
+++ b/test/lib/classic_game/funny_responses_test.rb
@@ -13,7 +13,7 @@ class FunnyResponsesTest < ActiveSupport::TestCase
   end
 
   test "unknown_command varies across calls" do
-    results = 50.times.map { FunnyResponses.unknown_command("x") }.uniq
+    results = Array.new(50) { FunnyResponses.unknown_command("x") }.uniq
     assert results.size > 1, "Expected multiple unique responses but got only #{results.size}"
   end
 

--- a/test/lib/classic_game/funny_responses_test.rb
+++ b/test/lib/classic_game/funny_responses_test.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FunnyResponsesTest < ActiveSupport::TestCase
+  FunnyResponses = ClassicGame::FunnyResponses
+
+  test "unknown_command returns string containing raw input and key phrase" do
+    result = FunnyResponses.unknown_command("xyzzy")
+    assert_kind_of String, result
+    assert_includes result, "xyzzy"
+    assert_includes result.downcase, "don't understand"
+  end
+
+  test "unknown_command varies across calls" do
+    results = 50.times.map { FunnyResponses.unknown_command("x") }.uniq
+    assert results.size > 1, "Expected multiple unique responses but got only #{results.size}"
+  end
+
+  test "cant_go includes key phrase" do
+    result = FunnyResponses.cant_go
+    assert_kind_of String, result
+    assert_includes result.downcase, "can't go"
+  end
+
+  test "go_where includes key phrase" do
+    result = FunnyResponses.go_where
+    assert_kind_of String, result
+    assert_includes result.downcase, "go where"
+  end
+
+  test "take_what includes key phrase" do
+    result = FunnyResponses.take_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "take what"
+  end
+
+  test "drop_what includes key phrase" do
+    result = FunnyResponses.drop_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "drop what"
+  end
+
+  test "use_what includes key phrase" do
+    result = FunnyResponses.use_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "use what"
+  end
+
+  test "examine_what includes key phrase" do
+    result = FunnyResponses.examine_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "examine what"
+  end
+
+  test "open_what includes key phrase" do
+    result = FunnyResponses.open_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "open what"
+  end
+
+  test "close_what includes key phrase" do
+    result = FunnyResponses.close_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "close what"
+  end
+
+  test "talk_to_whom includes key phrase" do
+    result = FunnyResponses.talk_to_whom
+    assert_kind_of String, result
+    assert_includes result.downcase, "talk to whom"
+  end
+
+  test "attack_what includes key phrase" do
+    result = FunnyResponses.attack_what
+    assert_kind_of String, result
+    assert_includes result.downcase, "attack what"
+  end
+
+  test "dont_see_that includes key phrase" do
+    result = FunnyResponses.dont_see_that
+    assert_kind_of String, result
+    assert_includes result.downcase, "don't see"
+  end
+
+  test "dont_have_that includes key phrase" do
+    result = FunnyResponses.dont_have_that
+    assert_kind_of String, result
+    assert_includes result.downcase, "don't have"
+  end
+
+  test "cant_use_here includes key phrase" do
+    result = FunnyResponses.cant_use_here
+    assert_kind_of String, result
+    assert_includes result.downcase, "can't use"
+  end
+
+  test "nothing_special includes key phrase" do
+    result = FunnyResponses.nothing_special
+    assert_kind_of String, result
+    assert_includes result.downcase, "nothing special"
+  end
+
+  test "each pool has multiple entries" do
+    assert FunnyResponses::UNKNOWN_COMMAND.size >= 3
+    assert FunnyResponses::CANT_GO.size >= 3
+    assert FunnyResponses::GO_WHERE.size >= 3
+    assert FunnyResponses::TAKE_WHAT.size >= 3
+    assert FunnyResponses::DROP_WHAT.size >= 3
+    assert FunnyResponses::USE_WHAT.size >= 3
+    assert FunnyResponses::EXAMINE_WHAT.size >= 3
+    assert FunnyResponses::OPEN_WHAT.size >= 3
+    assert FunnyResponses::CLOSE_WHAT.size >= 3
+    assert FunnyResponses::TALK_TO_WHOM.size >= 3
+    assert FunnyResponses::ATTACK_WHAT.size >= 3
+    assert FunnyResponses::DONT_SEE_THAT.size >= 3
+    assert FunnyResponses::DONT_HAVE_THAT.size >= 3
+    assert FunnyResponses::CANT_USE_HERE.size >= 3
+    assert FunnyResponses::NOTHING_SPECIAL.size >= 3
+  end
+end


### PR DESCRIPTION
## Summary

- Created `ClassicGame::FunnyResponses` module with 15 pools of humorous response variants (5 per pool)
- Replaced all hardcoded engine error strings across 7 handler files with random calls to `FunnyResponses`
- Added unit tests validating every method returns a string with the required backward-compatible substring

## Implementation

The `FunnyResponses` module lives at `app/lib/classic_game/funny_responses.rb`. Each pool is a frozen constant array; each public class method calls `.sample` to pick a random variant. All variants preserve the key substrings that existing handler tests assert against (e.g. `"can't go"`, `"don't see"`, `"don't have"`, `"don't understand"`).

Files modified:
- `app/lib/classic_game/engine.rb` — unknown command response
- `app/lib/classic_game/handlers/movement_handler.rb` — go where / can't go
- `app/lib/classic_game/handlers/item_handler.rb` — take/drop/use prompts, don't see/have, can't use
- `app/lib/classic_game/handlers/examine_handler.rb` — examine what, nothing special, don't see
- `app/lib/classic_game/handlers/interact_handler.rb` — talk to whom, attack what
- `app/lib/classic_game/handlers/container_handler.rb` — open/close what
- `app/lib/classic_game/handlers/combat_handler.rb` — use what

## Test plan

- [x] `test/lib/classic_game/funny_responses_test.rb` — 17 unit tests covering every method and pool size
- [ ] CI runs full suite including existing handler tests and system tests

## Fix notes

- **`NameError: uninitialized constant ClassicGame::FunnyResponses::UNKNOWN_COMMAND`** — Constants were defined inside `class << self`, scoping them to the singleton class. Moved all 15 constant arrays to the module level so they're accessible as `FunnyResponses::CONSTANT_NAME` while keeping the class methods inside `class << self`.
- **RuboCop offenses (3)** — Extracted 8 object-prompt constants into `FunnyResponses::ObjectPrompts` submodule to fix `Metrics/ModuleLength` (124 > 100). Wrapped a long string to fix `Layout/LineLength` (121 > 120). Replaced `50.times.map` with `Array.new(50)` to fix `Performance/TimesMap`.
- **Missing constants (9 errors)** — Added 8 missing constant arrays (`TAKE_WHAT`, `DROP_WHAT`, `USE_WHAT`, `EXAMINE_WHAT`, `OPEN_WHAT`, `CLOSE_WHAT`, `TALK_TO_WHOM`, `ATTACK_WHAT`) that were referenced by methods and tests but never defined in the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)