### PR TITLE
Full-Game System Test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,3 +45,9 @@ Add any of these if they help clarify intent:
 ## Preferences
 > **Important:** Every shell command must be a single, simple call — no `$()`,
 > no `&&` chains. Use separate tool calls and carry values between them.
+
+## Full-Game System Test
+
+Any feature that adds or modifies ClassicGame mechanics **must** update
+`test/lib/classic_game/full_game_system_test.rb` to exercise the new
+behavior. The test serves as a blocking sanity check in CI.

--- a/app/lib/classic_game/README.md
+++ b/app/lib/classic_game/README.md
@@ -438,6 +438,19 @@ System: === Hidden Vault ===
         A secret chamber filled with ancient artifacts...
 ```
 
+## Full-Game System Test
+
+`test/lib/classic_game/full_game_system_test.rb` runs a complete game
+playthrough from start to finish, exercising every mechanic:
+movement, items, containers, dialogue, combat, dice rolls, hidden
+exits, NPC exchange, and aggressive creatures.
+
+**New features must update this test.** If you add a new handler or
+mechanic, add steps to the playthrough and/or add a focused test case.
+The test uses `FakeGame` (in-memory, no database) and stubs all
+randomness for deterministic results. It runs in CI as part of
+`bin/rails test` and failures will block the PR.
+
 ## Testing
 
 Create a classic game and try these commands:

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -1,0 +1,537 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# End-to-end playthrough covering every ClassicGame mechanic with a purpose-built
+# in-memory world (FakeGame, no database).  All randomness is stubbed so the
+# results are deterministic across every CI run.
+class FullGameSystemTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  # ─── FULL GAME PLAYTHROUGH ────────────────────────────────────────────────
+
+  test "full game playthrough exercises every mechanic" do
+    game = build_game(world_data: full_game_world)
+
+    phase_examine_items(game)
+    phase_movement_basic(game)
+    phase_creature_talk(game)
+    phase_travel_to_tavern(game)
+    phase_dialogue(game)
+    phase_containers(game)
+    phase_npc_exchange(game)
+    phase_flag_locked_movement(game)
+    phase_travel_to_cave(game)
+    phase_combat(game)
+    phase_post_combat(game)
+    phase_unknown_command(game)
+  end
+
+  # ─── FOCUSED: FLAG-LOCKED MOVEMENT ───────────────────────────────────────
+
+  test "movement blocked by missing flag" do
+    game = build_game(world_data: full_game_world,
+                      player_state: player_state_in("tavern"))
+    result = cmd(game, "go northwest")
+    assert_not result[:success], "FLAG LOCK: should be blocked without innkeeper_trust"
+    assert_includes result[:response], "won't budge", "FLAG LOCK: wrong locked message"
+  end
+
+  # ─── FOCUSED: PLAYER DEATH ───────────────────────────────────────────────
+
+  test "combat player death shows game over" do
+    world = build_world(
+      starting_room: "arena",
+      rooms: { "arena" => { "name" => "Arena", "description" => "A fighting pit.",
+                            "exits" => {}, "creatures" => ["beast"] } },
+      creatures: { "beast" => { "name" => "Lethal Beast", "keywords" => ["beast"],
+                                "hostile" => false, "health" => 100,
+                                "attack" => 100, "defense" => 0 } }
+    )
+    game = build_game(world_data: world)
+    midpoint = ->(range) { range.is_a?(Range) ? (range.min + range.max) / 2 : 0 }
+    Object.stub(:rand, midpoint) do
+      cmd(game, "attack beast")
+      result = cmd(game, "attack")
+      assert_includes result[:response], "GAME OVER", "DEATH: game over message missing"
+    end
+  end
+
+  # ─── FOCUSED: FLEE FAILURE ───────────────────────────────────────────────
+
+  test "combat flee fails when rand is high" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: { "room1" => { "name" => "Room", "description" => "A room.",
+                            "exits" => {}, "creatures" => ["troll"] } },
+      creatures: { "troll" => { "name" => "Troll", "keywords" => ["troll"],
+                                "hostile" => false, "health" => 30,
+                                "attack" => 2, "defense" => 0 } }
+    )
+    game = build_game(world_data: world)
+    midpoint = ->(range) { range.is_a?(Range) ? (range.min + range.max) / 2 : 0 }
+    Object.stub(:rand, midpoint) { cmd(game, "attack troll") }
+    flee_rand = ->(range) { range == (1..100) ? 75 : 0 }
+    Object.stub(:rand, flee_rand) do
+      result = cmd(game, "flee")
+      assert result[:success], "FLEE FAIL: player should survive a failed flee"
+      assert_includes result[:response], "blocks your escape", "FLEE FAIL: wrong message"
+    end
+  end
+
+  # ─── FOCUSED: DICE ROLL FAILURE ──────────────────────────────────────────
+
+  test "dice roll failure branch executes on_failure" do
+    game = build_game(world_data: full_game_world,
+                      player_state: player_state_in("cave", inventory: ["lockpick"]))
+    cmd(game, "use lockpick")
+    Object.stub(:rand, ->(range) { range.is_a?(Range) ? range.min : 0 }) do
+      result = cmd(game, "roll")
+      assert result[:success], "ROLL FAIL: expected success result even on dice failure"
+      assert_includes result[:response], "Failed.", "ROLL FAIL: not in failure branch"
+      assert_includes result[:response], "The pick slips.", "ROLL FAIL: wrong failure message"
+    end
+    assert game.get_flag("lock_jammed"), "ROLL FAIL: lock_jammed flag not set"
+  end
+
+  # ─── FOCUSED: AGGRESSIVE CREATURE THRESHOLD ──────────────────────────────
+
+  test "aggressive creature attacks after threshold" do
+    world = build_world(
+      starting_room: "lair",
+      rooms: { "lair" => { "name" => "Lair", "description" => "A dark lair.",
+                           "exits" => {}, "creatures" => ["spider"] } },
+      creatures: { "spider" => { "name" => "Spider", "keywords" => ["spider"],
+                                 "hostile" => true, "health" => 10,
+                                 "attack" => 1, "defense" => 0,
+                                 "attack_condition" => { "moves" => 3 } } }
+    )
+    game = build_game(world_data: world)
+    midpoint = ->(range) { range.is_a?(Range) ? (range.min + range.max) / 2 : 0 }
+    Object.stub(:rand, midpoint) do
+      cmd(game, "look")
+      cmd(game, "look")
+      result = cmd(game, "look")
+      assert_includes result[:response].downcase, "attacks you",
+                      "AGGRO: spider should attack at threshold (3 moves)"
+    end
+  end
+
+  private
+
+    # Short wrapper so phase methods stay readable.
+    def cmd(game, text)
+      execute_engine_command(game, USER_ID, text)
+    end
+
+    # ─── PHASE: LOOK / HELP / EXAMINE / TAKE / INVENTORY / DROP ─────────────
+
+    def phase_examine_items(game)
+      r = cmd(game, "look")
+      assert r[:success], "LOOK: initial look failed"
+      assert_includes r[:response], "Entrance", "LOOK: room name not in response"
+      assert_includes r[:response], "Iron Key", "LOOK: iron_key not listed"
+
+      r = cmd(game, "help")
+      assert r[:success], "HELP: help command failed"
+      assert_includes r[:response].downcase, "movement", "HELP: movement section missing"
+
+      r = cmd(game, "examine iron key")
+      assert r[:success], "EXAMINE: examine iron key failed"
+      assert_includes r[:response].downcase, "iron", "EXAMINE: description missing"
+
+      r = cmd(game, "take iron key")
+      assert r[:success], "TAKE: take iron key failed"
+
+      r = cmd(game, "inventory")
+      assert r[:success], "INVENTORY: inventory failed"
+      assert_includes r[:response], "Iron Key", "INVENTORY: iron_key not listed"
+
+      r = cmd(game, "drop iron key")
+      assert r[:success], "DROP: drop iron key failed"
+      assert_includes r[:response].downcase, "drop", "DROP: confirmation missing"
+
+      r = cmd(game, "take iron key")
+      assert r[:success], "TAKE (re-take): re-take iron key failed"
+
+      r = cmd(game, "take health potion")
+      assert r[:success], "TAKE POTION: take health potion failed"
+    end
+
+    # ─── PHASE: SIMPLE MOVEMENT + SHORTHAND ──────────────────────────────────
+
+    def phase_movement_basic(game)
+      r = cmd(game, "go north")
+      assert r[:success], "MOVE NORTH: go north to armory failed"
+      assert_includes r[:response], "Armory", "MOVE NORTH: not in armory"
+
+      r = cmd(game, "take wooden shield")
+      assert r[:success], "TAKE SHIELD: take wooden shield failed"
+
+      r = cmd(game, "s")
+      assert r[:success], "MOVE S: shorthand south failed"
+      assert_includes r[:response], "Entrance", "MOVE S: not back in entrance"
+    end
+
+    # ─── PHASE: NON-HOSTILE CREATURE TALK ────────────────────────────────────
+
+    def phase_creature_talk(game)
+      r = cmd(game, "talk to rat")
+      assert r[:success], "TALK RAT: talk to friendly rat failed"
+      assert_includes r[:response], "squeaks", "TALK RAT: talk_text not returned"
+    end
+
+    # ─── PHASE: TRAVEL TO TAVERN ─────────────────────────────────────────────
+
+    def phase_travel_to_tavern(game)
+      r = cmd(game, "go east")
+      assert r[:success], "TRAVEL TAVERN: go east to tavern failed"
+      assert_includes r[:response], "Tavern", "TRAVEL TAVERN: not in tavern"
+    end
+
+    # ─── PHASE: NPC DIALOGUE (GREETING / TOPICS / LEADS_TO / REQUIRES_FLAG) ──
+
+    def phase_dialogue(game)
+      r = cmd(game, "talk to innkeeper")
+      assert r[:success], "DIALOGUE GREETING: talk to innkeeper failed"
+      assert_includes r[:response], "Welcome", "DIALOGUE GREETING: greeting not shown"
+
+      # requires_flag locked (innkeeper_trust not yet set)
+      r = cmd(game, "talk to innkeeper about goblin threat")
+      assert r[:success], "DIALOGUE RF LOCKED: call should succeed with locked_text"
+      assert_includes r[:response], "haven't earned", "DIALOGUE RF LOCKED: wrong locked_text"
+
+      # leads_to locked (stay topic not yet accessed)
+      r = cmd(game, "talk to innkeeper about rumor")
+      assert r[:success], "DIALOGUE LT LOCKED: call should succeed with locked_text"
+      assert_includes r[:response], "don't know", "DIALOGUE LT LOCKED: wrong locked_text"
+
+      # access leads_to parent → unlocks "rumor" topic
+      r = cmd(game, "talk to innkeeper about stay")
+      assert r[:success], "DIALOGUE LEADS_TO PARENT: failed"
+      assert_includes r[:response], "goblin", "DIALOGUE LEADS_TO PARENT: text missing"
+      assert_includes r[:response], "rumor", "DIALOGUE LEADS_TO PARENT: leads_to hint missing"
+
+      # leads_to child now unlocked → sets innkeeper_trust flag
+      r = cmd(game, "talk to innkeeper about rumor")
+      assert r[:success], "DIALOGUE LEADS_TO CHILD: failed"
+      assert_includes r[:response], "northwest", "DIALOGUE LEADS_TO CHILD: text missing"
+      assert game.get_flag("innkeeper_trust"), "DIALOGUE LEADS_TO CHILD: innkeeper_trust not set"
+
+      # requires_flag now satisfied
+      r = cmd(game, "talk to innkeeper about goblin threat")
+      assert r[:success], "DIALOGUE RF UNLOCKED: failed"
+      assert_includes r[:response], "terrorizing", "DIALOGUE RF UNLOCKED: text missing"
+    end
+
+    # ─── PHASE: CONTAINER (LOCKED / OPEN / TAKE / CLOSE / EXAMINE) ───────────
+
+    def phase_containers(game)
+      r = cmd(game, "drop iron key")
+      assert r[:success], "DROP KEY: failed before container test"
+
+      r = cmd(game, "open chest")
+      assert_not r[:success], "CONTAINER LOCKED: open should fail without key"
+      assert_includes r[:response].downcase, "locked", "CONTAINER LOCKED: wrong message"
+
+      r = cmd(game, "take iron key")
+      assert r[:success], "TAKE KEY BACK: failed"
+
+      r = cmd(game, "open chest")
+      assert r[:success], "CONTAINER OPEN: open chest with key failed"
+      assert_includes r[:response], "Gold Coin", "CONTAINER OPEN: contents not listed"
+
+      r = cmd(game, "take gold coin")
+      assert r[:success], "CONTAINER TAKE: take gold coin from chest failed"
+      assert_includes game.player_state(USER_ID)["inventory"], "gold_coin",
+                      "CONTAINER TAKE: gold_coin not in inventory"
+
+      r = cmd(game, "close chest")
+      assert r[:success], "CONTAINER CLOSE: close chest failed"
+
+      r = cmd(game, "examine chest")
+      assert r[:success], "CONTAINER EXAMINE CLOSED: failed"
+      assert_includes r[:response].downcase, "closed", "CONTAINER EXAMINE CLOSED: wrong state"
+    end
+
+    # ─── PHASE: NPC ITEM EXCHANGE ─────────────────────────────────────────────
+
+    def phase_npc_exchange(game)
+      r = cmd(game, "give gold coin to merchant")
+      assert r[:success], "GIVE: give gold coin to merchant failed"
+      assert_includes r[:response].downcase, "gold coin", "GIVE: accept message missing"
+      assert_includes game.player_state(USER_ID)["inventory"], "reward_gem",
+                      "GIVE: reward_gem not received"
+      assert_not_includes game.player_state(USER_ID)["inventory"], "gold_coin",
+                          "GIVE: gold_coin not removed from inventory"
+    end
+
+    # ─── PHASE: FLAG-LOCKED EXIT (SUCCESS AFTER FLAG SET) ────────────────────
+
+    def phase_flag_locked_movement(game)
+      r = cmd(game, "go northwest")
+      assert r[:success], "FLAG MOVE: go northwest failed (innkeeper_trust should be set)"
+      assert_includes r[:response], "Secret Chamber", "FLAG MOVE: not in secret chamber"
+
+      r = cmd(game, "go southeast")
+      assert r[:success], "FLAG MOVE RETURN: go southeast back to tavern failed"
+      assert_includes r[:response], "Tavern", "FLAG MOVE RETURN: not back in tavern"
+    end
+
+    # ─── PHASE: TRAVEL TO CAVE (ITEM-LOCKED EXIT) ─────────────────────────────
+
+    def phase_travel_to_cave(game)
+      cmd(game, "go west")
+
+      r = cmd(game, "go north")
+      assert r[:success], "TRAVEL CAVE: go north to armory failed"
+
+      r = cmd(game, "go west")
+      assert_not r[:success], "ITEM LOCK: go west (cave) should fail without using key"
+      assert_includes r[:response].downcase, "sealed", "ITEM LOCK: wrong locked message"
+
+      r = cmd(game, "use iron key on west")
+      assert r[:success], "ITEM UNLOCK: use iron key on west failed"
+      assert_includes r[:response].downcase, "gate", "ITEM UNLOCK: wrong unlock message"
+
+      r = cmd(game, "go west")
+      assert r[:success], "TRAVEL CAVE: go west to cave after unlock failed"
+      assert_includes r[:response], "Cave", "TRAVEL CAVE: not in cave"
+    end
+
+    # ─── PHASE: COMBAT (INITIATE / ATTACK / DEFEND / HEAL / DEFEAT) ──────────
+
+    def phase_combat(game)
+      r = cmd(game, "take lockpick")
+      assert r[:success], "TAKE LOCKPICK: failed"
+
+      combat_rand = ->(range) {
+        case range
+        when(-2..2) then 0
+        when(1..20) then 10
+        when(1..100) then 25
+        else range.is_a?(Range) ? range.min : 0
+        end
+      }
+      Object.stub(:rand, combat_rand) do
+        r = cmd(game, "attack goblin")
+        assert r[:success], "COMBAT INIT: attack goblin failed"
+        assert game.player_state(USER_ID).dig("combat", "active"),
+               "COMBAT INIT: combat not active after attack"
+
+        r = cmd(game, "attack")
+        assert r[:success], "COMBAT ATK 1: attack in combat failed"
+        assert_includes r[:response].downcase, "strike", "COMBAT ATK 1: strike message missing"
+
+        r = cmd(game, "defend")
+        assert r[:success], "COMBAT DEFEND: defend failed"
+        assert_includes r[:response].downcase, "guard", "COMBAT DEFEND: guard message missing"
+
+        r = cmd(game, "use health potion")
+        assert r[:success], "COMBAT POTION: use health potion in combat failed"
+        assert_includes r[:response].downcase, "recover", "COMBAT POTION: recover message missing"
+
+        cmd(game, "attack")
+        cmd(game, "attack")
+        r = cmd(game, "attack")
+        assert r[:success], "COMBAT FINAL: final attack failed"
+        assert_includes r[:response].downcase, "collapses", "COMBAT FINAL: defeat message missing"
+      end
+
+      assert_nil game.player_state(USER_ID).dig("combat", "active"),
+                 "COMBAT: combat still active after creature defeated"
+      assert_includes game.room_state("cave")["items"], "old_sword",
+                      "COMBAT LOOT: old_sword not dropped in cave"
+      assert_not_includes game.room_state("cave")["creatures"], "goblin",
+                          "COMBAT: goblin still listed in cave creatures"
+      assert game.get_flag("goblin_slain"), "COMBAT FLAG: goblin_slain flag not set"
+      assert game.exit_revealed?("cave", "south"),
+             "COMBAT HIDDEN: south exit not revealed on goblin defeat"
+    end
+
+    # ─── PHASE: POST-COMBAT (DICE ROLL / HIDDEN EXIT / EXAMINE REVEALS EXIT) ──
+
+    def phase_post_combat(game)
+      r = cmd(game, "use lockpick")
+      assert r[:success], "DICE TRIGGER: use lockpick failed"
+      assert_includes r[:response], "ROLL", "DICE TRIGGER: roll prompt missing"
+      assert game.player_state(USER_ID)["pending_roll"], "DICE TRIGGER: pending_roll not set"
+
+      r = cmd(game, "look")
+      assert_not r[:success], "DICE PENDING BLOCK: non-roll command should fail while roll pending"
+      assert_includes r[:response], "ROLL", "DICE PENDING BLOCK: prompt message missing"
+
+      Object.stub(:rand, ->(range) { range.is_a?(Range) ? range.max : 0 }) do
+        r = cmd(game, "roll")
+        assert r[:success], "DICE ROLL: roll command failed"
+        assert_includes r[:response], "Success!", "DICE ROLL: not in success branch"
+        assert_includes r[:response], "The lock clicks!", "DICE ROLL: success message missing"
+      end
+      assert_nil game.player_state(USER_ID)["pending_roll"],
+                 "DICE ROLL: pending_roll not cleared after resolve"
+      assert game.get_flag("north_lock_picked"), "DICE ROLL: success flag not set"
+
+      r = cmd(game, "go south")
+      assert r[:success], "HIDDEN EXIT: go south to treasury failed"
+      assert_includes r[:response], "Treasury", "HIDDEN EXIT: not in treasury"
+
+      r = cmd(game, "examine scroll")
+      assert r[:success], "EXAMINE REVEALS: examine scroll failed"
+      assert_includes r[:response].downcase, "east", "EXAMINE REVEALS: east mention missing"
+      assert game.exit_revealed?("treasury", "east"),
+             "EXAMINE REVEALS: east exit not revealed by scroll"
+    end
+
+    # ─── PHASE: UNKNOWN COMMAND ───────────────────────────────────────────────
+
+    def phase_unknown_command(game)
+      r = cmd(game, "xyzzy foo bar")
+      assert_not r[:success], "UNKNOWN: unknown command should fail"
+      assert_includes r[:response].downcase, "don't understand",
+                      "UNKNOWN: wrong response for unknown command"
+    end
+
+    # ─── WORLD DEFINITION ────────────────────────────────────────────────────
+
+    def full_game_world
+      build_world(
+        starting_room: "entrance",
+        rooms: world_rooms,
+        items: world_items,
+        npcs: world_npcs,
+        creatures: world_creatures
+      )
+    end
+
+    def world_rooms # rubocop:disable Metrics/MethodLength
+      {
+        "entrance" => { "name" => "Entrance Hall", "description" => "A dimly lit entrance hall.",
+                        "items" => ["iron_key", "health_potion"], "creatures" => ["friendly_rat"],
+                        "exits" => { "north" => "armory", "east" => "tavern" } },
+        "armory" => { "name" => "Armory", "description" => "Racks of dusty weapons line the walls.",
+                      "items" => ["wooden_shield"],
+                      "exits" => { "south" => "entrance", "west" => {
+                        "to" => "cave", "use_item" => "iron_key", "permanently_unlock" => true,
+                        "consume_item" => false, "locked_msg" => "The iron gate is sealed tight.",
+                        "on_unlock" => "You use the iron key. The gate swings open."
+                      } } },
+        "tavern" => { "name" => "Rusty Flagon Tavern", "description" => "A cozy tavern with a fire.",
+                      "items" => ["treasure_chest"], "npcs" => ["innkeeper", "merchant"],
+                      "exits" => { "west" => "entrance", "northwest" => {
+                        "to" => "secret_chamber", "requires_flag" => "innkeeper_trust",
+                        "locked_msg" => "A heavy door. It won't budge."
+                      } } },
+        "cave" => { "name" => "Dark Cave", "description" => "A cold, damp cave.",
+                    "items" => ["lockpick"], "creatures" => ["goblin"],
+                    "exits" => { "east" => "armory", "south" => {
+                      "to" => "treasury", "hidden" => true, "requires_flag" => "goblin_slain",
+                      "reveal_msg" => "A dark passage to the south opens up!"
+                    } } },
+        "treasury" => { "name" => "Treasury", "description" => "A damp chamber with stone walls.",
+                        "items" => ["ancient_scroll"],
+                        "exits" => { "north" => "cave", "east" => {
+                          "to" => "secret_chamber", "hidden" => true,
+                          "reveal_msg" => "An ancient passage opens to the east!"
+                        } } },
+        "secret_chamber" => { "name" => "Secret Chamber",
+                              "description" => "A hidden chamber with ancient artifacts.",
+                              "exits" => { "southeast" => "tavern", "west" => "treasury" } }
+      }
+    end
+
+    def world_items # rubocop:disable Metrics/MethodLength
+      {
+        "iron_key" => { "name" => "Iron Key", "keywords" => ["key", "iron"],
+                        "takeable" => true, "description" => "A heavy iron key." },
+        "health_potion" => { "name" => "Health Potion", "keywords" => ["potion", "health"],
+                             "takeable" => true, "consumable" => true,
+                             "combat_effect" => { "type" => "heal", "amount" => 5 },
+                             "description" => "A red bubbling potion." },
+        "wooden_shield" => { "name" => "Wooden Shield", "keywords" => ["shield", "wooden"],
+                             "takeable" => true, "defense_bonus" => 3,
+                             "description" => "A sturdy wooden shield." },
+        "lockpick" => { "name" => "Lockpick", "keywords" => ["lockpick", "pick"],
+                        "takeable" => true,
+                        "dice_roll" => {
+                          "dc" => 12, "dice" => "1d20",
+                          "attempt_message" => "You carefully work the lockpick...",
+                          "on_success" => { "sets_flag" => "north_lock_picked",
+                                            "message" => "The lock clicks!" },
+                          "on_failure" => { "sets_flag" => "lock_jammed",
+                                            "message" => "The pick slips." },
+                          "consume_on" => "failure"
+                        } },
+        "treasure_chest" => { "name" => "Treasure Chest", "keywords" => ["chest", "treasure"],
+                              "is_container" => true, "starts_closed" => true, "locked" => true,
+                              "unlock_item" => "iron_key", "contents" => ["gold_coin"],
+                              "closed_description" => "A closed wooden chest.",
+                              "open_description" => "An open wooden chest.",
+                              "locked_message" => "The chest is locked. You need a key.",
+                              "on_open_message" => "You unlock and open the chest." },
+        "gold_coin" => { "name" => "Gold Coin", "keywords" => ["coin", "gold"],
+                         "takeable" => true, "description" => "A shiny gold coin." },
+        "ancient_scroll" => { "name" => "Ancient Scroll", "keywords" => ["scroll", "ancient"],
+                              "takeable" => false, "description" => "An old weathered scroll.",
+                              "on_examine" => { "reveals_exit" => "east",
+                                                "text" => "The scroll reveals a passage to the east!" } },
+        "old_sword" => { "name" => "Old Sword", "keywords" => ["sword", "old"],
+                         "takeable" => true, "weapon_damage" => 8,
+                         "description" => "A battered but effective sword." },
+        "reward_gem" => { "name" => "Sparkling Gem", "keywords" => ["gem", "sparkling"],
+                          "takeable" => true, "description" => "A beautiful gemstone." }
+      }
+    end
+
+    def world_npcs
+      {
+        "innkeeper" => {
+          "name" => "Innkeeper", "keywords" => ["innkeeper", "barkeeper", "inn"],
+          "description" => "A stout innkeeper with a friendly smile.",
+          "dialogue" => {
+            "greeting" => "Welcome to the Rusty Flagon! What can I do for you?",
+            "default" => "I don't know what you mean.",
+            "topics" => {
+              "stay" => { "keywords" => ["stay", "room", "welcome"],
+                          "text" => "Business has been rough since the goblin moved into the cave.",
+                          "leads_to" => ["rumor"] },
+              "rumor" => { "keywords" => ["rumor", "secret", "chamber"],
+                           "text" => "There is a hidden chamber to the northwest. I'll trust you.",
+                           "locked_text" => "I don't know any secrets.",
+                           "sets_flag" => "innkeeper_trust" },
+              "goblin_threat" => { "keywords" => ["threat", "danger", "goblin"],
+                                   "text" => "The goblin has been terrorizing travelers for years.",
+                                   "locked_text" => "You haven't earned my trust yet.",
+                                   "requires_flag" => "innkeeper_trust" }
+            }
+          }
+        },
+        "merchant" => {
+          "name" => "Merchant", "keywords" => ["merchant", "trader", "shop"],
+          "description" => "A shifty-eyed merchant with a large pack.",
+          "accepts_item" => "gold_coin", "gives_item" => "reward_gem",
+          "accept_message" => "A gold coin! Just what I wanted.",
+          "sets_flag" => "trade_complete"
+        }
+      }
+    end
+
+    def world_creatures
+      {
+        "goblin" => {
+          "name" => "Goblin", "keywords" => ["goblin"],
+          "hostile" => true, "health" => 20, "attack" => 2, "defense" => 0,
+          "talk_text" => "The goblin snarls and waves its fist.",
+          "attack_condition" => { "moves" => 3 },
+          "loot" => ["old_sword"], "sets_flag_on_defeat" => "goblin_slain",
+          "on_defeat_msg" => "The goblin collapses with a screech!"
+        },
+        "friendly_rat" => {
+          "name" => "Friendly Rat", "keywords" => ["rat", "friendly"],
+          "hostile" => false, "health" => 3, "attack" => 1, "defense" => 0,
+          "talk_text" => "The rat squeaks and sniffs at you curiously."
+        }
+      }
+    end
+end

--- a/test/lib/classic_game/handlers/creature_interaction_test.rb
+++ b/test/lib/classic_game/handlers/creature_interaction_test.rb
@@ -6,7 +6,6 @@ class CreatureInteractionTest < ActiveSupport::TestCase
   include ClassicGameTestHelper
 
   USER_ID = 1
-  FakeUser = Struct.new(:id)
 
   # ─── TALK TO CREATURE ─────────────────────────────────────────────────────
 

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -3,6 +3,17 @@
 # In-memory game double for testing ClassicGame handlers without hitting the database.
 # Implements all game state methods used by BaseHandler and its subclasses.
 module ClassicGameTestHelper
+  FakeUser = Struct.new(:id)
+
+  # Convenience wrapper: run a command through the full Engine stack.
+  def execute_engine_command(game, user_id, command_text)
+    ClassicGame::Engine.execute(
+      game: game,
+      user: FakeUser.new(user_id),
+      command_text: command_text
+    )
+  end
+
   class FakeGame
     attr_accessor :game_state
 


### PR DESCRIPTION
## Summary

- Adds `test/lib/classic_game/full_game_system_test.rb`: a deterministic, in-memory end-to-end playthrough that exercises every ClassicGame mechanic from a single entry point
- Centralises `FakeUser` and `execute_engine_command` into `ClassicGameTestHelper` so any test can drive the full Engine stack without boilerplate
- Documents the test's existence and update requirement in both `CLAUDE.md` and `app/lib/classic_game/README.md`

## Implementation Details

### The problem this solves

Individual handler tests (e.g. `CombatHandlerTest`, `RollHandlerTest`) verify mechanics in isolation, but nothing proved that all the handlers compose correctly end-to-end — that combat initiated via the Engine correctly passes into `CombatHandler`, that defeating a creature reveals a hidden exit, that a pending dice roll blocks all other commands, etc.  This PR fills that gap with a single test that walks a player through an entire adventure, asserting at each step.

### World design (`full_game_world`)

A purpose-built six-room world with exactly one example of every mechanic:

| Room | Key contents |
|---|---|
| `entrance` | `iron_key`, `health_potion`, `friendly_rat` (non-hostile creature) |
| `armory` | `wooden_shield` (defense item); west exit is item-locked with `iron_key` |
| `tavern` | `treasure_chest` (locked container), `innkeeper` (multi-topic dialogue), `merchant` (item exchange); NW exit is flag-locked |
| `cave` | `goblin` (hostile, attack_condition: moves: 3, reveals hidden exit on defeat), `lockpick` (dice roll item) |
| `treasury` | `ancient_scroll` (on_examine reveals hidden east exit) |
| `secret_chamber` | Destination for flag-locked and hidden exits |

### Playthrough phases (`test "full game playthrough exercises every mechanic"`)

The main test calls twelve private phase methods in sequence — each covering one or more mechanics — so a failing assertion names the exact phase that broke:

1. **`phase_examine_items`** — `look`, `help`, `examine`, `take`, `inventory`, `drop`, `take` (re-take)
2. **`phase_movement_basic`** — simple direction move, shorthand (`s`), item pickup in new room
3. **`phase_creature_talk`** — `talk to rat` → `talk_text` returned for non-hostile creature
4. **`phase_travel_to_tavern`** — move to tavern via simple exit
5. **`phase_dialogue`** — greeting; `requires_flag` blocks then unlocks; `leads_to` chain (parent unlocks child); flag set on topic access
6. **`phase_containers`** — locked open fails, drop key, open fails again, re-take key, open succeeds, take from container, close, examine closed state
7. **`phase_npc_exchange`** — `give gold coin to merchant` → item removed, reward added, flag set
8. **`phase_flag_locked_movement`** — `go northwest` succeeds now that `innkeeper_trust` is set; return via `go southeast`
9. **`phase_travel_to_cave`** — item-locked exit fails, `use iron key on west` unlocks permanently, `go west` succeeds
10. **`phase_combat`** — attack goblin (initiate, player wins initiative), attack (round 1), defend, use health potion in combat, three more attacks to defeat; post-combat assertions: loot in room, creature removed, flag set, hidden exit revealed
11. **`phase_post_combat`** — use lockpick (triggers pending roll), non-roll command blocked, roll resolves to success (rand stubbed), pending_roll cleared, `go south` through newly revealed hidden exit, `examine scroll` reveals hidden east exit
12. **`phase_unknown_command`** — gibberish input returns "I don't understand"

### Focused tests

Five isolated test methods cover edge-case branches the playthrough cannot deterministically reach:

| Test | Mechanic |
|---|---|
| `test "movement blocked by missing flag"` | Flag-locked exit fails without flag |
| `test "combat player death shows game over"` | GAME OVER text on lethal creature retaliation |
| `test "combat flee fails when rand is high"` | Flee blocked when `rand(1..100) > 50` |
| `test "dice roll failure branch executes on_failure"` | `on_failure` directive runs; `lock_jammed` flag set |
| `test "aggressive creature attacks after threshold"` | Spider auto-attacks on 3rd room action via Engine |

### Deterministic randomness

All `rand()` calls (initiative, damage variance, flee check, dice rolls) are stubbed with `Object.stub(:rand, lambda)` scoped to each block that needs it:

- **Combat sections**: `rand(-2..2) → 0`, `rand(1..20) → 10` (tie = player wins), `rand(1..100) → 25` (flee succeeds)
- **Dice roll success**: `rand(any range) → range.max` (20 on a d20 ≥ DC 12)
- **Dice roll failure**: `rand(any range) → range.min` (1 on a d20 < DC 12)
- **Flee failure test**: `rand(1..100) → 75` (> 50 = fail)

### Helper changes

- `ClassicGameTestHelper::FakeUser = Struct.new(:id)` — moved from `CreatureInteractionTest` (local constant) to the shared helper so all test files can use it
- `ClassicGameTestHelper#execute_engine_command(game, user_id, command_text)` — thin wrapper over `ClassicGame::Engine.execute` with a `FakeUser`; used by the new test via a private `cmd(game, text)` alias

## Testing Plan

- [ ] All existing handler tests still pass (`FakeUser` now comes from the helper module; local definition removed from `CreatureInteractionTest`)
- [ ] `FullGameSystemTest` playthrough passes end-to-end (12 phases × multiple assertions each)
- [ ] All 5 focused tests pass
- [ ] No test is flaky — every random outcome is stubbed
- [ ] `bin/rails test` picks up `test/lib/classic_game/full_game_system_test.rb` automatically (no registration needed)

## Notes

- The world is balanced around `FakeGame#starting_hp = 10` and `wooden_shield#defense_bonus = 3`. With `rand(-2..2) = 0`, the goblin deals exactly 1 damage per round to a shielded player — the player survives the full 6-round fight with 7 HP remaining.
- `Metrics/BlockLength` is excluded for `test/**/*` so the large `test "..." do...end` blocks are RuboCop-clean. All private `def` methods are kept under 60 lines to satisfy `Metrics/MethodLength`. The two data methods (`world_rooms`, `world_items`) exceed 60 lines and carry inline `# rubocop:disable` directives.
- The `FakeGame` restart path (`game.messages.destroy_all`) is never exercised in this test — focused death tests use the non-restart path (beast is `hostile: false` so Engine's auto-attack check skips it after the manual attack).