### PR TITLE
Full-Game System Test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,10 @@ Add any of these if they help clarify intent:
 2. **`/plan-feature`** — reads the spec, explores the codebase, writes an implementation plan
 3. **`/implement-feature`** — writes tests first, implements, runs full suite, marks PR ready
 
+## Full-Game System Test
+
+The file `test/lib/classic_game/full_game_system_test.rb` is a comprehensive end-to-end playthrough test that exercises every game mechanic. When adding or modifying classic game features, update this test to cover the new behavior.
+
 ## Preferences
 > **Important:** Every shell command must be a single, simple call — no `$()`,
 > no `&&` chains. Use separate tool calls and carry values between them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,9 @@ Add any of these if they help clarify intent:
 
 ## Full-Game System Test
 
-The file `test/lib/classic_game/full_game_system_test.rb` is a comprehensive end-to-end playthrough test that exercises every game mechanic. When adding or modifying classic game features, update this test to cover the new behavior.
+The file `test/lib/classic_game/full_game_system_test.rb` is a comprehensive end-to-end playthrough test that exercises every game mechanic. When adding or modifying classic game features, update this test to cover the new behavior. Run it with:
+
+    bin/rails test test/lib/classic_game/full_game_system_test.rb
 
 ## Preferences
 > **Important:** Every shell command must be a single, simple call — no `$()`,

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -10,7 +10,7 @@ require "test_helper"
 #   - Troll HP: 1  (dies on any hit; min player damage is 1)
 #   - Dice roll DC: 1  (1d20 minimum is 1, so roll always succeeds)
 #   - srand(42) wraps the test for repeatable rand sequences
-class FullGameSystemTest < ActiveSupport::TestCase
+class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
   include ClassicGameTestHelper
 
   FakeUser = Struct.new(:id)
@@ -53,7 +53,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
       )
     end
 
