### PR TITLE
Interactive Inventory System

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -92,4 +92,19 @@
   .input {
     @apply p-[5px] text-lg bg-stone-800 outline-none focus:outline-none focus-visible:outline-none focus:border-terminal-green placeholder:text-terminal-green placeholder:opacity-[0.5] ring-transparent focus:ring-transparent focus-visible:ring-transparent;
   }
+
+  .inventory-item {
+    @apply border border-terminal-green px-2 py-1 cursor-pointer my-1;
+    transition: background-color 0.15s ease;
+  }
+
+  @media (hover: hover) {
+    .inventory-item:hover {
+      @apply bg-terminal-green bg-opacity-10;
+    }
+  }
+
+  .inventory-detail {
+    @apply mt-1;
+  }
 }

--- a/app/components/message_component.html.erb
+++ b/app/components/message_component.html.erb
@@ -2,7 +2,13 @@
 	<% if @message.event? %>
 		<%= render(EventMessageComponent.new(@message)) %>
 	<% elsif @message.host_message? %>
-		<%= simple_format(@message.content) %>
+		<% if inventory_message? %>
+			<div data-controller="inventory">
+				<%= format_inventory_html(@message.content) %>
+			</div>
+		<% else %>
+			<%= simple_format(@message.content) %>
+		<% end %>
 	<% elsif @message.player_message? %>
 		<%= @message.display_name %> /&gt; <%= @message.content %>
 	<% end %>

--- a/app/components/message_component.rb
+++ b/app/components/message_component.rb
@@ -57,7 +57,7 @@ class MessageComponent < ViewComponent::Base
 
       art_end = rest.index { |l| l.present? && !l.start_with?("  ") } || rest.length
       art_text = rest[0...art_end].join("\n")
-      detail_text = rest[art_end..].reject(&:blank?).join("\n")
+      detail_text = rest[art_end..].compact_blank.join("\n")
 
       content_tag(:div, class: "inventory-item", data: { action: "click->inventory#toggle" }) do
         content_tag(:div, name_line, class: "font-bold") +

--- a/app/components/message_component.rb
+++ b/app/components/message_component.rb
@@ -15,4 +15,56 @@ class MessageComponent < ViewComponent::Base
       "text-white host-message py-2 pl-5": @message.host_message? && !@message.event?
     )
   end
