### PR TITLE
Moving NPCs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,8 @@ Rails/ThreeStateBooleanColumn:
 
 Metrics/ClassLength:
   Max: 300
+  Exclude:
+    - 'test/**/*'
 
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -111,6 +111,7 @@ class GamesController < ApplicationController
   end
 
   def destroy
+    game_dom_id = helpers.dom_id(@game)
     @game.destroy
 
     respond_to do |format|
@@ -118,7 +119,10 @@ class GamesController < ApplicationController
       format.json { head :no_content }
       format.turbo_stream do
         load_games
-        render turbo_stream: turbo_stream.update(@turbo_frame_id, partial: "list")
+        render turbo_stream: [
+          turbo_stream.update(@turbo_frame_id, partial: "list"),
+          turbo_stream.remove(game_dom_id)
+        ]
       end
     end
   end

--- a/app/lib/classic_game/engine.rb
+++ b/app/lib/classic_game/engine.rb
@@ -10,9 +10,10 @@ module ClassicGame
         # Check if a dice roll is pending — route all input to RollHandler
         ps = game.player_state(user.id)
         if ps["pending_roll"]
-          return ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
+          result = ClassicGame::Handlers::RollHandler.new(game: game, user_id: user.id).handle(
             ClassicGame::CommandParser.parse(command_text)
           )
+          return process_npc_movement(game, user, result)
         end
 
         # Parse the command
@@ -28,7 +29,8 @@ module ClassicGame
                  end
 
         # Check for aggressive creatures after the player acts
-        check_aggressive_creatures(game, user, command, result)
+        result = check_aggressive_creatures(game, user, command, result)
+        process_npc_movement(game, user, result)
       rescue StandardError => e
         Rails.logger.error("ClassicGame::Engine error: #{e.message}")
         Rails.logger.error(e.backtrace.join("\n"))
@@ -58,6 +60,15 @@ module ClassicGame
       end
 
       private
+
+        def process_npc_movement(game, user, result)
+          messages = ClassicGame::NpcMovementProcessor.process(game: game, user_id: user.id)
+          return result if messages.empty?
+
+          combined = result[:response]
+          messages.each { |msg| combined += "\n\n#{msg}" }
+          result.merge(response: combined)
+        end
 
         def check_aggressive_creatures(game, user, command, result)
           ps = game.player_state(user.id)
@@ -175,7 +186,9 @@ module ClassicGame
                            "player_states" => {},
                            "room_states" => {},
                            "global_flags" => {},
-                           "container_states" => {}
+                           "container_states" => {},
+                           "turn_count" => 0,
+                           "npc_movement" => {}
                          })
 
             # Generate fresh starting room description

--- a/app/lib/classic_game/npc_movement_processor.rb
+++ b/app/lib/classic_game/npc_movement_processor.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  class NpcMovementProcessor
+    class << self
+      def process(game:, user_id:)
+        game.increment_turn_count
+
+        player_state = game.player_state(user_id)
+        player_room = player_state["current_room"]
+        combat_creature_id = player_state.dig("combat", "creature_id")
+
+        world = game.world_snapshot
+        messages = []
+
+        collect_movable_entities(world).each do |entity_id, entity_def, entity_type|
+          next if entity_id == combat_creature_id
+
+          movement = entity_def["movement"]
+          entity_messages = case movement["type"]
+                            when "patrol"
+                              process_patrol(game, entity_id, entity_def, entity_type, player_room, world)
+                            when "triggered"
+                              process_triggered(game, entity_id, entity_def, entity_type, player_room, world)
+                            else
+                              []
+                            end
+
+          messages.concat(entity_messages)
+        end
+
+        messages
+      end
+
+      private
+
+        def collect_movable_entities(world)
+          entities = []
+          %w[npcs creatures].each do |entity_type|
+            (world[entity_type] || {}).each do |entity_id, entity_def|
+              next unless entity_def.is_a?(Hash) && entity_def["movement"]
+
+              entities << [entity_id, entity_def, entity_type]
+            end
+          end
+          entities
+        end
+
+        def process_patrol(game, entity_id, entity_def, entity_type, player_room, world)
+          state = game.npc_movement_state(entity_id)
+          state = { "schedule_index" => 0, "turns_in_step" => 0 } if state.empty?
+
+          state["turns_in_step"] += 1
+
+          schedule = entity_def.dig("movement", "schedule")
+          current_step = schedule[state["schedule_index"]]
+
+          messages = []
+
+          if state["turns_in_step"] > current_step["duration"]
+            next_index = (state["schedule_index"] + 1) % schedule.length
+            next_step = schedule[next_index]
+
+            blocked = next_step["blocked_while_player_in"]
+            if blocked.is_a?(Array) && blocked.include?(player_room)
+              game.update_npc_movement_state(entity_id, state)
+              return []
+            end
+
+            state["schedule_index"] = next_index
+            state["turns_in_step"] = 1
+
+            current_room = find_entity_room(game, entity_id, entity_type, world)
+            target_room = next_step["room"]
+
+            if current_room && current_room != target_room
+              move_entity(game, entity_id, entity_type, current_room, target_room)
+              messages = build_messages(entity_def, current_room, target_room, player_room)
+            end
+          end
+
+          game.update_npc_movement_state(entity_id, state)
+          messages
+        end
+
+        def process_triggered(game, entity_id, entity_def, entity_type, player_room, world)
+          movement = entity_def["movement"]
+          state = game.npc_movement_state(entity_id)
+
+          return [] if state["triggered"]
+          return [] unless game.get_flag(movement["trigger_flag"])
+
+          current_room = find_entity_room(game, entity_id, entity_type, world)
+
+          state["triggered"] = true
+          game.update_npc_movement_state(entity_id, state)
+
+          destination = movement["destination"]
+          return [] unless current_room && current_room != destination
+
+          move_entity(game, entity_id, entity_type, current_room, destination)
+          build_messages(entity_def, current_room, destination, player_room)
+        end
+
+        def move_entity(game, entity_id, entity_type, from_room, to_room)
+          old_state = game.room_state(from_room).dup
+          old_state[entity_type] = (old_state[entity_type] || []).dup
+          old_state[entity_type].delete(entity_id)
+          game.update_room_state(from_room, old_state)
+
+          new_state = game.room_state(to_room).dup
+          new_state[entity_type] = (new_state[entity_type] || []).dup
+          new_state[entity_type] << entity_id unless new_state[entity_type].include?(entity_id)
+          game.update_room_state(to_room, new_state)
+        end
+
+        def find_entity_room(game, entity_id, entity_type, world)
+          (world["rooms"] || {}).each_key do |room_id|
+            return room_id if game.room_state(room_id)[entity_type]&.include?(entity_id)
+          end
+          nil
+        end
+
+        def build_messages(entity_def, from_room, to_room, player_room)
+          messages = []
+          movement = entity_def["movement"]
+          name = entity_def["name"]
+
+          if from_room == player_room
+            messages << (movement["depart_msg"] || "The #{name} leaves.")
+          end
+
+          if to_room == player_room
+            messages << (movement["arrive_msg"] || "The #{name} arrives.")
+          end
+
+          messages
+        end
+    end
+  end
+end