-    def rooms_data # rubocop:disable Metrics/MethodLength
+    def rooms_data
       {
         "entrance" => {
           "name" => "Entrance Hall",
@@ -70,7 +70,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
         "storeroom" => {
           "name" => "Storeroom",
           "description" => "A dusty storeroom with shelves.",
-          "items" => ["supply_crate", "lockpick"],
+          "items" => %w[supply_crate lockpick],
           "exits" => { "west" => "entrance" }
         },
         "cave" => {
@@ -112,36 +112,36 @@ class FullGameSystemTest < ActiveSupport::TestCase
           "takeable" => true, "description" => "A tarnished old key."
         },
         "gem" => {
-          "name" => "Glowing Gem", "keywords" => ["gem", "glowing"],
+          "name" => "Glowing Gem", "keywords" => %w[gem glowing],
           "takeable" => true, "description" => "It pulsates with inner light."
         },
         "enchanted_blade" => {
-          "name" => "Enchanted Blade", "keywords" => ["blade", "sword", "enchanted"],
+          "name" => "Enchanted Blade", "keywords" => %w[blade sword enchanted],
           "takeable" => true, "weapon_damage" => 3,
           "description" => "A blade humming with magic."
         },
         "scroll" => {
-          "name" => "Ancient Scroll", "keywords" => ["scroll", "ancient"],
+          "name" => "Ancient Scroll", "keywords" => %w[scroll ancient],
           "takeable" => true, "description" => "Yellowed parchment covered in runes.",
           "on_use" => { "type" => "message", "text" => "The scroll speaks of ancient prophecies." }
         },
         "victory_crown" => {
-          "name" => "Victory Crown", "keywords" => ["crown", "victory"],
+          "name" => "Victory Crown", "keywords" => %w[crown victory],
           "takeable" => true, "description" => "The crown of the realm."
         }
       }
     end
 
-    def complex_items # rubocop:disable Metrics/MethodLength
+    def complex_items
       {
         "health_potion" => {
-          "name" => "Health Potion", "keywords" => ["potion", "health"],
+          "name" => "Health Potion", "keywords" => %w[potion health],
           "takeable" => true, "consumable" => true,
           "description" => "A red potion that restores health.",
           "combat_effect" => { "type" => "heal", "amount" => 5 }
         },
         "lockpick" => {
-          "name" => "Lockpick", "keywords" => ["lockpick", "pick"],
+          "name" => "Lockpick", "keywords" => %w[lockpick pick],
           "takeable" => true, "description" => "A slender metal pick.",
           "dice_roll" => {
             "dc" => 1, "dice" => "1d20",
@@ -153,7 +153,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
           }
         },
         "supply_crate" => {
-          "name" => "Supply Crate", "keywords" => ["crate", "supply", "chest"],
+          "name" => "Supply Crate", "keywords" => %w[crate supply chest],
           "is_container" => true, "starts_closed" => true,
           "locked" => true, "unlock_item" => "old_key",
           "contents" => ["health_potion"],
@@ -170,7 +170,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
       { "guide" => guide_data, "wizard" => wizard_data }
     end
 
-    def guide_data # rubocop:disable Metrics/MethodLength
+    def guide_data
       {
         "name" => "Guide", "keywords" => ["guide"],
         "description" => "A helpful traveler who knows the area.",
@@ -179,7 +179,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
           "sets_flag" => "spoke_to_guide",
           "topics" => {
             "directions" => {
-              "keywords" => ["directions", "direction"],
+              "keywords" => %w[directions direction],
               "text" => "Head north for the tower, south for the cave.",
               "leads_to" => ["secret"]
             },
@@ -270,7 +270,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
     end
 
     # Phase 3: take, container locking, open with key, close, drop/take, use absent item
-    def phase_items_containers(game, user) # rubocop:disable Metrics/MethodLength
+    def phase_items_containers(game, user)
       r = ex(game, user, "go east")
       assert_includes r[:response], "Storeroom", "PHASE 3: should move to storeroom"
 
@@ -359,7 +359,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
     end
 
     # Phase 6: enter cave, talk (no aggro), two looks (aggro on 4th action), combat, loot
-    def phase_combat(game, user) # rubocop:disable Metrics/MethodLength
+    def phase_combat(game, user)
       r = ex(game, user, "go south")
       assert_includes r[:response], "Dark Cave", "PHASE 6: should enter the cave"
       assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat yet after entering"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -1,0 +1,450 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Comprehensive end-to-end playthrough of a purpose-built 5-room world.
+# Routes every command through ClassicGame::Engine to exercise the full stack:
+# aggressive-creature checks, pending-roll routing, and all handler dispatch paths.
+#
+# Design choices for determinism:
+#   - Troll HP: 1  (dies on any hit; min player damage is 1)
+#   - Dice roll DC: 1  (1d20 minimum is 1, so roll always succeeds)
+#   - srand(42) wraps the test for repeatable rand sequences
+class FullGameSystemTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  FakeUser = Struct.new(:id)
+  USER_ID = 42
+
+  test "full game playthrough" do
+    world = build_full_game_world
+    game  = build_game(world_data: world)
+    user  = FakeUser.new(USER_ID)
+
+    with_deterministic_rand(42) do
+      phase_orientation(game, user)
+      phase_dialogue(game, user)
+      phase_items_containers(game, user)
+      phase_dice_rolls(game, user)
+      phase_movement(game, user)
+      phase_combat(game, user)
+      phase_npc_exchange(game, user)
+      phase_final_room(game, user)
+      phase_verification(game, user)
+    end
+  end
+
+  private
+
+    # Convenience wrapper so phase methods stay concise
+    def ex(game, user, cmd)
+      execute_engine(game, user, cmd)
+    end
+
+    # ─── World builders ─────────────────────────────────────────────────────
+
+    def build_full_game_world
+      build_world(
+        starting_room: "entrance",
+        rooms: rooms_data,
+        items: items_data,
+        npcs: npcs_data,
+        creatures: creatures_data
+      )
+    end
+
+    def rooms_data # rubocop:disable Metrics/MethodLength
+      {
+        "entrance" => {
+          "name" => "Entrance Hall",
+          "description" => "A grand entrance hall. A guide stands nearby.",
+          "items" => ["old_key"],
+          "npcs" => ["guide"],
+          "exits" => {
+            "east" => "storeroom",
+            "south" => "cave",
+            "north" => { "to" => "tower", "requires_flag" => "tower_unlocked",
+                         "locked_msg" => "The tower door is sealed." }
+          }
+        },
+        "storeroom" => {
+          "name" => "Storeroom",
+          "description" => "A dusty storeroom with shelves.",
+          "items" => ["supply_crate", "lockpick"],
+          "exits" => { "west" => "entrance" }
+        },
+        "cave" => {
+          "name" => "Dark Cave",
+          "description" => "A damp, dimly lit cave.",
+          "creatures" => ["troll"],
+          "exits" => {
+            "north" => "entrance",
+            "west" => { "to" => "alcove", "hidden" => true, "requires_flag" => "troll_slain",
+                        "reveal_msg" => "A passage to the west is now visible!" }
+          }
+        },
+        "tower" => {
+          "name" => "Wizard's Tower",
+          "description" => "A tall tower filled with arcane artifacts.",
+          "items" => ["scroll"],
+          "npcs" => ["wizard"],
+          "exits" => { "south" => "entrance" }
+        },
+        "alcove" => {
+          "name" => "Hidden Alcove",
+          "description" => "A small, secret alcove.",
+          "items" => ["victory_crown"],
+          "exits" => { "east" => "cave" },
+          "on_enter" => { "type" => "message",
+                          "text" => "You squeeze through a hidden passage into a forgotten alcove!" }
+        }
+      }
+    end
+
+    def items_data
+      basic_items.merge(complex_items)
+    end
+
+    def basic_items
+      {
+        "old_key" => {
+          "name" => "Old Key", "keywords" => ["key"],
+          "takeable" => true, "description" => "A tarnished old key."
+        },
+        "gem" => {
+          "name" => "Glowing Gem", "keywords" => ["gem", "glowing"],
+          "takeable" => true, "description" => "It pulsates with inner light."
+        },
+        "enchanted_blade" => {
+          "name" => "Enchanted Blade", "keywords" => ["blade", "sword", "enchanted"],
+          "takeable" => true, "weapon_damage" => 3,
+          "description" => "A blade humming with magic."
+        },
+        "scroll" => {
+          "name" => "Ancient Scroll", "keywords" => ["scroll", "ancient"],
+          "takeable" => true, "description" => "Yellowed parchment covered in runes.",
+          "on_use" => { "type" => "message", "text" => "The scroll speaks of ancient prophecies." }
+        },
+        "victory_crown" => {
+          "name" => "Victory Crown", "keywords" => ["crown", "victory"],
+          "takeable" => true, "description" => "The crown of the realm."
+        }
+      }
+    end
+
+    def complex_items # rubocop:disable Metrics/MethodLength
+      {
+        "health_potion" => {
+          "name" => "Health Potion", "keywords" => ["potion", "health"],
+          "takeable" => true, "consumable" => true,
+          "description" => "A red potion that restores health.",
+          "combat_effect" => { "type" => "heal", "amount" => 5 }
+        },
+        "lockpick" => {
+          "name" => "Lockpick", "keywords" => ["lockpick", "pick"],
+          "takeable" => true, "description" => "A slender metal pick.",
+          "dice_roll" => {
+            "dc" => 1, "dice" => "1d20",
+            "attempt_message" => "You attempt to pick a lock...",
+            "consume_on" => "failure",
+            "on_success" => { "message" => "The lock clicks open! You've mastered the lockpick.",
+                              "sets_flag" => "lockpick_mastered" },
+            "on_failure" => { "message" => "The lockpick snaps! Better luck next time." }
+          }
+        },
+        "supply_crate" => {
+          "name" => "Supply Crate", "keywords" => ["crate", "supply", "chest"],
+          "is_container" => true, "starts_closed" => true,
+          "locked" => true, "unlock_item" => "old_key",
+          "contents" => ["health_potion"],
+          "description" => "A heavy wooden crate.",
+          "closed_description" => "A heavy wooden crate, firmly closed.",
+          "open_description" => "An open supply crate.",
+          "locked_message" => "It's locked tight.",
+          "on_open_message" => "You unlock and open the crate."
+        }
+      }
+    end
+
+    def npcs_data
+      { "guide" => guide_data, "wizard" => wizard_data }
+    end
+
+    def guide_data # rubocop:disable Metrics/MethodLength
+      {
+        "name" => "Guide", "keywords" => ["guide"],
+        "description" => "A helpful traveler who knows the area.",
+        "dialogue" => {
+          "greeting" => "Welcome, adventurer! Ask me about 'directions' to learn more.",
+          "sets_flag" => "spoke_to_guide",
+          "topics" => {
+            "directions" => {
+              "keywords" => ["directions", "direction"],
+              "text" => "Head north for the tower, south for the cave.",
+              "leads_to" => ["secret"]
+            },
+            "secret" => {
+              "keywords" => ["secret"],
+              "text" => "There is a hidden alcove beyond the cave.",
+              "locked_text" => "I have nothing more to share."
+            },
+            "tower" => {
+              "keywords" => ["tower"],
+              "text" => "The wizard will trade rare gems for powerful weapons.",
+              "sets_flag" => "tower_unlocked",
+              "requires_flag" => "spoke_to_guide",
+              "locked_text" => "I wouldn't know anything about that."
+            }
+          }
+        }
+      }
+    end
+
+    def wizard_data
+      {
+        "name" => "Wizard", "keywords" => ["wizard"],
+        "description" => "A robed figure with a long beard.",
+        "accepts_item" => "gem", "gives_item" => "enchanted_blade",
+        "accept_message" => "Ah, a Glowing Gem! Just what I needed.",
+        "dialogue" => { "greeting" => "I am the wizard. Bring me a gem and I shall reward you." }
+      }
+    end
+
+    def creatures_data
+      {
+        "troll" => {
+          "name" => "Troll", "keywords" => ["troll"],
+          "hostile" => true, "health" => 1, "attack" => 3, "defense" => 0,
+          # attack_condition moves:4 allows go-south + talk + look before the 2nd look triggers aggro
+          "attack_condition" => { "moves" => 4 },
+          "loot" => ["gem"], "sets_flag_on_defeat" => "troll_slain",
+          "on_defeat_msg" => "The troll collapses with a thunderous crash!",
+          "aggro_text" => "The troll snarls and charges at you!",
+          "talk_text" => "The troll growls menacingly."
+        }
+      }
+    end
+
+    # ─── Phase helpers ───────────────────────────────────────────────────────
+
+    # Phase 1: basic observation commands from the starting room
+    def phase_orientation(game, user)
+      r = ex(game, user, "look")
+      assert r[:success], "PHASE 1: look should succeed"
+      assert_includes r[:response], "Entrance Hall"
+      assert_includes r[:response], "Old Key"
+      assert_includes r[:response], "Guide"
+      # north exit is visible (not hidden, just flag-gated); no west exit on this room
+      assert_includes r[:response], "NORTH"
+      assert_not_includes r[:response], "WEST"
+
+      r = ex(game, user, "help")
+      assert_includes r[:response], "Available commands"
+
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "carrying nothing"
+
+      r = ex(game, user, "examine guide")
+      assert_includes r[:response], "helpful traveler"
+    end
+
+    # Phase 2: NPC dialogue — greeting, leads_to chain, requires_flag topic
+    def phase_dialogue(game, user)
+      r = ex(game, user, "talk to guide")
+      assert r[:success], "PHASE 2: greeting should succeed"
+      assert_includes r[:response], "Welcome, adventurer"
+      assert game.get_flag("spoke_to_guide"), "spoke_to_guide flag should be set after greeting"
+
+      r = ex(game, user, "talk to guide about directions")
+      assert_includes r[:response], "Head north for the tower"
+      assert_includes r[:response], "secret", "leads_to hint should mention the unlocked topic"
+
+      r = ex(game, user, "talk to guide about secret")
+      assert r[:success], "secret topic should be unlocked after asking about directions"
+      assert_includes r[:response], "hidden alcove"
+
+      r = ex(game, user, "talk to guide about tower")
+      assert r[:success], "tower topic requires spoke_to_guide flag, which is set"
+      assert_includes r[:response], "wizard"
+      assert game.get_flag("tower_unlocked"), "tower_unlocked flag should be set after tower topic"
+    end
+
+    # Phase 3: take, container locking, open with key, close, drop/take, use absent item
+    def phase_items_containers(game, user) # rubocop:disable Metrics/MethodLength
+      r = ex(game, user, "go east")
+      assert_includes r[:response], "Storeroom", "PHASE 3: should move to storeroom"
+
+      r = ex(game, user, "open crate")
+      assert_not r[:success], "crate should be locked before player has the key"
+      assert_includes r[:response].downcase, "locked"
+
+      ex(game, user, "go west")
+
+      r = ex(game, user, "take key")
+      assert r[:success], "should be able to take the old key from the entrance"
+      assert_includes game.player_state(USER_ID)["inventory"], "old_key"
+
+      ex(game, user, "go east")
+
+      r = ex(game, user, "open crate")
+      assert r[:success], "crate should open with key in inventory"
+      assert_includes r[:response], "Health Potion"
+
+      r = ex(game, user, "take potion")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "health_potion"
+
+      r = ex(game, user, "close crate")
+      assert r[:success]
+
+      r = ex(game, user, "examine crate")
+      assert_includes r[:response], "firmly closed"
+
+      r = ex(game, user, "take lockpick")
+      assert r[:success]
+
+      r = ex(game, user, "drop lockpick")
+      assert r[:success]
+      assert_not_includes game.player_state(USER_ID)["inventory"], "lockpick"
+
+      r = ex(game, user, "take lockpick")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "lockpick"
+
+      r = ex(game, user, "use scroll")
+      assert_not r[:success], "scroll is in the tower, not in inventory"
+    end
+
+    # Phase 4: dice roll trigger, pending-roll guard, roll resolution
+    def phase_dice_rolls(game, user)
+      r = ex(game, user, "use lockpick")
+      assert r[:success], "PHASE 4: using lockpick should trigger a pending roll"
+      assert_includes r[:response], "ROLL"
+      assert game.player_state(USER_ID)["pending_roll"].present?, "pending_roll should be set"
+
+      r = ex(game, user, "look")
+      assert_not r[:success], "non-roll commands should be blocked while roll is pending"
+      assert_includes r[:response].upcase, "ROLL"
+
+      r = ex(game, user, "roll")
+      assert r[:success], "roll should succeed (DC 1 guarantees success)"
+      assert_includes r[:response], "Success"
+      assert_includes r[:response], "lock clicks open"
+      assert_nil game.player_state(USER_ID)["pending_roll"], "pending_roll should be cleared"
+      assert game.get_flag("lockpick_mastered"), "on_success sets_flag should fire"
+    end
+
+    # Phase 5: flag-gated north exit, use scroll (on_use message), examine, return
+    def phase_movement(game, user)
+      r = ex(game, user, "go west")
+      assert_includes r[:response], "Entrance Hall", "PHASE 5: should return to entrance"
+
+      r = ex(game, user, "go north")
+      assert r[:success], "north exit should be traversable now that tower_unlocked is set"
+      assert_includes r[:response], "Wizard's Tower"
+
+      r = ex(game, user, "take scroll")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "scroll"
+
+      r = ex(game, user, "use scroll")
+      assert r[:success]
+      assert_includes r[:response], "ancient prophecies"
+
+      r = ex(game, user, "examine scroll")
+      assert_includes r[:response], "parchment"
+
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Entrance Hall"
+    end
+
+    # Phase 6: enter cave, talk (no aggro), two looks (aggro on 4th action), combat, loot
+    def phase_combat(game, user) # rubocop:disable Metrics/MethodLength
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Dark Cave", "PHASE 6: should enter the cave"
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat yet after entering"
+
+      r = ex(game, user, "talk to troll")
+      assert_includes r[:response], "growls menacingly"
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat after talking (moves:4)"
+
+      # 3rd room action — still below threshold
+      ex(game, user, "look")
+      assert_not game.player_state(USER_ID).dig("combat", "active"), "no combat on 3rd action"
+
+      # 4th room action — troll attacks!
+      r = ex(game, user, "look")
+      assert_includes r[:response], "troll snarls", "aggro_text should appear on 4th action"
+      assert game.player_state(USER_ID).dig("combat", "active"), "troll should have initiated combat"
+
+      # One-hit kill: troll has 1 HP, min player damage is 1
+      r = ex(game, user, "attack")
+      assert_includes r[:response], "thunderous crash", "defeat message should appear"
+      assert_includes r[:response], "drops: Glowing Gem", "loot should be dropped"
+      assert_includes r[:response], "passage to the west is now visible", "hidden exit should be revealed"
+      assert game.get_flag("troll_slain"), "troll_slain flag should be set"
+      assert_nil game.player_state(USER_ID)["combat"], "combat should be cleared after victory"
+
+      r = ex(game, user, "look")
+      assert_not_includes game.room_state("cave")["creatures"] || [], "troll"
+      assert_includes r[:response], "Glowing Gem", "dropped gem should be visible"
+      assert_includes r[:response], "WEST", "revealed west exit should appear"
+
+      r = ex(game, user, "take gem")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "gem"
+    end
+
+    # Phase 7: navigate to wizard and exchange gem for enchanted blade
+    def phase_npc_exchange(game, user)
+      r = ex(game, user, "go north")
+      assert_includes r[:response], "Entrance Hall", "PHASE 7: cave → entrance"
+
+      r = ex(game, user, "go north")
+      assert_includes r[:response], "Wizard's Tower"
+
+      r = ex(game, user, "give gem to wizard")
+      assert r[:success], "give should succeed — wizard accepts the gem"
+      assert_includes r[:response], "Glowing Gem"
+      assert_includes r[:response], "Enchanted Blade"
+      assert_includes game.player_state(USER_ID)["inventory"], "enchanted_blade"
+      assert_not_includes game.player_state(USER_ID)["inventory"], "gem"
+
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "Enchanted Blade"
+    end
+
+    # Phase 8: traverse the now-revealed hidden exit and pick up the victory crown
+    def phase_final_room(game, user)
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Entrance Hall", "PHASE 8: tower → entrance"
+
+      r = ex(game, user, "go south")
+      assert_includes r[:response], "Dark Cave"
+
+      r = ex(game, user, "go west")
+      assert r[:success], "hidden west exit should be traversable after troll defeated"
+      assert_includes r[:response], "Hidden Alcove"
+      assert_includes r[:response], "squeeze through", "on_enter message should show on first visit"
+
+      r = ex(game, user, "take crown")
+      assert r[:success]
+      assert_includes game.player_state(USER_ID)["inventory"], "victory_crown"
+    end
+
+    # Phase 9: final state verification
+    def phase_verification(game, user)
+      r = ex(game, user, "inventory")
+      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
+      assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
+      assert_includes r[:response], "Old Key",         "old key should still be in inventory"
+      assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+
+      assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
+      assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"
+      assert game.get_flag("troll_slain"),     "troll_slain flag should be set"
+
+      assert_not_includes game.room_state("cave")["creatures"] || [], "troll"
+      assert game.exit_revealed?("cave", "west"), "west exit from cave should be permanently revealed"
+    end
+end

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -140,6 +140,21 @@ module ClassicGameTestHelper
       end
   end
 
+  # ─── Engine helper ─────────────────────────────────────────────────────────
+
+  # Route a command through the full Engine (handles pending rolls, aggro checks, etc.)
+  def execute_engine(game, user, command_text)
+    ClassicGame::Engine.execute(game: game, user: user, command_text: command_text)
+  end
+
+  # Seed the PRNG for deterministic outcomes, then restore the previous seed.
+  def with_deterministic_rand(seed = 42)
+    old_seed = srand(seed)
+    yield
+  ensure
+    srand(old_seed)
+  end
+
   # ─── Builders ──────────────────────────────────────────────────────────────
 
   def build_world(rooms: {}, items: {}, npcs: {}, creatures: {}, starting_room: nil)

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -140,9 +140,13 @@ module ClassicGameTestHelper
       end
   end
 
+  FakeUser = Struct.new(:id)
+
   # ─── Engine helper ─────────────────────────────────────────────────────────
 
-  # Route a command through the full Engine (handles pending rolls, aggro checks, etc.)
+  # Route a command through the full Engine (handles pending rolls, aggro checks,
+  # restart confirmation, and handler dispatch). Accepts any object that responds
+  # to #id — use FakeUser.new(some_id) as the user argument.
   def execute_engine(game, user, command_text)
     ClassicGame::Engine.execute(game: game, user: user, command_text: command_text)
   end


### PR DESCRIPTION
## Summary

- Adds a comprehensive end-to-end playthrough test (`test/lib/classic_game/full_game_system_test.rb`) that drives a complete game run through a purpose-built 5-room world, exercising every ClassicGame mechanic in a single test method
- Adds `FakeUser` struct and `with_deterministic_rand` helper to `ClassicGameTestHelper` so future tests can reuse them
- Documents the test in `CLAUDE.md` so contributors know to update it when changing game features

## Implementation Details

### The Idea

The existing test suite tests each handler in isolation. That's great for unit-level coverage, but it leaves a gap: it doesn't verify that the handlers compose correctly when routed through `ClassicGame::Engine.execute`. The Engine also owns three cross-cutting concerns — the aggressive-creature check, the pending-roll guard, and restart-confirmation routing — that can't be tested by calling handlers directly.

The full-game system test closes this gap. Every command is routed through `Engine.execute`, which means the test catches regressions in any of those cross-cutting paths as well as in individual handler logic.

### World Design

A self-contained 5-room world was built specifically for this test (not reusing `QaWorldData`) so it is immune to changes in the QA world:

| Room | Key contents |
|---|---|
| Entrance Hall | `old_key` item, `guide` NPC; exits east (storeroom), south (cave), north (tower — flag-gated) |
| Storeroom | `supply_crate` (locked container), `lockpick` (dice-roll item) |
| Dark Cave | `troll` creature; north exit to entrance, hidden west exit (revealed on troll defeat) |
| Wizard's Tower | `wizard` NPC (item exchange), `scroll` (on-use message item) |
| Hidden Alcove | `victory_crown`; on-enter message on first visit |

Two design choices make outcomes deterministic regardless of the PRNG seed:
- **Troll HP = 1** — the minimum possible player damage is 1, so the troll dies in exactly one `attack` command
- **Lockpick DC = 1** — a 1d20 roll always produces ≥ 1, guaranteeing the success branch every time

`srand(42)` still wraps the test so initiative order and damage variance produce identical numbers on every run.

### Playthrough Phases

| Phase | Mechanics exercised |
|---|---|
| 1 — Orientation | `look`, `help`, `inventory`, `examine`; hidden exit absent from output |
| 2 — Dialogue | `talk to` greeting (sets flag), `leads_to` chain, `requires_flag` topic, topic `sets_flag` |
| 3 — Items & Containers | `go`, `take`, `drop`; locked container (fail without key, succeed with key); `open`, `close`, `examine` container |
| 4 — Dice Roll | `use` item with `dice_roll`; pending-roll guard blocks non-roll commands; `roll` resolves with DC 1 success |
| 5 — Flag-Gated Movement | `go north` through `requires_flag` exit; `use scroll` on-use message; `examine` item |
| 6 — Combat | `attack_condition moves:4` triggers aggro on 4th room action; one-hit troll kill; loot drops; `sets_flag_on_defeat`; hidden exit auto-revealed |
| 7 — NPC Exchange | `give gem to wizard`; item removed from inventory, reward added |
| 8 — Hidden Exit | Traverse the now-visible west exit; `on_enter` message on first visit; take `victory_crown` |
| 9 — Verification | Final inventory contents; all expected flags set; troll absent from room state |

### Helper Additions (`test/support/classic_game_helper.rb`)

- `FakeUser = Struct.new(:id)` — moved to the shared module so the full-game test and any future Engine-level tests don't each define their own
- `with_deterministic_rand(seed = 42)` — seeds `Kernel.rand` for the block duration and restores the previous seed in an `ensure` clause

## Testing Plan

- The new test file lives in `test/lib/classic_game/` which is already in `bin/rails test`'s default path, so CI picks it up automatically
- Each assertion carries a `PHASE N:` prefix in its failure message to pinpoint the broken mechanic without reading through the whole playthrough
- The test is entirely in-memory (`FakeGame`), so it runs without a database and is safe to parallelize

## Notes

- The `FakeUser` constant is defined locally in `FullGameSystemTest` as well as in `ClassicGameTestHelper`. Both exist in separate Ruby namespaces (`FullGameSystemTest::FakeUser` vs `ClassicGameTestHelper::FakeUser`) — no constant collision or warning
- `RuboCop Metrics/ClassLength` and `Metrics/MethodLength` offenses on the long phase methods and the test class itself are suppressed inline because the length is intrinsic to the exhaustive nature of the test
- The `CreatureInteractionTest` still defines its own local `FakeUser` — it was left untouched to avoid a noisy diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)