+
+  def inventory_message?
+    @message.content.to_s.start_with?("=== INVENTORY ===")
+  end
+
+  def format_inventory_html(content)
+    parts = split_inventory_parts(content)
+    safe_join(parts.map { |part| render_inventory_part(part) })
+  end
+
+  private
+
+    def split_inventory_parts(content)
+      parts = []
+      buffer = []
+
+      content.split("\n").each do |line|
+        if line.match?(/^\[.+\]$/) && buffer.any?
+          parts << buffer.dup
+          buffer = [line]
+        else
+          buffer << line
+        end
+      end
+      parts << buffer unless buffer.empty?
+      parts
+    end
+
+    def render_inventory_part(lines)
+      if lines.first&.match?(/^\[.+\]$/)
+        render_item_part(lines)
+      else
+        content_tag(:div, lines.join("\n"), class: "whitespace-pre-wrap")
+      end
+    end
+
+    def render_item_part(lines)
+      name_line = lines[0]
+      rest = lines[1..] || []
+
+      art_end = rest.index { |l| l.present? && !l.start_with?("  ") } || rest.length
+      art_text = rest[0...art_end].join("\n")
+      detail_text = rest[art_end..].reject(&:blank?).join("\n")
+
+      content_tag(:div, class: "inventory-item", data: { action: "click->inventory#toggle" }) do
+        content_tag(:div, name_line, class: "font-bold") +
+          content_tag(:div, data: { inventory_detail: true }, class: "inventory-detail hidden") do
+            content_tag(:pre, art_text, class: "text-xs leading-tight") +
+              content_tag(:p, detail_text)
+          end
+      end
+    end
 end

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -12,6 +12,7 @@ export default class extends Controller {
   observer = null
   scrollPosition = 'last'
   message_count = 0
+  lastInventoryAt = 0
 
   connect(){
     const targetNode = document.querySelector('.grid-in-message-container');
@@ -87,6 +88,14 @@ export default class extends Controller {
       let inputText = e.target.textContent.trim().toUpperCase()
 
       if(inputText === ""){ return false; }
+
+      if(/^(INVENTORY|INV|I)$/.test(inputText)) {
+        if(Date.now() - this.lastInventoryAt < 3000) {
+          this.show_error("Wait before checking inventory again.", true)
+          return false;
+        }
+        this.lastInventoryAt = Date.now()
+      }
 
       window.stimulus_controller("terminalInput", "terminal").clear_input()
       this.errorTarget.style.display = "none"

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -90,7 +90,7 @@ export default class extends Controller {
       if(inputText === ""){ return false; }
 
       if(/^(INVENTORY|INV|I)$/.test(inputText)) {
-        if(Date.now() - this.lastInventoryAt < 3000) {
+        if(Date.now() - this.lastInventoryAt < 500) {
           this.show_error("Wait before checking inventory again.", true)
           return false;
         }

--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle(event) {
+    const item = event.currentTarget
+    const details = item.querySelectorAll("[data-inventory-detail]")
+    details.forEach(detail => detail.classList.toggle("hidden"))
+  }
+}

--- a/app/lib/classic_game/base_handler.rb
+++ b/app/lib/classic_game/base_handler.rb
@@ -225,6 +225,11 @@ module ClassicGame
         total_defense
       end
 
+      # Return ASCII art for an item, delegating to the InventoryArt registry
+      def item_art(item_id, item_def)
+        ClassicGame::InventoryArt.for(item_id, item_def)
+      end
+
       # Check if a dice roll is pending
       def pending_roll?
         player_state["pending_roll"].present?

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -163,13 +163,54 @@ module ClassicGame
 
           return success("You are carrying nothing.") if inventory.empty?
 
-          lines = ["You are carrying:"]
-          inventory.each do |item_id|
-            item_name = world_snapshot.dig("items", item_id, "name") || item_id
-            lines << "  - #{item_name}"
+          # Anti-spam: condensed mode when called twice in the same turn
+          if player_state["last_inventory_at"] == game.turn_count
+            names = inventory.map { |id| world_snapshot.dig("items", id, "name") || id }
+            return success("You are carrying: #{names.join(', ')}")
           end
 
+          lines = ["=== INVENTORY ===", ""]
+
+          inventory.each do |item_id|
+            item_def = world_snapshot.dig("items", item_id)
+            if item_def
+              lines.concat(inventory_item_block(item_id, item_def))
+            else
+              lines << "[#{item_id}]"
+            end
+            lines << ""
+          end
+
+          lines << "--- Type EXAMINE [item] for details ---"
+
+          new_state = player_state.merge("last_inventory_at" => game.turn_count)
+          update_player_state(new_state)
+
           success(lines.join("\n"))
+        end
+
+        def inventory_item_block(item_id, item_def)
+          lines = []
+          lines << "[#{item_def['name']}]"
+
+          # ASCII art indented 2 spaces
+          art = item_art(item_id, item_def)
+          art.each_line { |art_line| lines << "  #{art_line.chomp}" }
+
+          # Brief description (first sentence)
+          if item_def["description"].present?
+            first_sentence = item_def["description"].split(/(?<=[.!?])\s+/).first
+            lines << first_sentence
+          end
+
+          # Stat indicators
+          stats = []
+          stats << "(weapon +#{item_def['weapon_damage']})" if item_def["weapon_damage"].present?
+          stats << "(defense +#{item_def['defense_bonus']})" if item_def["defense_bonus"].present?
+          stats << "(consumable)" if item_def["consumable"]
+          lines << stats.join(" ") if stats.any?
+
+          lines
         end
 
         def describe_current_room

--- a/app/lib/classic_game/inventory_art.rb
+++ b/app/lib/classic_game/inventory_art.rb
@@ -3,7 +3,7 @@
 module ClassicGame
   class InventoryArt
     ART = {
-      "weapon" => <<~ART.chomp,
+      "weapon" => <<~'ART'.chomp,
            |>
           /|
          / |
@@ -11,53 +11,53 @@ module ClassicGame
         |__|
          ||
       ART
-      "potion" => <<~ART.chomp,
+      "potion" => <<~'ART'.chomp,
           ,--.
          ( ~~ )
         |/~~~~\|
         |      |
          '----'
       ART
-      "key" => <<~ART.chomp,
+      "key" => <<~'ART'.chomp,
           ___
          (   )
           ---
            |
           _|_
       ART
-      "scroll" => <<~ART.chomp,
+      "scroll" => <<~'ART'.chomp,
           .---.
          (     )
          |~~~~~|
          (     )
           '---'
       ART
-      "shield" => <<~ART.chomp,
+      "shield" => <<~'ART'.chomp,
           /--\
          /    \
         | |  | |
          \ -- /
           \--/
       ART
-      "container" => <<~ART.chomp,
+      "container" => <<~'ART'.chomp,
          _____
         |-----|
         |     |
         |_____|
       ART
-      "crown" => <<~ART.chomp,
+      "crown" => <<~'ART'.chomp,
         |\ /\ /|
         | V  V |
         |      |
          \----/
       ART
-      "gem" => <<~ART.chomp,
+      "gem" => <<~'ART'.chomp,
             /\
            /  \
           / <> \
         /________\
       ART
-      "default" => <<~ART.chomp,
+      "default" => <<~'ART'.chomp,
           ___
          /   \
         | bag |

--- a/app/lib/classic_game/inventory_art.rb
+++ b/app/lib/classic_game/inventory_art.rb
@@ -3,7 +3,7 @@
 module ClassicGame
   class InventoryArt
     ART = {
-      "weapon" => <<~'ART'.chomp,
+      "weapon" => <<~ART.chomp,
            |>
           /|
          / |
@@ -11,53 +11,53 @@ module ClassicGame
         |__|
          ||
       ART
-      "potion" => <<~'ART'.chomp,
+      "potion" => <<~ART.chomp,
           ,--.
          ( ~~ )
         |/~~~~\|
         |      |
          '----'
       ART
-      "key" => <<~'ART'.chomp,
-          ___
-         (   )
-          ---
-           |
-          _|_
+      "key" => <<~ART.chomp,
+            ___
+           (   )
+            ---
+             |
+            _|_
       ART
-      "scroll" => <<~'ART'.chomp,
-          .---.
-         (     )
-         |~~~~~|
-         (     )
-          '---'
+      "scroll" => <<~ART.chomp,
+            .---.
+           (     )
+           |~~~~~|
+           (     )
+            '---'
       ART
-      "shield" => <<~'ART'.chomp,
+      "shield" => <<~ART.chomp,
           /--\
          /    \
         | |  | |
          \ -- /
           \--/
       ART
-      "container" => <<~'ART'.chomp,
+      "container" => <<~ART.chomp,
          _____
         |-----|
         |     |
         |_____|
       ART
-      "crown" => <<~'ART'.chomp,
+      "crown" => <<~ART.chomp,
         |\ /\ /|
         | V  V |
         |      |
          \----/
       ART
-      "gem" => <<~'ART'.chomp,
+      "gem" => <<~ART.chomp,
             /\
            /  \
           / <> \
         /________\
       ART
-      "default" => <<~'ART'.chomp,
+      "default" => <<~ART.chomp
           ___
          /   \
         | bag |
@@ -66,7 +66,7 @@ module ClassicGame
       ART
     }.freeze
 
-    def self.for(item_id, item_def)
+    def self.for(_item_id, item_def)
       return item_def["art"] if item_def["art"].present?
 
       # Check keywords against category names

--- a/app/lib/classic_game/inventory_art.rb
+++ b/app/lib/classic_game/inventory_art.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  class InventoryArt
+    ART = {
+      "weapon" => <<~ART.chomp,
+           |>
+          /|
+         / |
+        /  |
+        |__|
+         ||
+      ART
+      "potion" => <<~ART.chomp,
+          ,--.
+         ( ~~ )
+        |/~~~~\|
+        |      |
+         '----'
+      ART
+      "key" => <<~ART.chomp,
+          ___
+         (   )
+          ---
+           |
+          _|_
+      ART
+      "scroll" => <<~ART.chomp,
+          .---.
+         (     )
+         |~~~~~|
+         (     )
+          '---'
+      ART
+      "shield" => <<~ART.chomp,
+          /--\
+         /    \
+        | |  | |
+         \ -- /
+          \--/
+      ART
+      "container" => <<~ART.chomp,
+         _____
+        |-----|
+        |     |
+        |_____|
+      ART
+      "crown" => <<~ART.chomp,
+        |\ /\ /|
+        | V  V |
+        |      |
+         \----/
+      ART
+      "gem" => <<~ART.chomp,
+            /\
+           /  \
+          / <> \
+        /________\
+      ART
+      "default" => <<~ART.chomp,
+          ___
+         /   \
+        | bag |
+        |     |
+         \___/
+      ART
+    }.freeze
+
+    def self.for(item_id, item_def)
+      return item_def["art"] if item_def["art"].present?
+
+      # Check keywords against category names
+      keywords = item_def["keywords"] || []
+      ART.each_key do |category|
+        return ART[category] if keywords.any? do |kw|
+          kw.downcase.include?(category) || category.include?(kw.downcase)
+        end
+      end
+
+      # Semantic property fallbacks
+      return ART["weapon"] if item_def["weapon_damage"].present?
+      return ART["potion"] if item_def.dig("combat_effect", "type") == "heal"
+      return ART["container"] if item_def["is_container"]
+
+      ART["default"]
+    end
+  end
+end

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -428,7 +428,10 @@ class FullGameSystemTest < ActiveSupport::TestCase
       assert_not_includes game.player_state(USER_ID)["inventory"], "gem"
 
       r = ex(game, user, "inventory")
+      assert_includes r[:response], "=== INVENTORY ==="
       assert_includes r[:response], "Enchanted Blade"
+      # Enchanted blade has weapon_damage so weapon art (contains "|>") should appear
+      assert_includes r[:response], "|>"
     end
 
     # Phase 8: traverse the now-revealed hidden exit and pick up the victory crown
@@ -480,10 +483,12 @@ class FullGameSystemTest < ActiveSupport::TestCase
     # Phase 10: final state verification
     def phase_verification(game, user)
       r = ex(game, user, "inventory")
-      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
-      assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
-      assert_includes r[:response], "Old Key",         "old key should still be in inventory"
-      assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+      assert_includes r[:response], "=== INVENTORY ===", "PHASE 10: inventory should show enhanced header"
+      assert_includes r[:response], "EXAMINE",           "inventory should show EXAMINE footer hint"
+      assert_includes r[:response], "Victory Crown",     "PHASE 9: victory crown should be in inventory"
+      assert_includes r[:response], "Enchanted Blade",   "enchanted blade should be in inventory"
+      assert_includes r[:response], "Old Key",           "old key should still be in inventory"
+      assert_not_includes r[:response], "Glowing Gem",   "gem was given away"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
       assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"

--- a/test/lib/classic_game/handlers/inventory_display_test.rb
+++ b/test/lib/classic_game/handlers/inventory_display_test.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryDisplayTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {}
+        }
+      },
+      items: {
+        "sword" => {
+          "name" => "Iron Sword",
+          "keywords" => %w[sword iron],
+          "takeable" => true,
+          "weapon_damage" => 3,
+          "description" => "A razor-sharp iron sword. Forged in fire."
+        },
+        "shield" => {
+          "name" => "Wooden Shield",
+          "keywords" => %w[shield wooden],
+          "takeable" => true,
+          "defense_bonus" => 2,
+          "description" => "A sturdy wooden shield."
+        },
+        "potion" => {
+          "name" => "Health Potion",
+          "keywords" => %w[potion health],
+          "takeable" => true,
+          "consumable" => true,
+          "description" => "A red potion that restores health.",
+          "combat_effect" => { "type" => "heal", "amount" => 5 }
+        },
+        "trinket" => {
+          "name" => "Strange Trinket",
+          "keywords" => %w[trinket strange],
+          "takeable" => true,
+          "description" => "A curious trinket of unknown origin."
+        },
+        "magic_orb" => {
+          "name" => "Magic Orb",
+          "keywords" => %w[orb magic],
+          "takeable" => true,
+          "art" => "<*>\n|X|\n<*>",
+          "description" => "A glowing orb humming with power."
+        },
+        "crate" => {
+          "name" => "Wooden Crate",
+          "keywords" => %w[crate wooden],
+          "is_container" => true,
+          "starts_closed" => false,
+          "contents" => []
+        }
+      }
+    )
+  end
+
+  # ─── Test 1: Header and footer ──────────────────────────────────────────────
+
+  test "inventory shows header and footer" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: %w[sword potion])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+    assert_includes result[:response], "Iron Sword"
+    assert_includes result[:response], "Health Potion"
+    assert_includes result[:response], "EXAMINE"
+  end
+
+  # ─── Test 2: ASCII art for weapon ───────────────────────────────────────────
+
+  test "inventory shows ASCII art for weapon" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: %w[sword potion])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    # Weapon art contains the distinctive "|>" marker
+    assert_includes result[:response], "|>"
+  end
+
+  # ─── Test 3: Item stats ──────────────────────────────────────────────────────
+
+  test "inventory shows item stats" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: %w[sword shield potion])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "(weapon +3)"
+    assert_includes result[:response], "(defense +2)"
+    assert_includes result[:response], "(consumable)"
+  end
+
+  # ─── Test 4: Condensed list on rapid repeat ──────────────────────────────────
+
+  test "inventory shows condensed list on rapid repeat" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: %w[sword shield])
+    )
+
+    # First call — full display
+    result1 = execute("inventory")
+    assert result1[:success]
+    assert_includes result1[:response], "=== INVENTORY ==="
+
+    # Second call on the same turn (turn_count not incremented) — condensed
+    result2 = execute("inventory")
+    assert result2[:success]
+    assert_includes result2[:response], "You are carrying:"
+    assert_not_includes result2[:response], "=== INVENTORY ==="
+  end
+
+  # ─── Test 5: Empty inventory unchanged ───────────────────────────────────────
+
+  test "empty inventory unchanged" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: [])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_equal "You are carrying nothing.", result[:response]
+  end
+
+  # ─── Test 6: Custom item art ─────────────────────────────────────────────────
+
+  test "inventory with custom item art" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: ["magic_orb"])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "<*>"
+  end
+
+  # ─── Test 7: Inventory works during combat ────────────────────────────────────
+
+  test "inventory works during combat" do
+    combat_state = {
+      "active" => true,
+      "creature_id" => "troll",
+      "creature_health" => 5,
+      "creature_max_health" => 5,
+      "moves" => 0
+    }
+    world_with_creature = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Cave", "description" => "A cave.", "exits" => {} }
+      },
+      items: {
+        "sword" => {
+          "name" => "Iron Sword",
+          "keywords" => %w[sword],
+          "takeable" => true,
+          "weapon_damage" => 3,
+          "description" => "A sharp sword."
+        }
+      },
+      creatures: {
+        "troll" => {
+          "name" => "Troll",
+          "keywords" => ["troll"],
+          "hostile" => true,
+          "health" => 5,
+          "attack" => 2,
+          "defense" => 0
+        }
+      }
+    )
+    game = build_game(
+      world_data: world_with_creature,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: ["sword"], combat: combat_state)
+    )
+
+    command = ClassicGame::CommandParser.parse("inventory")
+    result = ClassicGame::Handlers::CombatHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+  end
+
+  # ─── Test 8: Art fallback to default for unknown item ─────────────────────────
+
+  test "inventory art fallback to default for unknown item" do
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: ["trinket"])
+    )
+
+    result = execute("inventory")
+
+    assert result[:success]
+    # Default art contains "| bag |"
+    assert_includes result[:response], "| bag |"
+  end
+
+  private
+
+    def execute(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -67,7 +67,7 @@ module TestSupport
         "name" => "The Market",
         "description" => "Colorful stalls line the street, filled with exotic wares.",
         "exits" => { "east" => "town_square" },
-        "items" => [],
+        "items" => ["magic_wand"],
         "npcs" => ["merchant"]
       }
     end
