### PR TITLE
Visual Inventory System

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -96,4 +96,14 @@
   .input {
     @apply p-[5px] text-lg bg-stone-800 outline-none focus:outline-none focus-visible:outline-none focus:border-terminal-green placeholder:text-terminal-green placeholder:opacity-[0.5] ring-transparent focus:ring-transparent focus-visible:ring-transparent;
   }
+
+  .inventory-item-line {
+    cursor: pointer;
+    transition: color 0.15s;
+  }
+
+  .inventory-item-line:hover {
+    color: #fff;
+    text-decoration: underline;
+  }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -79,6 +79,10 @@
 }
 
 @layer components {
+  .host-message p {
+    white-space: pre-wrap;
+  }
+
   .button {
     @apply px-[10px] py-[2px] font-bold border-solid border-2 border-terminal-green text-terminal-green inline-block uppercase cursor-pointer active:text-stone-800 active:bg-terminal-green focus-visible:text-stone-800 focus-visible:bg-terminal-green focus-visible:outline-none;
   }

--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -1,0 +1,71 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  observer = null
+
+  connect() {
+    setTimeout(() => {
+      this.observer = new MutationObserver((mutationsList) => {
+        for (const mutation of mutationsList) {
+          if (mutation.type === "childList") {
+            mutation.addedNodes.forEach((node) => {
+              if (node.nodeType === Node.ELEMENT_NODE && node.classList.contains("game-message")) {
+                setTimeout(() => this.enhanceInventoryMessage(node), 0)
+              }
+            })
+          }
+        }
+      })
+      this.observer.observe(this.element, { childList: true, subtree: true })
+    }, 0)
+  }
+
+  disconnect() {
+    if (this.observer) {
+      this.observer.disconnect()
+    }
+  }
+
+  enhanceInventoryMessage(messageNode) {
+    const text = messageNode.textContent || ""
+    if (!text.includes("INVENTORY") || !text.includes("╔")) {
+      return
+    }
+
+    const paragraphs = messageNode.querySelectorAll("p")
+    paragraphs.forEach((p) => {
+      const lines = p.innerHTML.split(/<br\s*\/?>/i)
+      const enhanced = lines.map((line) => {
+        const plainText = line.replace(/<[^>]+>/g, "")
+        const match = plainText.match(/^║\s(.{3})\s(.+?)\s*║\s*$/)
+        if (match) {
+          const itemName = match[2].trim()
+          if (itemName && !itemName.match(/^\d+ items?$/) && !itemName.startsWith("INVENTORY")) {
+            const escaped = itemName.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+            return line.replace(
+              plainText,
+              plainText.replace(
+                itemName,
+                `<span class="inventory-item-line" data-item-name="${escaped}">${escaped}</span>`
+              )
+            )
+          }
+        }
+        return line
+      })
+      p.innerHTML = enhanced.join("<br>")
+    })
+
+    messageNode.querySelectorAll(".inventory-item-line").forEach((span) => {
+      span.addEventListener("click", (e) => {
+        const name = e.currentTarget.dataset.itemName
+        if (!name) return
+        const input = document.querySelector(".terminal-input[contenteditable]")
+        if (!input) return
+        input.textContent = "EXAMINE " + name
+        const event = new KeyboardEvent("keydown", { keyCode: 13, bubbles: true, cancelable: true })
+        input.dispatchEvent(event)
+      })
+    })
+  }
+}

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -43,6 +43,9 @@ module ClassicGame
             # Check if it's a container
             return handle_examine_container(item_id, item_def) if item_def["is_container"]
 
+            # Enriched view for inventory items
+            return enriched_item_description(item_id, item_def) if item?(item_id)
+
             # Regular item examination
             description = item_def["description"] || "You see nothing special about the #{item_def['name']}."
             return success(description)
@@ -163,11 +166,33 @@ module ClassicGame
 
           return success("You are carrying nothing.") if inventory.empty?
 
-          lines = ["You are carrying:"]
+          lines = ["=== INVENTORY ==="]
           inventory.each do |item_id|
-            item_name = world_snapshot.dig("items", item_id, "name") || item_id
-            lines << "  - #{item_name}"
+            item_def = world_snapshot.dig("items", item_id)
+            item_name = item_def&.dig("name") || item_id
+            art_line = ClassicGame::ItemArt.art_for(item_id, item_def).lines.first.chomp
+            lines << "  #{art_line}  #{item_name}"
           end
