### PR TITLE
Interactive Inventory System

### DIFF
--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -180,11 +180,11 @@ module ClassicGame
           name = item_def&.dig("name") || item_id
           desc_raw = item_def&.dig("description")
           short_desc = if desc_raw
-            first = desc_raw.split(".").first
-            first ? "#{first}." : desc_raw
-          else
-            "A mysterious item."
-          end
+                         first = desc_raw.split(".").first
+                         first ? "#{first}." : desc_raw
+                       else
+                         "A mysterious item."
+                       end
 
           art = inventory_art_for(item_def)
           art_lines = art.split("\n")
@@ -192,8 +192,8 @@ module ClassicGame
           content_lines = art_lines.map { |l| "  #{l}" } + ["  #{name}", "  #{short_desc}"]
           inner_width = [content_lines.map(&:length).max, 21].max
 
-          border_top = "┌#{"─" * inner_width}┐"
-          border_bot = "└#{"─" * inner_width}┘"
+          border_top = "┌#{'─' * inner_width}┐"
+          border_bot = "└#{'─' * inner_width}┘"
           rows = content_lines.map { |l| "│#{l.ljust(inner_width)}│" }
 
           ([border_top] + rows + [border_bot]).join("\n")

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -163,13 +163,44 @@ module ClassicGame
 
           return success("You are carrying nothing.") if inventory.empty?
 
-          lines = ["You are carrying:"]
+          lines = ["=== INVENTORY ===", ""]
+
           inventory.each do |item_id|
-            item_name = world_snapshot.dig("items", item_id, "name") || item_id
-            lines << "  - #{item_name}"
+            item_def = world_snapshot.dig("items", item_id)
+            lines << format_inventory_item(item_id, item_def)
+            lines << ""
           end
 
+          lines << "Type EXAMINE <item> to inspect an item more closely."
+
           success(lines.join("\n"))
+        end
+
+        def format_inventory_item(item_id, item_def)
+          name = item_def&.dig("name") || item_id
+          desc_raw = item_def&.dig("description")
+          short_desc = if desc_raw
+            first = desc_raw.split(".").first
+            first ? "#{first}." : desc_raw
+          else
+            "A mysterious item."
+          end
+
+          art = inventory_art_for(item_def)
+          art_lines = art.split("\n")
+
+          content_lines = art_lines.map { |l| "  #{l}" } + ["  #{name}", "  #{short_desc}"]
+          inner_width = [content_lines.map(&:length).max, 21].max
+
+          border_top = "┌#{"─" * inner_width}┐"
+          border_bot = "└#{"─" * inner_width}┘"
+          rows = content_lines.map { |l| "│#{l.ljust(inner_width)}│" }
+
+          ([border_top] + rows + [border_bot]).join("\n")
+        end
+
+        def inventory_art_for(item_def)
+          ClassicGame::ItemArt.art_for(item_def)
         end
 
         def describe_current_room

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module ItemArt
+    ART = {
+      "sword"  => "   /|\n  / |\n /  |\n/___/",
+      "blade"  => "  /\n |/\n  |\\\n  |_",
+      "key"    => " (O)--\n |___]",
+      "potion" => "  _\n(/)\n|~|\n|_|",
+      "shield" => "/---\\\n|[*]|\n\\---/",
+      "scroll" => " ____\n(    )\n|-..-|",
+      "crown"  => "^v^v^\n|___|",
+      "gem"    => " /\\\n<  >\n \\/",
+      "coin"   => ".---.\n|($)|\n'---'",
+    }.freeze
+
+    GENERIC_ART = ".-----.\n|     |\n'-----'".freeze
+
+    def self.art_for(item_def)
+      return GENERIC_ART unless item_def
+
+      keywords = item_def["keywords"] || []
+      keywords.each do |kw|
+        return ART[kw] if ART.key?(kw)
+      end
+
+      GENERIC_ART
+    end
+  end
+end

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -3,18 +3,18 @@
 module ClassicGame
   module ItemArt
     ART = {
-      "sword"  => "   /|\n  / |\n /  |\n/___/",
-      "blade"  => "  /\n |/\n  |\\\n  |_",
-      "key"    => " (O)--\n |___]",
+      "sword" => "   /|\n  / |\n /  |\n/___/",
+      "blade" => "  /\n |/\n  |\\\n  |_",
+      "key" => " (O)--\n |___]",
       "potion" => "  _\n(/)\n|~|\n|_|",
       "shield" => "/---\\\n|[*]|\n\\---/",
       "scroll" => " ____\n(    )\n|-..-|",
-      "crown"  => "^v^v^\n|___|",
-      "gem"    => " /\\\n<  >\n \\/",
-      "coin"   => ".---.\n|($)|\n'---'",
+      "crown" => "^v^v^\n|___|",
+      "gem" => " /\\\n<  >\n \\/",
+      "coin" => ".---.\n|($)|\n'---'"
     }.freeze
 
-    GENERIC_ART = ".-----.\n|     |\n'-----'".freeze
+    GENERIC_ART = ".-----.\n|     |\n'-----'"
 
     def self.art_for(item_def)
       return GENERIC_ART unless item_def