@@ -141,7 +141,15 @@ module TestSupport
           "defense_bonus" => 3,
           "description" => "A sturdy iron shield."
         },
-        "lockpick" => lockpick_item
+        "lockpick" => lockpick_item,
+        "magic_wand" => {
+          "name" => "Magic Wand",
+          "keywords" => %w[wand magic],
+          "takeable" => true,
+          "weapon_damage" => 2,
+          "art" => "  *  \n *** \n  *  ",
+          "description" => "A slender wand crackling with arcane energy."
+        }
       }
     end
 

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -79,7 +79,7 @@ module QaWorld
         cmd_and_wait "take key"
 
         cmd "inventory"
-        assert_text "You are carrying"
+        assert_text "=== INVENTORY ==="
       end
 
       # ─── Phase 3: Dialogue ────────────────────────────────────────

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class InventoryTest < ApplicationSystemTestCase
+    test "inventory shows enhanced display with header and footer" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      # Take the rusty key so inventory is non-empty
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "=== INVENTORY ==="
+      assert_text "Rusty Key"
+      assert_text "EXAMINE"
+    end
+
+    test "inventory shows key art for key item" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("inventory", :return)
+      # Key art contains "(   )" from the key icon
+      assert_text "(   )"
+    end
+
+    test "inventory shows custom art for magic wand" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("go west", :return)
+      assert_text "The Market"
+
+      find(".terminal-input").send_keys("take wand", :return)
+      assert_text "Magic Wand"
+
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "=== INVENTORY ==="
+      assert_text "Magic Wand"
+      assert_text "***"
+    end
+  end
+end

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -15,6 +15,9 @@ module QaWorld
       find(".terminal-input").send_keys("inventory", :return)
       assert_text "=== INVENTORY ==="
       assert_text "Rusty Key"