+          lines << "(#{inventory.size} #{inventory.size == 1 ? 'item' : 'items'}) — EXAMINE <item> for details"
+
+          success(lines.join("\n"))
+        end
+
+        def enriched_item_description(item_id, item_def)
+          art = ClassicGame::ItemArt.art_for(item_id, item_def)
+          name = item_def["name"] || item_id
+          description = item_def["description"] || "You see nothing special about the #{name}."
+
+          stats = []
+          stats << "Damage: +#{item_def['weapon_damage']}" if item_def["weapon_damage"]
+          stats << "Defense: +#{item_def['defense_bonus']}" if item_def["defense_bonus"]
+          if item_def["consumable"]
+            stats << "Consumable"
+            stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP" if item_def.dig("combat_effect", "type") == "heal"
+          end
+
+          lines = [art, "--- #{name} ---", description]
+          lines << stats.join(" | ") if stats.any?
 
           success(lines.join("\n"))
         end

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -16,6 +16,8 @@ module ClassicGame
         end
       end
 
+      BOX_WIDTH = 25
+
       private
 
         def handle_look(target)
@@ -166,14 +168,38 @@ module ClassicGame
 
           return success("You are carrying nothing.") if inventory.empty?
 
-          lines = ["=== INVENTORY ==="]
+          last_at = player_state["last_inventory_at"].to_f
+          now = Time.now.to_f
+          update_player_state(player_state.merge("last_inventory_at" => now))
+
+          item_count = inventory.size
+          item_word = item_count == 1 ? "item" : "items"
+
+          if last_at > 0 && now - last_at < 2.0
+            return success("You're carrying #{item_count} #{item_word}. EXAMINE <item> for details.")
+          end
+
+          border    = "╔" + ("═" * BOX_WIDTH) + "╗"
+          separator = "╠" + ("═" * BOX_WIDTH) + "╣"
+          bottom    = "╚" + ("═" * BOX_WIDTH) + "╝"
+
+          lines = [
+            border,
+            "║" + " INVENTORY ".center(BOX_WIDTH) + "║",
+            separator
+          ]
+
           inventory.each do |item_id|
             item_def = world_snapshot.dig("items", item_id)
-            item_name = item_def&.dig("name") || item_id
-            art_line = ClassicGame::ItemArt.art_for(item_id, item_def).lines.first.chomp
-            lines << "  #{art_line}  #{item_name}"
+            item_name = (item_def&.dig("name") || item_id)[0, 19]
+            icon = ClassicGame::ItemArt.icon_for(item_id, item_def)
+            lines << "║ #{icon} #{item_name.ljust(19)} ║"
           end
-          lines << "(#{inventory.size} #{inventory.size == 1 ? 'item' : 'items'}) — EXAMINE <item> for details"
+
+          lines << separator
+          lines << "║ #{"#{item_count} #{item_word}".ljust(23)} ║"
+          lines << bottom
+          lines << "EXAMINE <item> for details"
 
           success(lines.join("\n"))
         end
@@ -191,10 +217,55 @@ module ClassicGame
             stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP" if item_def.dig("combat_effect", "type") == "heal"
           end
 
-          lines = [art, "--- #{name} ---", description]
-          lines << stats.join(" | ") if stats.any?
+          border    = "╔" + ("═" * BOX_WIDTH) + "╗"
+          separator = "╠" + ("═" * BOX_WIDTH) + "╣"
+          bottom    = "╚" + ("═" * BOX_WIDTH) + "╝"
+
+          lines = [
+            border,
+            "║" + " #{name} ".center(BOX_WIDTH) + "║",
+            separator
+          ]
+
+          art.each_line do |art_line|
+            lines << "║ #{art_line.chomp[0, 23].ljust(23)} ║"
+          end
+
+          lines << separator
+
+          wrap_text(description, 23).each do |desc_line|
+            lines << "║ #{desc_line.ljust(23)} ║"
+          end
+
+          if stats.any?
+            lines << separator
+            stats.each do |stat|
+              lines << "║ #{stat.ljust(23)} ║"
+            end
+          end
+
+          lines << bottom
 
           success(lines.join("\n"))