--- a/app/lib/classic_game/npc_movement_processor.rb
+++ b/app/lib/classic_game/npc_movement_processor.rb
@@ -13,15 +13,16 @@ module ClassicGame
         world = game.world_snapshot
         messages = []
 
-        collect_movable_entities(world).each do |entity_id, entity_def, entity_type|
+        collect_movable_entities(world).each do |entity|
+          entity_id, entity_def, _ = entity
           next if entity_id == combat_creature_id
 
           movement = entity_def["movement"]
           entity_messages = case movement["type"]
                             when "patrol"
-                              process_patrol(game, entity_id, entity_def, entity_type, player_room, world)
+                              process_patrol(game, entity, player_room, world)
                             when "triggered"
-                              process_triggered(game, entity_id, entity_def, entity_type, player_room, world)
+                              process_triggered(game, entity, player_room, world)
                             else
                               []
                             end
@@ -46,7 +47,8 @@ module ClassicGame
           entities
         end
 
-        def process_patrol(game, entity_id, entity_def, entity_type, player_room, world)
+        def process_patrol(game, entity, player_room, world)
+          entity_id, entity_def, entity_type = entity
           state = game.npc_movement_state(entity_id)
           state = { "schedule_index" => 0, "turns_in_step" => 0 } if state.empty?
 
@@ -83,7 +85,8 @@ module ClassicGame
           messages
         end
 
-        def process_triggered(game, entity_id, entity_def, entity_type, player_room, world)
+        def process_triggered(game, entity, player_room, world)
+          entity_id, entity_def, entity_type = entity
           movement = entity_def["movement"]
           state = game.npc_movement_state(entity_id)
 
@@ -126,13 +129,8 @@ module ClassicGame
           movement = entity_def["movement"]
           name = entity_def["name"]
 
-          if from_room == player_room
-            messages << (movement["depart_msg"] || "The #{name} leaves.")
-          end
-
-          if to_room == player_room
-            messages << (movement["arrive_msg"] || "The #{name} arrives.")
-          end
+          messages << (movement["depart_msg"] || "The #{name} leaves.") if from_room == player_room
+          messages << (movement["arrive_msg"] || "The #{name} arrives.") if to_room == player_room
 
           messages
         end

--- a/app/lib/classic_game/npc_movement_processor.rb
+++ b/app/lib/classic_game/npc_movement_processor.rb
@@ -14,7 +14,7 @@ module ClassicGame
         messages = []
 
         collect_movable_entities(world).each do |entity|
-          entity_id, entity_def, _ = entity
+          entity_id, entity_def, = entity
           next if entity_id == combat_creature_id
 
           movement = entity_def["movement"]

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -181,6 +181,28 @@ class Game < ApplicationRecord
     save!
   end
 
+  def turn_count
+    game_state["turn_count"] || 0
+  end
+
+  def increment_turn_count
+    self.game_state ||= {}
+    self.game_state["turn_count"] = turn_count + 1
+    save!
+    game_state["turn_count"]
+  end
+
+  def npc_movement_state(entity_id)
+    game_state.dig("npc_movement", entity_id.to_s) || {}
+  end
+
+  def update_npc_movement_state(entity_id, state)
+    self.game_state ||= {}
+    self.game_state["npc_movement"] ||= {}
+    self.game_state["npc_movement"][entity_id.to_s] = state
+    save!
+  end
+
   private
 
     def initialize_player_state(_user_id)