+
+      # Click the inventory item to expand hidden detail
+      find(".inventory-item", text: "Rusty Key").click
       assert_text "EXAMINE"
     end
 
@@ -26,7 +29,10 @@ module QaWorld
       assert_text "Rusty Key"
 
       find(".terminal-input").send_keys("inventory", :return)
-      # Key art contains "(   )" from the key icon
+      assert_text "=== INVENTORY ==="
+
+      # Click the inventory item to expand and reveal art
+      find(".inventory-item", text: "Rusty Key").click
       assert_text "(   )"
     end
 
@@ -43,6 +49,9 @@ module QaWorld
       find(".terminal-input").send_keys("inventory", :return)
       assert_text "=== INVENTORY ==="
       assert_text "Magic Wand"
+
+      # Click the inventory item to expand and reveal art
+      find(".inventory-item", text: "Magic Wand").click
       assert_text "***"
     end
   end


### PR DESCRIPTION
## Description

Add visual ASCII art and item descriptions to the inventory interface to make viewing items more engaging and prevent spam from repeated inventory checks. Players can click/tap items to view details, creating a more polished UX while maintaining the text adventure feel.

## Acceptance Criteria
- Inventory items display with ASCII art (at least for select items)
- Players can click/tap items to reveal detailed descriptions
- Inventory view is noticeably more visually appealing than plain text lists
- Feature works in both single-player and multiplayer environments
- Descriptions are readable and don't clutter the main chat/output area

Kind: feature

## Fix Notes
- Fixed 9 RuboCop offenses:
  - `message_component.rb`: replaced `reject(&:blank?)` with `compact_blank` (Rails/CompactBlank)
  - `inventory_art.rb`: removed redundant heredoc delimiter quotes (Style/RedundantHeredocDelimiterQuotes)
  - `inventory_art.rb`: fixed heredoc indentation to 2 spaces (Layout/HeredocIndentation)
  - `inventory_art.rb`: removed trailing comma after last hash item (Style/TrailingCommaInHashLiteral)
  - `inventory_art.rb`: prefixed unused `item_id` argument with underscore (Lint/UnusedMethodArgument)