+        end
+
+        def wrap_text(text, width)
+          words = text.split(" ")
+          result = []
+          current = ""
+
+          words.each do |word|
+            if current.empty?
+              current = word
+            elsif (current + " " + word).length <= width
+              current += " " + word
+            else
+              result << current
+              current = word
+            end
+          end
+          result << current unless current.empty?
+          result
         end
 
         def describe_current_room

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -8,15 +8,37 @@ module ClassicGame
       "key" => "--o\n |\n--",
       "scroll" => "/-~-\\\n| ~ |\n\\---/",
       "armor" => " /--\\\n| () |\n \\--/",
+      "shield" => " _\n[#]\n|_|",
       "treasure" => " /\\\n/  \\\n\\**/\n \\/",
       "container" => "+----+\n|    |\n+----+",
       "default" => "[item]"
     }.freeze
 
-    ITEM_ART = {}.freeze
+    ICON_MAP = {
+      "weapon" => "/|\\",
+      "potion" => "(*)",
+      "key" => "-o-",
+      "scroll" => "~=~",
+      "armor" => "[+]",
+      "shield" => "[#]",
+      "treasure" => "<*>",
+      "container" => "[=]",
+      "default" => " * "
+    }.freeze
+
+    ITEM_ART = {
+      "old_key" => " _\n|o|\n '--",
+      "health_potion" => "  _\n (+)\n |H|",
+      "enchanted_blade" => "  *\n /|\n/ |\n===",
+      "victory_crown" => " /\\*\\/\\\n( *** )\n \\___/"
+    }.freeze
 
     def self.art_for(item_id, item_def)
       ITEM_ART[item_id] || CATEGORY_ART[category_for(item_def)] || CATEGORY_ART["default"]
+    end
+
+    def self.icon_for(item_id, item_def)
+      ICON_MAP[category_for(item_def)]
     end
 
     def self.category_for(item_def)
@@ -26,6 +48,7 @@ module ClassicGame
       return "potion" if item_def["consumable"] && item_def.dig("combat_effect", "type") == "heal"
       return "key" if (item_def["keywords"] || []).include?("key")
       return "scroll" if (item_def["keywords"] || []).include?("scroll")
+      return "shield" if (item_def["keywords"] || []).include?("shield")
       return "container" if item_def["is_container"]
       return "treasure" if ((item_def["keywords"] || []) & %w[crown gem]).any?
 

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module ItemArt
+    CATEGORY_ART = {
+      "weapon" => "  /|\n / |\n/  |\n===+",
+      "potion" => "  _\n (*)\n |_|",
+      "key" => "--o\n |\n--",
+      "scroll" => "/-~-\\\n| ~ |\n\\---/",
+      "armor" => " /--\\\n| () |\n \\--/",
+      "treasure" => " /\\\n/  \\\n\\**/\n \\/",
+      "container" => "+----+\n|    |\n+----+",
+      "default" => "[item]"
+    }.freeze
+
+    ITEM_ART = {}.freeze
+
+    def self.art_for(item_id, item_def)
+      ITEM_ART[item_id] || CATEGORY_ART[category_for(item_def)] || CATEGORY_ART["default"]
+    end
+
+    def self.category_for(item_def)
+      item_def = item_def || {}
+      return "weapon" if item_def["weapon_damage"]
+      return "armor" if item_def["defense_bonus"]
+      return "potion" if item_def["consumable"] && item_def.dig("combat_effect", "type") == "heal"
+      return "key" if (item_def["keywords"] || []).include?("key")
+      return "scroll" if (item_def["keywords"] || []).include?("scroll")
+      return "container" if item_def["is_container"]
+      return "treasure" if ((item_def["keywords"] || []) & %w[crown gem]).any?
+
+      "default"
+    end
+  end
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -12,7 +12,7 @@
 <div id="message-content-wrapper" class="invisible">
   <%= render "/messages/pager", game: @game, pagy: @pagy %>
 
-  <div id="game-messages" class="relative">
+  <div id="game-messages" class="relative" data-controller="inventory">
     <%= turbo_frame_tag(:messages) do %>
       <% @messages.reverse.each do |message| %>
         <%= render "/messages/message", message: message %>

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -480,10 +480,16 @@ class FullGameSystemTest < ActiveSupport::TestCase
     # Phase 10: final state verification
     def phase_verification(game, user)
       r = ex(game, user, "inventory")