--- a/test/lib/classic_game/handlers/inventory_handler_test.rb
+++ b/test/lib/classic_game/handlers/inventory_handler_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {},
+          "items" => []
+        }
+      },
+      items: {
+        "sword" => {
+          "name" => "Iron Sword",
+          "keywords" => %w[sword iron],
+          "description" => "A sharp iron blade. It gleams in the light."
+        },
+        "shield" => {
+          "name" => "Wooden Shield",
+          "keywords" => ["shield"],
+          "description" => "A sturdy wooden shield."
+        },
+        "mystery_item" => {
+          "name" => "Strange Object",
+          "keywords" => ["mystery"],
+          "description" => "You have no idea what this is."
+        },
+        "rock" => {
+          "name" => "Plain Rock",
+          "keywords" => ["rock"]
+        }
+      },
+      creatures: {
+        "troll" => {
+          "name" => "Cave Troll",
+          "keywords" => ["troll"],
+          "health" => 5,
+          "max_health" => 5,
+          "damage" => 2,
+          "description" => "A fearsome troll."
+        }
+      }
+    )
+    @game = build_game(world_data: @world, player_id: USER_ID)
+  end
+
+  test "inventory when empty shows carrying nothing" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "You are carrying nothing."
+  end
+
+  test "inventory shows decorated header" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+  end
+
+  test "inventory shows item name for each item" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: %w[sword shield])
+    result = execute("inventory")
+
+    assert_includes result[:response], "Iron Sword"
+    assert_includes result[:response], "Wooden Shield"
+  end
+
+  test "inventory shows ASCII art for items with matching keywords" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], ClassicGame::ItemArt::ART["sword"].split("\n").first
+  end
+
+  test "inventory shows item description" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "A sharp iron blade."
+  end
+
+  test "inventory shows generic art for items without matching keywords" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["mystery_item"])
+    result = execute("inventory")
+
+    assert_includes result[:response], ClassicGame::ItemArt::GENERIC_ART.split("\n").first
+  end
+
+  test "inventory shows examine hint" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "EXAMINE"
+  end
+
+  test "inventory shows fallback description for items without description" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["rock"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "A mysterious item."
+  end
+
+  test "inventory shortcut i works" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("i")
+
+    assert_includes result[:response], "=== INVENTORY ==="
+    assert_includes result[:response], "Iron Sword"
+  end
+
+  test "inventory works during combat" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in(
+      "room1",
+      inventory: ["sword"],
+      combat: {
+        "active" => true,
+        "creature_id" => "troll",
+        "creature_health" => 5,
+        "creature_max_health" => 5,
+        "round_number" => 1,
+        "defending" => false,
+        "turn_order" => "player"
+      }
+    )
+    command = ClassicGame::CommandParser.parse("inventory")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+  end
+
+  private
+
+    def execute(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+end


### PR DESCRIPTION
## Summary

- Replaced the flat `"You are carrying: - Item Name"` inventory display with a rich, decorated format
- Each item renders inside a box-drawing border (`┌─┐│└─┘`) with ASCII art, the item name, and a one-sentence description
- Added `ClassicGame::ItemArt` module (`app/lib/classic_game/item_art.rb`) with art keyed to 9 item categories (sword, blade, key, potion, shield, scroll, crown, gem, coin) and a generic fallback for unrecognized items
- Empty inventory message and all existing `assert_includes` checks on item names continue to pass unchanged
- Added `"Type EXAMINE <item> to inspect an item more closely."` hint at the end of every non-empty inventory response

## Implementation details

**New files:**
- `app/lib/classic_game/item_art.rb` — `ClassicGame::ItemArt` module with `ART` hash, `GENERIC_ART` constant, and `.art_for(item_def)` class method
- `test/lib/classic_game/handlers/inventory_handler_test.rb` — 10 unit tests covering all acceptance criteria

**Modified files:**
- `app/lib/classic_game/handlers/examine_handler.rb` — `handle_inventory` replaced with decorated output; two new private helpers (`format_inventory_item`, `inventory_art_for`) keep method lengths under the 60-line RuboCop limit

## Test plan

- [ ] `bin/rails test test/lib/classic_game/handlers/inventory_handler_test.rb` — 10 new unit tests
- [ ] `bin/rails test test/lib/classic_game/full_game_system_test.rb` — existing full-game assertions on item names continue to pass
- [ ] `bin/rails test` — full suite green

## Fix notes

**CI RuboCop fixes (commit 250e797):**
- Fixed `if/else/end` indentation alignment in `format_inventory_item` (`examine_handler.rb:182`)
- Changed double-quoted strings inside interpolations to single-quoted (`border_top`/`border_bot`)
- Removed extra alignment spaces from `ART` hash keys in `item_art.rb` for consistent `key` style
- Removed trailing comma after last hash entry
- Removed redundant `.freeze` on `GENERIC_ART` string literal

🤖 Generated with [Claude Code](https://claude.ai/claude-code)