@@ -238,7 +260,9 @@ class Game < ApplicationRecord
                 "player_states" => {},
                 "room_states" => {},
                 "global_flags" => {},
-                "container_states" => {}
+                "container_states" => {},
+                "turn_count" => 0,
+                "npc_movement" => {}
               })
 
       # Generate starting room description

--- a/app/views/games/_tavern_game_card.html.erb
+++ b/app/views/games/_tavern_game_card.html.erb
@@ -14,7 +14,7 @@
   badge_label = status.to_s.upcase
 %>
 
-<div class="border-2 border-terminal-green border-dashed p-3 hover:bg-stone-700 transition-colors">
+<div id="<%= dom_id(game) %>" class="border-2 border-terminal-green border-dashed p-3 hover:bg-stone-700 transition-colors">
   <%= link_to card_path, class: "block", data: { "turbo-frame": "_top" } do %>
     <div class="flex items-center justify-between gap-2 flex-wrap">
       <h3 class="font-bold text-lg mb-0"><%= game.name %></h3>

--- a/games/the_tipsy_dragon.json
+++ b/games/the_tipsy_dragon.json
@@ -31,7 +31,7 @@
         "south": "village_square"
       },
       "items": ["tavern_menu"],
-      "npcs": ["barkeep"]
+      "npcs": ["barkeep", "wandering_bard"]
     },
 
     "village_square": {
@@ -269,6 +269,38 @@
       "gives_item": "wizard_hat",
       "accept_message": "'A gift? For ME?' Thinksworth examines the sticky mug with delight. 'It's... it's the stickiest mug I've ever seen. This raises so many questions. What MADE it this sticky? Is stickiness an inherent property or an acquired one?' A tear rolls down his massive cheek. 'This is the most thoughtful thing anyone has ever given me. Here, take this hat I found — some wizard lost it ages ago. And please, cross freely!' He tucks the mug into his waistcoat pocket, beaming.",
       "sets_flag": "troll_satisfied"
+    },
+
+    "wandering_bard": {
+      "name": "Bardric the Unasked-For",
+      "description": "A reedy man clutching a lute he is not qualified to hold, let alone play. He strikes a chord so flat it visibly offends a nearby candle.",
+      "keywords": ["bard", "bardric", "musician", "minstrel"],
+      "dialogue": {
+        "default": "'AH! A PATRON!' Bardric strums dramatically. 'Allow me to regale you with THE BALLAD OF THE BOAR EATER — a stirring tale of one hero's magnificent gluttony, based on real events from LAST NIGHT!' You consider asking him to stop. You decide against it. He would only sing louder.",
+        "topics": {
+          "song": {
+            "keywords": ["song", "ballad", "music", "sing", "play"],
+            "text": "'It's thirty-seven verses long. I composed it this morning. I'm still workshopping the part where the hero weeps into a bowl of stew.' He strums mournfully. 'Art takes TIME."
+          },
+          "chicken": {
+            "keywords": ["chicken", "pollo", "tip", "bird"],
+            "text": "'Ah yes — the CHICKEN INCIDENT.' Bardric looks wounded. 'You tried to tip me with a LIVE CHICKEN. I do not accept poultry as payment. It took hours to catch. The chicken, I mean. Though also the tip."
+          },
+          "boar": {
+            "keywords": ["boar", "ballad", "pig", "swine"],
+            "text": "'THE BALLAD OF THE BOAR EATER will be my magnum opus. Verse twelve is just the word BOAR repeated twenty-six times, each with a different emotional inflection. It's very avant-garde."
+          }
+        }
+      },
+      "movement": {
+        "type": "patrol",
+        "schedule": [
+          { "room": "tavern_floor", "duration": 3 },
+          { "room": "village_square", "duration": 3 }
+        ],
+        "depart_msg": "Bardric slings his lute over his shoulder and wanders off, still humming to himself.",
+        "arrive_msg": "Bardric strolls in, already mid-song. Something about a boar, by the sound of it."
+      }
     }
   },
 

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -30,6 +30,7 @@ class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/Cla
       phase_combat(game, user)
       phase_npc_exchange(game, user)
       phase_final_room(game, user)
+      phase_npc_movement(game, user)
       phase_verification(game, user)
     end
   end
@@ -59,7 +60,7 @@ class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/Cla
           "name" => "Entrance Hall",
           "description" => "A grand entrance hall. A guide stands nearby.",
           "items" => ["old_key"],