-      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
+      assert_includes r[:response], "Victory Crown",   "PHASE 10: victory crown should be in inventory"
       assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
       assert_includes r[:response], "Old Key",         "old key should still be in inventory"
       assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+      assert_includes r[:response], "=== INVENTORY ===", "inventory should show formatted header"
+      assert_includes r[:response], "EXAMINE",         "inventory should include examine hint"
+
+      r = ex(game, user, "examine enchanted blade")
+      assert_includes r[:response], "Damage: +3",            "enchanted blade should show weapon stats"
+      assert_includes r[:response], "blade humming with magic", "enchanted blade description should appear"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
       assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -496,7 +496,8 @@ class FullGameSystemTest < ActiveSupport::TestCase
 
       r = ex(game, user, "examine enchanted blade")
       assert_includes r[:response], "Damage: +3",            "enchanted blade should show weapon stats"
-      assert_includes r[:response], "blade humming with magic", "enchanted blade description should appear"
+      plain_response = r[:response].gsub(/[║╔╗╚╝╠╣═]/, "").gsub(/\n/, " ").gsub(/\s+/, " ")
+      assert_includes plain_response, "blade humming with magic", "enchanted blade description should appear"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
       assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -479,6 +479,11 @@ class FullGameSystemTest < ActiveSupport::TestCase
 
     # Phase 10: final state verification
     def phase_verification(game, user)
+      # Clear the inventory throttle timestamp so we get the full visual inventory
+      ps = game.player_state(USER_ID)
+      ps.delete("last_inventory_at")
+      game.update_player_state(USER_ID, ps)
+
       r = ex(game, user, "inventory")
       assert_includes r[:response], "Victory Crown",   "PHASE 10: victory crown should be in inventory"
       assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -484,7 +484,9 @@ class FullGameSystemTest < ActiveSupport::TestCase
       assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
       assert_includes r[:response], "Old Key",         "old key should still be in inventory"
       assert_not_includes r[:response], "Glowing Gem", "gem was given away"
-      assert_includes r[:response], "=== INVENTORY ===", "inventory should show formatted header"
+      assert_includes r[:response], "INVENTORY", "inventory should show formatted header"
+      assert(r[:response].include?("╔") || r[:response].include?("║"),
+             "inventory should show box drawing characters")
       assert_includes r[:response], "EXAMINE",         "inventory should include examine hint"
 
       r = ex(game, user, "examine enchanted blade")

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExamineHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {},
+          "items" => ["sword"]
+        }
+      },
+      items: {
+        "sword" => {
+          "name" => "Iron Sword", "keywords" => %w[sword iron],
+          "takeable" => true, "weapon_damage" => 3,
+          "description" => "A sharp iron sword."
+        },
+        "shield" => {
+          "name" => "Wooden Shield", "keywords" => ["shield"],
+          "takeable" => true, "defense_bonus" => 2,
+          "description" => "A sturdy wooden shield."
+        },
+        "health_potion" => {
+          "name" => "Health Potion", "keywords" => %w[potion health],
+          "takeable" => true, "consumable" => true,
+          "description" => "A red potion.",
+          "combat_effect" => { "type" => "heal", "amount" => 5 }
+        }
+      }
+    )
+    @game = build_game(world_data: @world, player_id: USER_ID)
+  end
+
+  # ─── INVENTORY ───────────────────────────────────────────────────────────────
+
+  test "inventory displays formatted header" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+    assert_includes result[:response], "Iron Sword"
+  end
+
+  test "inventory shows item count" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: %w[sword shield])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "(2 items)"
+  end
+
+  test "inventory shows singular item count" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "(1 item)"
+  end
+
+  test "inventory includes examine hint" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "EXAMINE"
+  end
+
+  test "empty inventory shows carrying nothing" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "You are carrying nothing."
+  end
+
+  # ─── EXAMINE INVENTORY ITEMS ─────────────────────────────────────────────────
+
+  test "examining inventory item shows ASCII art" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert result[:response].include?("\n"), "response should be multi-line with ASCII art"
+  end
+
+  test "examining inventory item shows item name header" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert_includes result[:response], "Iron Sword"
+  end
+
+  test "examining inventory item shows weapon stats" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "Damage: +3"
+  end
+
+  test "examining inventory potion shows consumable" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["health_potion"])
+    result = execute("examine potion")
+
+    assert result[:success]
+    assert_includes result[:response], "Consumable"
+  end
+
+  test "examining inventory potion shows heal amount" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["health_potion"])
+    result = execute("examine potion")
+
+    assert result[:success]
+    assert_includes result[:response], "Heals 5 HP"
+  end
+
+  test "examining inventory armor shows defense stats" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["shield"])
+    result = execute("examine shield")
+
+    assert result[:success]
+    assert_includes result[:response], "Defense: +2"
+  end
+
+  # ─── EXAMINE ROOM ITEMS ───────────────────────────────────────────────────────
+
+  test "examining room item does not show stats" do
+    # sword is in room items but NOT in inventory
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "A sharp iron sword."
+    assert_not_includes result[:response], "Damage:"
+  end
+
+  test "examining room item shows plain description" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "A sharp iron sword."
+  end
+
+  private
+
+    def execute(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+end

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -47,7 +47,9 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = execute("inventory")
 
     assert result[:success]
-    assert_includes result[:response], "=== INVENTORY ==="
+    assert_includes result[:response], "INVENTORY"
+    assert(result[:response].include?("╔") || result[:response].include?("║"),
+           "inventory should show box drawing characters")
     assert_includes result[:response], "Iron Sword"
   end
 
@@ -56,14 +58,14 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = execute("inventory")
 
     assert result[:success]
-    assert_includes result[:response], "(2 items)"
+    assert_includes result[:response], "2 items"
   end
 
   test "inventory shows singular item count" do
     @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
     result = execute("inventory")
 
-    assert_includes result[:response], "(1 item)"
+    assert_includes result[:response], "1 item"
   end
 
   test "inventory includes examine hint" do
@@ -81,14 +83,54 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     assert_includes result[:response], "You are carrying nothing."
   end
 
+  test "inventory shows weapon icon" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "/|\\"
+  end
+
+  test "inventory shows multiple item icons" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: %w[sword health_potion])
+    result = execute("inventory")
+
+    assert_includes result[:response], "/|\\"
+    assert_includes result[:response], "(*)"
+    assert_includes result[:response], "2 items"
+  end
+
+  test "inventory anti-spam returns condensed response on rapid check" do
+    state = player_state_in("room1", inventory: ["sword"]).merge("last_inventory_at" => Time.now.to_f)
+    @game.game_state["player_states"][USER_ID.to_s] = state
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "You're carrying 1 item"
+    assert_includes result[:response], "EXAMINE <item> for details"
+    assert_not(result[:response].include?("╔") || result[:response].include?("╚"),
+               "condensed response should not contain box borders")
+  end
+
+  test "inventory returns full box after cooldown" do
+    state = player_state_in("room1", inventory: ["sword"]).merge("last_inventory_at" => Time.now.to_f - 3.0)
+    @game.game_state["player_states"][USER_ID.to_s] = state
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "INVENTORY"
+    assert(result[:response].include?("╔") || result[:response].include?("║"),
+           "full response should contain box drawing characters")
+  end
+
   # ─── EXAMINE INVENTORY ITEMS ─────────────────────────────────────────────────
 
-  test "examining inventory item shows ASCII art" do
+  test "examining inventory item shows framed output" do
     @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
     result = execute("examine sword")
 
     assert result[:success]
-    assert result[:response].include?("\n"), "response should be multi-line with ASCII art"
+    assert(result[:response].include?("╔") || result[:response].include?("║"),
+           "framed examine should show box drawing characters")
   end
 
   test "examining inventory item shows item name header" do
@@ -130,6 +172,25 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     assert_includes result[:response], "Defense: +2"
   end
 
+  test "examining inventory item shows description in framed output" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "A sharp iron sword."
+  end
+
+  test "examining inventory potion shows framed consumable info" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["health_potion"])
+    result = execute("examine potion")
+
+    assert result[:success]
+    assert(result[:response].include?("╔") || result[:response].include?("║"),
+           "framed examine should show box drawing characters")
+    assert_includes result[:response], "Health Potion"
+    assert_includes result[:response], "Heals 5 HP"
+  end
+
   # ─── EXAMINE ROOM ITEMS ───────────────────────────────────────────────────────
 
   test "examining room item does not show stats" do