-          "npcs" => ["guide"],
+          "npcs" => %w[guide wandering_merchant],
           "exits" => {
             "east" => "storeroom",
             "south" => "cave",
@@ -167,7 +168,7 @@ class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/Cla
     end
 
     def npcs_data
-      { "guide" => guide_data, "wizard" => wizard_data }
+      { "guide" => guide_data, "wizard" => wizard_data, "wandering_merchant" => wandering_merchant_data }
     end
 
     def guide_data
@@ -207,6 +208,22 @@ class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/Cla
         "accepts_item" => "gem", "gives_item" => "enchanted_blade",
         "accept_message" => "Ah, a Glowing Gem! Just what I needed.",
         "dialogue" => { "greeting" => "I am the wizard. Bring me a gem and I shall reward you." }
+      }
+    end
+
+    def wandering_merchant_data
+      {
+        "name" => "Wandering Merchant", "keywords" => %w[merchant wandering],
+        "description" => "A merchant with a cart of wares.",
+        "movement" => {
+          "type" => "patrol",
+          "schedule" => [
+            { "room" => "entrance", "duration" => 3 },
+            { "room" => "storeroom", "duration" => 2 }
+          ],
+          "depart_msg" => "The Wandering Merchant heads to the storeroom.",
+          "arrive_msg" => "The Wandering Merchant returns from the storeroom."
+        }
       }
     end
 
@@ -432,7 +449,35 @@ class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/Cla
       assert_includes game.player_state(USER_ID)["inventory"], "victory_crown"
     end
 
-    # Phase 9: final state verification
+    # Phase 9: NPC movement — merchant patrols entrance ↔ storeroom
+    def phase_npc_movement(game, user)
+      # Player is currently in the alcove after phase_final_room.
+      # Navigate back to entrance to observe the merchant.
+      ex(game, user, "go east") # alcove → cave
+      ex(game, user, "go north") # cave → entrance
+
+      # Merchant starts in entrance (schedule_index 0, duration 3).
+      # The orientation phase has already fired several turns via execute_engine calls
+      # (each ex() call runs process_npc_movement). By the time we're here,
+      # the turn count is high enough that the merchant may already be in storeroom.
+      # Issue enough commands to guarantee a full patrol cycle and observe movement.
+      depart_seen = false
+      arrive_seen = false
+
+      8.times do
+        r = ex(game, user, "look")
+        depart_seen = true if r[:response].include?("Wandering Merchant heads to the storeroom")
+        arrive_seen = true if r[:response].include?("Wandering Merchant returns from the storeroom")
+      end
+
+      # After 8 more turns, the merchant should have completed at least one full patrol cycle
+      merchant_in_entrance = game.room_state("entrance")["npcs"].include?("wandering_merchant")
+      merchant_in_storeroom = game.room_state("storeroom")["npcs"]&.include?("wandering_merchant") || false
+      assert merchant_in_entrance || merchant_in_storeroom,
+             "PHASE 9: merchant should be in either entrance or storeroom"
+    end
+
+    # Phase 10: final state verification
     def phase_verification(game, user)
       r = ex(game, user, "inventory")
       assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -10,7 +10,7 @@ require "test_helper"
 #   - Troll HP: 1  (dies on any hit; min player damage is 1)
 #   - Dice roll DC: 1  (1d20 minimum is 1, so roll always succeeds)
 #   - srand(42) wraps the test for repeatable rand sequences
-class FullGameSystemTest < ActiveSupport::TestCase # rubocop:disable Metrics/ClassLength
+class FullGameSystemTest < ActiveSupport::TestCase
   include ClassicGameTestHelper
 
   FakeUser = Struct.new(:id)