@@ -148,6 +209,15 @@ class ExamineHandlerTest < ActiveSupport::TestCase
 
     assert result[:success]
     assert_includes result[:response], "A sharp iron sword."
+  end
+
+  test "examining room item does not show box borders" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_not(result[:response].include?("╔") || result[:response].include?("╚"),
+               "room item examine should not have box borders")
   end
 
   private

--- a/test/lib/classic_game/item_art_test.rb
+++ b/test/lib/classic_game/item_art_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ItemArtTest < ActiveSupport::TestCase
+  # ─── category_for ────────────────────────────────────────────────────────────
+
+  test "category_for returns weapon for weapon_damage items" do
+    assert_equal "weapon", ClassicGame::ItemArt.category_for("weapon_damage" => 3)
+  end
+
+  test "category_for returns armor for defense_bonus items" do
+    assert_equal "armor", ClassicGame::ItemArt.category_for("defense_bonus" => 2)
+  end
+
+  test "category_for returns potion for consumable heal items" do
+    item_def = { "consumable" => true, "combat_effect" => { "type" => "heal", "amount" => 5 } }
+    assert_equal "potion", ClassicGame::ItemArt.category_for(item_def)
+  end
+
+  test "category_for returns key when keywords include key" do
+    assert_equal "key", ClassicGame::ItemArt.category_for("keywords" => %w[brass key])
+  end
+
+  test "category_for returns scroll when keywords include scroll" do
+    assert_equal "scroll", ClassicGame::ItemArt.category_for("keywords" => %w[ancient scroll])
+  end
+
+  test "category_for returns container for is_container items" do
+    assert_equal "container", ClassicGame::ItemArt.category_for("is_container" => true)
+  end
+
+  test "category_for returns treasure when keywords include crown" do
+    assert_equal "treasure", ClassicGame::ItemArt.category_for("keywords" => %w[crown victory])
+  end
+
+  test "category_for returns treasure when keywords include gem" do
+    assert_equal "treasure", ClassicGame::ItemArt.category_for("keywords" => %w[gem glowing])
+  end
+
+  test "category_for returns default for unknown items" do
+    assert_equal "default", ClassicGame::ItemArt.category_for("name" => "Mystery Box")
+  end
+
+  test "category_for handles nil item_def" do
+    assert_equal "default", ClassicGame::ItemArt.category_for(nil)
+  end
+
+  # ─── art_for ─────────────────────────────────────────────────────────────────
+
+  test "art_for returns non-empty string for weapon item" do
+    result = ClassicGame::ItemArt.art_for("anything", "weapon_damage" => 1)
+    assert result.present?
+  end
+
+  test "art_for returns weapon art for weapon_damage items" do
+    result = ClassicGame::ItemArt.art_for("sword", "weapon_damage" => 3)
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["weapon"], result
+  end
+
+  test "art_for falls back to default for unknown items" do
+    result = ClassicGame::ItemArt.art_for("mystery", "name" => "Mystery")
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
+  end
+
+  test "art_for handles nil item_def" do
+    result = ClassicGame::ItemArt.art_for("unknown", nil)
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
+  end
+end

--- a/test/lib/classic_game/item_art_test.rb
+++ b/test/lib/classic_game/item_art_test.rb
@@ -67,4 +67,49 @@ class ItemArtTest < ActiveSupport::TestCase
     result = ClassicGame::ItemArt.art_for("unknown", nil)
     assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
   end
+
+  test "art_for returns specific ITEM_ART entry over generic category art" do
+    result = ClassicGame::ItemArt.art_for("old_key", "keywords" => ["key"])
+    assert_equal ClassicGame::ItemArt::ITEM_ART["old_key"], result
+    assert_not_equal ClassicGame::ItemArt::CATEGORY_ART["key"], result
+  end
+
+  # ─── icon_for ────────────────────────────────────────────────────────────────
+
+  test "icon_for returns weapon icon for weapon_damage items" do
+    result = ClassicGame::ItemArt.icon_for("x", "weapon_damage" => 1)
+    assert_equal "/|\\", result
+  end
+
+  test "icon_for returns armor icon for defense_bonus items" do
+    result = ClassicGame::ItemArt.icon_for("x", "defense_bonus" => 1)
+    assert_equal "[+]", result
+  end
+
+  test "icon_for returns potion icon for consumable heal items" do
+    item_def = { "consumable" => true, "combat_effect" => { "type" => "heal", "amount" => 5 } }
+    result = ClassicGame::ItemArt.icon_for("x", item_def)
+    assert_equal "(*)", result
+  end
+
+  test "icon_for returns default icon for nil item_def" do
+    result = ClassicGame::ItemArt.icon_for("x", nil)
+    assert_equal " * ", result
+  end
+
+  test "icon_for returns shield icon for shield keyword items" do
+    result = ClassicGame::ItemArt.icon_for("x", "keywords" => ["shield"])
+    assert_equal "[#]", result
+  end
+
+  # ─── category_for shield ─────────────────────────────────────────────────────
+
+  test "category_for returns shield when keywords include shield" do
+    assert_equal "shield", ClassicGame::ItemArt.category_for("keywords" => ["shield"])
+  end
+
+  test "category_for returns shield before default fallback" do
+    result = ClassicGame::ItemArt.category_for("keywords" => %w[wooden shield])
+    assert_equal "shield", result
+  end
 end

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class InventoryTest < ApplicationSystemTestCase
+    test "inventory shows formatted header" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "=== INVENTORY ==="
+    end
+
+    test "inventory shows examine hint" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "EXAMINE"
+    end
+
+    test "examine inventory key shows description" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("examine key", :return)
+      assert_text "Rusty Key"
+      assert_text "rusty iron key"
+    end
+  end
+end

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -9,7 +9,7 @@ module QaWorld
       find(".terminal-input").click
       find(".terminal-input").send_keys("take key", :return)
       find(".terminal-input").send_keys("inventory", :return)
-      assert_text "=== INVENTORY ==="
+      assert_text "INVENTORY"
     end
 
     test "inventory shows examine hint" do


### PR DESCRIPTION
## Summary

- Adds box-drawing bordered inventory display with per-item ASCII icons (weapon `/|\`, potion `(*)`, key `-o-`, shield `[#]`, etc.)
- Adds anti-spam cooldown: rapid repeated `INVENTORY` commands return a condensed one-line response instead of the full box
- Framed `EXAMINE` output for inventory items: ASCII art, word-wrapped description, and stats all inside a box-drawn frame
- New `ItemArt.icon_for` and `ICON_MAP` constant; shield category detection; specific `ITEM_ART` entries for `old_key`, `health_potion`, `enchanted_blade`, `victory_crown`
- New Stimulus `inventory` controller that observes game messages, detects inventory output by box-drawing characters, and wraps item names in clickable spans that auto-submit `EXAMINE <item>` commands
- CSS `.inventory-item-line` class for hover styling on clickable inventory items

## Test plan

- [ ] `bin/rails test test/lib/classic_game/handlers/examine_handler_test.rb` — updated and new tests for box-drawing format, icons, anti-spam, framed examine
- [ ] `bin/rails test test/lib/classic_game/item_art_test.rb` — new tests for `icon_for`, shield category, specific `ITEM_ART` entries
- [ ] `bin/rails test test/lib/classic_game/full_game_system_test.rb` — updated phase_verification assertions for new inventory format
- [ ] Manual browser test: type `INVENTORY` in-game, verify box rendering and item name hover/click behavior

## Fix notes

- **`aa45920`**: Fixed `FullGameSystemTest#test_full_game_playthrough` phase 10 failure. The visual inventory's 2-second anti-spam throttle was firing because all test phases execute in-memory faster than 2 seconds. Phase 7 sets `last_inventory_at`, and by phase 10 the wall-clock delta is still under the threshold, so the inventory command returned the compact "You're carrying N items" message instead of the full visual inventory with item names. Fix: clear `last_inventory_at` before the phase 10 inventory assertion.

- **`797ec12`**: Fixed `FullGameSystemTest` line 499 failure. The framed `EXAMINE` output word-wraps long descriptions across lines with box-drawing characters (`║`), so `"blade humming with magic"` is split across two lines. Fix: strip box-drawing characters and normalize whitespace before the substring assertion.

- **`684b267`**: Fixed `QaWorld::InventoryTest#test_inventory_shows_formatted_header` system test failure. The test asserted `"=== INVENTORY ==="` but the visual inventory system replaced the plain-text header with a box-drawing bordered format (`║ INVENTORY ║`). Updated the assertion to match the new format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)