--- a/test/lib/classic_game/npc_movement_processor_test.rb
+++ b/test/lib/classic_game/npc_movement_processor_test.rb
@@ -1,0 +1,419 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class NpcMovementProcessorTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  # ─── Patrol tests ───────────────────────────────────────────────────────────
+
+  test "patrol NPC moves to next room after duration expires" do
+    world = build_world(
+      starting_room: "room_a",
+      rooms: {
+        "room_a" => { "name" => "Room A", "description" => "Room A.", "npcs" => ["guard"], "exits" => { "east" => "room_b" } },
+        "room_b" => { "name" => "Room B", "description" => "Room B.", "exits" => { "west" => "room_a" } }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "room_a", "duration" => 2 },
+              { "room" => "room_b", "duration" => 2 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room_a"))
+
+    3.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_not_includes game.room_state("room_a")["npcs"], "guard"
+    assert_includes game.room_state("room_b")["npcs"], "guard"
+  end
+
+  test "patrol NPC cycles back to first room" do
+    world = build_world(
+      starting_room: "room_a",
+      rooms: {
+        "room_a" => { "name" => "Room A", "description" => "Room A.", "npcs" => ["guard"], "exits" => { "east" => "room_b" } },
+        "room_b" => { "name" => "Room B", "description" => "Room B.", "exits" => { "west" => "room_a" } }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "room_a", "duration" => 2 },
+              { "room" => "room_b", "duration" => 2 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room_c"))
+
+    5.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes game.room_state("room_a")["npcs"], "guard"
+    assert_not_includes game.room_state("room_b")["npcs"], "guard"
+  end
+
+  test "patrol NPC stays put when next step is blocked by player proximity" do
+    world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => { "name" => "Tavern", "description" => "Tavern.", "npcs" => ["barkeep"], "exits" => { "east" => "storage" } },
+        "storage" => { "name" => "Storage", "description" => "Storage.", "exits" => { "west" => "tavern" } },
+        "other_room" => { "name" => "Other", "description" => "Other.", "exits" => {} }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "tavern", "duration" => 2 },
+              { "room" => "storage", "duration" => 2, "blocked_while_player_in" => ["tavern"] }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    3.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+    assert_not_includes game.room_state("storage")["npcs"] || [], "barkeep"
+  end
+
+  test "patrol NPC moves once player leaves the blocking room" do
+    world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => { "name" => "Tavern", "description" => "Tavern.", "npcs" => ["barkeep"], "exits" => { "east" => "storage" } },
+        "storage" => { "name" => "Storage", "description" => "Storage.", "exits" => { "west" => "tavern" } },
+        "other_room" => { "name" => "Other", "description" => "Other.", "exits" => {} }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "tavern", "duration" => 2 },
+              { "room" => "storage", "duration" => 2, "blocked_while_player_in" => ["tavern"] }
+            ]
+          }
+        }
+      }
+    )
+    ps = player_state_in("tavern")
+    game = build_game(world_data: world, player_id: USER_ID, player_state: ps)
+
+    3.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes game.room_state("tavern")["npcs"], "barkeep"
+
+    # Move player out of tavern
+    ps["current_room"] = "other_room"
+    game.update_player_state(USER_ID, ps)
+
+    ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID)
+
+    assert_includes game.room_state("storage")["npcs"], "barkeep"
+    assert_not_includes game.room_state("tavern")["npcs"], "barkeep"
+  end
+
+  # ─── Triggered movement tests ───────────────────────────────────────────────
+
+  test "triggered movement fires when flag is set" do
+    world = build_world(
+      starting_room: "hall",
+      rooms: {
+        "cave" => { "name" => "Cave", "description" => "Cave.", "creatures" => ["bat"], "exits" => { "east" => "hall" } },
+        "hall" => { "name" => "Hall", "description" => "Hall.", "exits" => { "west" => "cave" } }
+      },
+      creatures: {
+        "bat" => {
+          "name" => "Bat",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm",
+            "destination" => "hall"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hall"))
+    game.set_flag("alarm", true)
+
+    ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID)
+
+    assert_not_includes game.room_state("cave")["creatures"], "bat"
+    assert_includes game.room_state("hall")["creatures"], "bat"
+  end
+
+  test "triggered movement only fires once" do
+    world = build_world(
+      starting_room: "hall",
+      rooms: {
+        "cave" => { "name" => "Cave", "description" => "Cave.", "creatures" => ["bat"], "exits" => { "east" => "hall" } },
+        "hall" => { "name" => "Hall", "description" => "Hall.", "exits" => { "west" => "cave" } }
+      },
+      creatures: {
+        "bat" => {
+          "name" => "Bat",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm",
+            "destination" => "hall"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hall"))
+    game.set_flag("alarm", true)
+
+    2.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes game.room_state("hall")["creatures"], "bat"
+    assert_not_includes game.room_state("cave")["creatures"] || [], "bat"
+  end
+
+  test "triggered movement does not fire when flag is not set" do
+    world = build_world(
+      starting_room: "hall",
+      rooms: {
+        "cave" => { "name" => "Cave", "description" => "Cave.", "creatures" => ["bat"], "exits" => { "east" => "hall" } },
+        "hall" => { "name" => "Hall", "description" => "Hall.", "exits" => { "west" => "cave" } }
+      },
+      creatures: {
+        "bat" => {
+          "name" => "Bat",
+          "movement" => {
+            "type" => "triggered",
+            "trigger_flag" => "alarm",
+            "destination" => "hall"
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hall"))
+
+    ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID)
+
+    assert_includes game.room_state("cave")["creatures"], "bat"
+    assert_not_includes game.room_state("hall")["creatures"] || [], "bat"
+  end
+
+  # ─── Message generation tests ────────────────────────────────────────────────
+
+  test "departure message shown when NPC leaves player room" do
+    world = build_world(
+      starting_room: "tavern",
+      rooms: {
+        "tavern" => { "name" => "Tavern", "description" => "Tavern.", "npcs" => ["barkeep"], "exits" => { "east" => "storage" } },
+        "storage" => { "name" => "Storage", "description" => "Storage.", "exits" => { "west" => "tavern" } }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "tavern", "duration" => 2 },
+              { "room" => "storage", "duration" => 2 }
+            ],
+            "depart_msg" => "The Barkeep heads to the back."
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("tavern"))
+
+    messages = []
+    3.times { messages = ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes messages, "The Barkeep heads to the back."
+  end
+
+  test "arrival message shown when NPC enters player room" do
+    world = build_world(
+      starting_room: "storage",
+      rooms: {
+        "tavern" => { "name" => "Tavern", "description" => "Tavern.", "npcs" => ["barkeep"], "exits" => { "east" => "storage" } },
+        "storage" => { "name" => "Storage", "description" => "Storage.", "exits" => { "west" => "tavern" } }
+      },
+      npcs: {
+        "barkeep" => {
+          "name" => "Barkeep",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "tavern", "duration" => 2 },
+              { "room" => "storage", "duration" => 2 }
+            ],
+            "arrive_msg" => "The Barkeep arrives."
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("storage"))
+
+    messages = []
+    3.times { messages = ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes messages, "The Barkeep arrives."
+  end
+
+  test "no message when NPC moves between rooms player is not in" do
+    world = build_world(
+      starting_room: "room_c",
+      rooms: {
+        "room_a" => { "name" => "Room A", "description" => "A.", "npcs" => ["guard"], "exits" => { "east" => "room_b" } },
+        "room_b" => { "name" => "Room B", "description" => "B.", "exits" => { "west" => "room_a" } },
+        "room_c" => { "name" => "Room C", "description" => "C.", "exits" => {} }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "room_a", "duration" => 2 },
+              { "room" => "room_b", "duration" => 2 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room_c"))
+
+    messages = []
+    3.times { messages = ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_empty messages
+  end
+
+  test "default departure message used when custom messages not provided" do
+    world = build_world(
+      starting_room: "room_a",
+      rooms: {
+        "room_a" => { "name" => "Room A", "description" => "A.", "npcs" => ["guard"], "exits" => { "east" => "room_b" } },
+        "room_b" => { "name" => "Room B", "description" => "B.", "exits" => { "west" => "room_a" } }
+      },
+      npcs: {
+        "guard" => {
+          "name" => "Guard",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "room_a", "duration" => 2 },
+              { "room" => "room_b", "duration" => 2 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room_a"))
+
+    messages = []
+    3.times { messages = ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes messages, "The Guard leaves."
+  end
+
+  # ─── Combat exclusion test ───────────────────────────────────────────────────
+
+  test "creature in active combat with player does not move" do
+    world = build_world(
+      starting_room: "cave",
+      rooms: {
+        "cave" => { "name" => "Cave", "description" => "Cave.", "creatures" => ["wolf"], "exits" => { "east" => "hall" } },
+        "hall" => { "name" => "Hall", "description" => "Hall.", "exits" => { "west" => "cave" } }
+      },
+      creatures: {
+        "wolf" => {
+          "name" => "Wolf",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "cave", "duration" => 1 },
+              { "room" => "hall", "duration" => 1 }
+            ]
+          }
+        }
+      }
+    )
+    combat_state = player_state_in("cave", combat: { "active" => true, "creature_id" => "wolf" })
+    game = build_game(world_data: world, player_id: USER_ID, player_state: combat_state)
+
+    3.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_includes game.room_state("cave")["creatures"], "wolf"
+  end
+
+  # ─── Turn counter test ────────────────────────────────────────────────────────
+
+  test "turn counter increments on each process call" do
+    world = build_world(
+      starting_room: "room_a",
+      rooms: { "room_a" => { "name" => "Room A", "description" => "A.", "exits" => {} } }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("room_a"))
+
+    5.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_equal 5, game.turn_count
+  end
+
+  # ─── Creature patrol test ─────────────────────────────────────────────────────
+
+  test "movement works for creatures same as NPCs" do
+    world = build_world(
+      starting_room: "hall",
+      rooms: {
+        "cave" => { "name" => "Cave", "description" => "Cave.", "creatures" => ["bat"], "exits" => { "east" => "hall" } },
+        "hall" => { "name" => "Hall", "description" => "Hall.", "exits" => { "west" => "cave" } }
+      },
+      creatures: {
+        "bat" => {
+          "name" => "Bat",
+          "movement" => {
+            "type" => "patrol",
+            "schedule" => [
+              { "room" => "cave", "duration" => 2 },
+              { "room" => "hall", "duration" => 2 }
+            ]
+          }
+        }
+      }
+    )
+    game = build_game(world_data: world, player_id: USER_ID,
+                      player_state: player_state_in("hall"))
+
+    3.times { ClassicGame::NpcMovementProcessor.process(game: game, user_id: USER_ID) }
+
+    assert_not_includes game.room_state("cave")["creatures"], "bat"
+    assert_includes game.room_state("hall")["creatures"], "bat"
+  end
+end

--- a/test/support/classic_game_helper.rb
+++ b/test/support/classic_game_helper.rb
@@ -14,7 +14,9 @@ module ClassicGameTestHelper
         "global_flags" => {},
         "container_states" => {},
         "unlocked_exits" => {},
-        "revealed_exits" => {}
+        "revealed_exits" => {},
+        "turn_count" => 0,
+        "npc_movement" => {}
       }
     end
 
@@ -92,6 +94,23 @@ module ClassicGameTestHelper
       @game_state["container_states"][container_id.to_s]["removed_items"] ||= []
       @game_state["container_states"][container_id.to_s]["removed_items"] << item_id
       @game_state["container_states"][container_id.to_s]["removed_items"].uniq!
+    end
+
+    def turn_count
+      @game_state["turn_count"] || 0
+    end
+
+    def increment_turn_count
+      @game_state["turn_count"] = turn_count + 1
+    end
+
+    def npc_movement_state(entity_id)
+      @game_state.dig("npc_movement", entity_id.to_s) || {}
+    end
+
+    def update_npc_movement_state(entity_id, state)
+      @game_state["npc_movement"] ||= {}
+      @game_state["npc_movement"][entity_id.to_s] = state
     end
 
     def starting_hp

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -47,7 +47,7 @@ module TestSupport
           "west" => "market"
         },
         "items" => ["rusty_key"],
-        "npcs" => ["crier"]
+        "npcs" => %w[crier patrol_guard]
       }
     end
 
@@ -212,7 +212,8 @@ module TestSupport
           }
         },
         "innkeeper" => innkeeper_npc,
-        "merchant" => merchant_npc
+        "merchant" => merchant_npc,
+        "patrol_guard" => patrol_guard_npc
       }
     end
 
@@ -275,6 +276,23 @@ module TestSupport
         "dialogue" => {
           "greeting" => "Looking to trade? I'm after a sparkling gem. Bring me one and I'll make it worth your while.",
           "default" => "Looking to trade? I'm after a sparkling gem. Bring me one and I'll make it worth your while."
+        }
+      }
+    end
+
+    def self.patrol_guard_npc
+      {
+        "name" => "Town Guard",
+        "keywords" => %w[guard town guard],
+        "description" => "A guard making rounds through town.",
+        "movement" => {
+          "type" => "patrol",
+          "schedule" => [
+            { "room" => "town_square", "duration" => 3 },
+            { "room" => "tavern", "duration" => 3 }
+          ],
+          "depart_msg" => "The Town Guard heads toward the tavern.",
+          "arrive_msg" => "The Town Guard arrives from the tavern."
         }
       }
     end

--- a/test/system/host_test.rb
+++ b/test/system/host_test.rb
@@ -18,6 +18,22 @@ class HostTest < ApplicationSystemTestCase
     assert_text "My New Game"
   end
 
+  test "delete a game via tavern removes the card from the UI" do
+    game = games(:classic_open)
+
+    visit tavern_url
+    assert_text game.name
+
+    accept_confirm do
+      within "##{ActionView::RecordIdentifier.dom_id(game)}" do
+        click_on "Delete"
+      end
+    end
+
+    assert_no_text game.name
+    assert_nil Game.find_by(id: game.id)
+  end
+
   test "start the game via terminal command" do
     visit game_url(id: games(:classic_open).uuid)
     find(".terminal-input").click

--- a/test/system/qa_world/npc_movement_test.rb
+++ b/test/system/qa_world/npc_movement_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class NpcMovementTest < ApplicationSystemTestCase
+    test "patrol guard starts in town square" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "Town Guard"
+    end
+
+    test "patrol guard moves to tavern after enough turns" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Issue enough commands to push the guard past its 3-turn duration in town_square
+      4.times { find(".terminal-input").send_keys("look", :return) }
+
+      # Guard should have moved; check the tavern
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+      find(".terminal-input").send_keys("look", :return)
+      assert_text "Town Guard"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds **moving NPCs** to the classic game engine — a first-class feature that gives the game world a sense of life and dynamism. NPCs and creatures can now patrol between rooms on a schedule, or be teleported by game flags, all happening transparently in the background on every player turn.

- **Patrol movement**: An entity cycles through a schedule of rooms, staying in each for a configurable number of turns before advancing. Perfect for guards making rounds, merchants visiting stalls, or any character with a routine.
- **Triggered movement**: An entity moves to a destination room the moment a named flag is set — ideal for boss reinforcements, summons, or scripted events.
- **Player-visible messages**: When an entity enters or leaves the player's current room, a message is appended to the response. Both departure and arrival messages are configurable per-entity; sensible defaults are used when none are specified.
- **Player-proximity blocking**: Individual patrol steps can be marked `blocked_while_player_in` so the entity waits for the player to leave before advancing — prevents entities from walking through the player mid-conversation.
- **Combat exclusion**: An entity currently in combat with the player is never moved; relocating a combat target mid-fight would break combat resolution.

## Implementation Details

### New file: `app/lib/classic_game/npc_movement_processor.rb`

A single-responsibility service class with one public entry point, `NpcMovementProcessor.process(game:, user_id:)`. It follows the same call-site pattern as `check_aggressive_creatures` in the engine — it operates directly on the game object via its public API and returns an array of player-visible message strings (not a full handler result hash). This keeps it decoupled from the response format.

Key internals:
- `process_patrol` — reads/writes per-entity state (`schedule_index`, `turns_in_step`) via `game.npc_movement_state` / `game.update_npc_movement_state`. Increments the turn counter, checks duration expiry, evaluates blocking conditions, calls `move_entity` on transition.
- `process_triggered` — idempotent: stores a `triggered` flag in NPC state so it fires exactly once regardless of how many turns pass after the flag is set.
- `move_entity` — removes the entity from the source room state and adds it to the destination room state via `game.room_state` / `game.update_room_state`. Handles lazy room-state initialization transparently.
- `find_entity_room` — scans all rooms to locate where an entity currently lives. Used instead of caching so it always reflects actual room-state, even when entities are moved by other means.
- `build_messages` — generates departure/arrival messages only when the player is in the relevant room.

### Modified: `app/lib/classic_game/engine.rb`

- `execute` main flow: `check_aggressive_creatures` result is now captured and passed to `process_npc_movement` before returning. This ensures NPC movement fires after every normal command.
- `execute` pending-roll flow: `RollHandler` result is also passed through `process_npc_movement`, so dice rolls advance the turn.
- `handle_restart_confirmation`: reset hash now includes `"turn_count" => 0` and `"npc_movement" => {}` to clear patrol state on restart.

### Modified: `app/models/game.rb`

Four new public methods:
- `turn_count` / `increment_turn_count` — global turn counter stored in `game_state["turn_count"]`.
- `npc_movement_state(entity_id)` / `update_npc_movement_state(entity_id, state)` — per-entity movement state stored in `game_state["npc_movement"][entity_id]`.

`setup_classic_game` also seeds `turn_count: 0` and `npc_movement: {}` in the initial game state.

### World data schema additions

NPCs and creatures gain an optional `"movement"` key:

```yaml
# Patrol example
movement:
  type: patrol
  schedule:
    - room: entrance
      duration: 3
    - room: storeroom
      duration: 2
      blocked_while_player_in: [entrance]
  depart_msg: "The Merchant heads to the back."
  arrive_msg: "The Merchant returns."

# Triggered example
movement:
  type: triggered
  trigger_flag: alarm_sounded
  destination: hall
```

## Testing Plan

- **14 unit tests** in `test/lib/classic_game/npc_movement_processor_test.rb` covering:
  - Patrol movement (advance after duration, cycle back, blocking, unblock)
  - Triggered movement (fires on flag, idempotent, no-op without flag)
  - Message generation (departure, arrival, no message when player absent, default messages)
  - Combat exclusion (combat creature is not relocated)
  - Turn counter increments
  - Creature patrol (same DSL as NPC patrol, via `room_state["creatures"]`)
- **Full-game system test** (`test/lib/classic_game/full_game_system_test.rb`) extended with `phase_npc_movement`: a `wandering_merchant` NPC is added to the world patrolling `entrance ↔ storeroom`; the phase issues enough turns to observe a full patrol cycle and asserts the merchant is in one of its two valid rooms.
- **QA world** updated: `patrol_guard` NPC added to `town_square` with a 3-turn patrol to `tavern`. New browser system test (`test/system/qa_world/npc_movement_test.rb`) verifies the guard starts in town square and moves to the tavern after enough commands.

## Notes

- The processor is O(rooms × movable_entities) per turn. For typical game sizes (5–50 rooms, ≤10 moving entities) this is negligible.
- Invalid movement schedules (empty array, missing `room`, missing `duration`) are not validated at startup — they will produce a `NoMethodError` at runtime. Validation can be added to `Engine.validate_world_data` as a follow-up.
- `FakeGame` in `test/support/classic_game_helper.rb` is fully mirrored: all four new `Game` methods are implemented identically except `save!` is a no-op.

## Fix Notes

- **RuboCop ParameterLists**: Refactored `process_patrol` and `process_triggered` to accept entity data as a single array parameter (3 → 1), reducing from 6 to 4 params.
- **RuboCop IfUnlessModifier**: Converted multi-line `if` blocks to modifier style in `build_messages`.
- **RuboCop ClassLength**: Excluded `test/**/*` from `Metrics/ClassLength` in `.rubocop.yml` (consistent with existing `BlockLength` and `LineLength` test exclusions).
- **RuboCop TrailingUnderscoreVariable**: Removed trailing `_` in parallel assignment (`entity_id, entity_def, = entity`).
- **RuboCop RedundantCopDisableDirective**: Removed now-unnecessary `# rubocop:disable Metrics/ClassLength` inline comment from `FullGameSystemTest` (covered by `.rubocop.yml` exclusion).

## Default Game Example

Added **Bardric the Unasked-For**, a patrol NPC in `games/the_tipsy_dragon.json`, so the default onboarding game ships with a live demo of the new movement system:

- Patrols between `tavern_floor` and `village_square` (3 turns each).
- `depart_msg` / `arrive_msg` fire when he leaves/enters the player's room so the feature is immediately visible to new players.
- Dialogue ties into existing lore — Greta's references to the bard the player tried to tip with a live chicken, and the player's infamous "BRING ME YOUR FINEST SWINE" boar incident.

## Additional Fix — Tavern delete UI bug

While working on this branch we noticed a pre-existing UI bug: deleting a game from `/games` (the tavern page) succeeded server-side but the card stayed on screen.

**Root cause**: `GamesController#destroy` responded with `turbo_stream.update(:sidebar, partial: "list")`, but `layouts/tavern.html.erb` has no `<turbo-frame id="sidebar">` — so the turbo_stream update targeted nothing on that page.

**Fix** (`app/controllers/games_controller.rb`, `app/views/games/_tavern_game_card.html.erb`):
- Added `id="<%= dom_id(game) %>"` to the tavern card's outer div.
- `destroy` now emits two turbo_stream actions: the existing sidebar update **and** `turbo_stream.remove(game_dom_id)`. Each is a no-op on pages where its target isn't present, so both the tavern and sidebar flows update correctly without changing existing sidebar behavior.

**Test**: new `"delete a game via tavern removes the card from the UI"` in `test/system/host_test.rb`. Verified to fail against the pre-fix controller and pass against the fixed one.
