### PR TITLE
Better Inventory System

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -79,6 +79,10 @@
 }
 
 @layer components {
+  .host-message p {
+    white-space: pre-wrap;
+  }
+
   .button {
     @apply px-[10px] py-[2px] font-bold border-solid border-2 border-terminal-green text-terminal-green inline-block uppercase cursor-pointer active:text-stone-800 active:bg-terminal-green focus-visible:text-stone-800 focus-visible:bg-terminal-green focus-visible:outline-none;
   }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -96,4 +96,18 @@
   .input {
     @apply p-[5px] text-lg bg-stone-800 outline-none focus:outline-none focus-visible:outline-none focus:border-terminal-green placeholder:text-terminal-green placeholder:opacity-[0.5] ring-transparent focus:ring-transparent focus-visible:ring-transparent;
   }
+
+  .inventory-item {
+    @apply cursor-pointer px-2 py-1 transition-colors duration-100;
+  }
+
+  @media (hover: hover) {
+    .inventory-item {
+      @apply hover:bg-terminal-green/20;
+    }
+  }
+
+  .inventory-item:active {
+    @apply bg-terminal-green/40;
+  }
 }

--- a/app/components/event_message_component.html.erb
+++ b/app/components/event_message_component.html.erb
@@ -1,3 +1,6 @@
+<% if @message.event_type == "inventory" %>
+	<%= render(InventoryMessageComponent.new(@message)) %>
+<% else %>
 <div class="w-fit border-2 border-white/75 my-5 px-4 pb-4 border-solid mx-auto">
 	<% if @message.event_type == "roll" %>
 		<div class="w-fit text-center px-4 mx-auto mt-[-18px] bg-stone-800">
@@ -27,3 +30,4 @@
 		</div>
 	<% end %>
 </div>
+<% end %>

--- a/app/components/inventory_message_component.html.erb
+++ b/app/components/inventory_message_component.html.erb
@@ -1,0 +1,17 @@
+<div class="w-fit border-2 border-white/75 my-5 px-4 pb-4 border-solid mx-auto">
+	<div class="w-fit text-center px-4 mx-auto mt-[-18px] bg-stone-800">
+		=== INVENTORY ===
+	</div>
+	<% items.each do |item| %>
+		<div class="inventory-item"
+		     data-controller="inventory-item"
+		     data-inventory-item-command-value="EXAMINE <%= item['name'] %>"
+		     data-action="click->inventory-item#send">
+			<pre class="text-xs inline-block align-middle"><%= item['art_line'] %></pre>
+			<span class="ml-2"><%= item['name'] %></span>
+		</div>
+	<% end %>
+	<div class="text-center mt-2 opacity-60 text-sm">
+		(<%= item_count %> <%= item_count == 1 ? 'item' : 'items' %>) — Click an item for details
+	</div>
+</div>

--- a/app/components/inventory_message_component.rb
+++ b/app/components/inventory_message_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class InventoryMessageComponent < ViewComponent::Base
+  def initialize(message)
+    super
+
+    @message = message
+  end
+
+  def items
+    @message.event_data || []
+  end
+
+  def item_count
+    items.length
+  end
+end

--- a/app/javascript/controllers/inventory_item_controller.js
+++ b/app/javascript/controllers/inventory_item_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { command: String }
+
+  send() {
+    const terminal = window.stimulus_controller("terminalInput", "terminal")
+    if (!terminal) { return }
+
+    terminal.inputTarget.textContent = this.commandValue
+    terminal.inputTarget.dispatchEvent(new KeyboardEvent("keydown", { keyCode: 13, bubbles: true }))
+  }
+}

--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -22,12 +22,23 @@ class ClassicCommandJob
       broadcast_dice_roll(game, message, result)
       sync_classic_sidebar(game, user, message.game_user)
 
-      # Create response message (will auto-broadcast via callback)
-      Message.create!(
-        game: game,
-        content: result[:response]
-        # NOTE: no game_user_id, so it's a "host" message from the game engine
-      )
+      # Create inventory event message if inventory_data is present
+      if result.dig(:state_changes, :inventory_data).present?
+        Message.create!(
+          game: game,
+          game_user: message.game_user,
+          event_type: "inventory",
+          event_data: result[:state_changes][:inventory_data],
+          content: result[:response]
+        )
+      else
+        # Create normal host response message (will auto-broadcast via callback)
+        Message.create!(
+          game: game,
+          content: result[:response]
+          # NOTE: no game_user_id, so it's a "host" message from the game engine
+        )
+      end
     end
   end
 

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -203,7 +203,9 @@ module ClassicGame
           stats << "Defense: +#{item_def['defense_bonus']}" if item_def["defense_bonus"]
           if item_def["consumable"]
             stats << "Consumable"
-            stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP" if item_def.dig("combat_effect", "type") == "heal"
+            if item_def.dig("combat_effect", "type") == "heal"
+              stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP"
+            end
           end
           stats
         end

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -43,6 +43,9 @@ module ClassicGame
             # Check if it's a container
             return handle_examine_container(item_id, item_def) if item_def["is_container"]
 
+            # Enriched view for inventory items
+            return enriched_item_description(item_id, item_def) if item?(item_id)
+
             # Regular item examination
             description = item_def["description"] || "You see nothing special about the #{item_def['name']}."
             return success(description)
@@ -163,11 +166,33 @@ module ClassicGame
 
           return success("You are carrying nothing.") if inventory.empty?
 
-          lines = ["You are carrying:"]
+          lines = ["=== INVENTORY ==="]
           inventory.each do |item_id|
-            item_name = world_snapshot.dig("items", item_id, "name") || item_id
-            lines << "  - #{item_name}"
+            item_def = world_snapshot.dig("items", item_id)
+            item_name = item_def&.dig("name") || item_id
+            art_line = ClassicGame::ItemArt.art_for(item_id, item_def).lines.first.chomp
+            lines << "  #{art_line}  #{item_name}"
           end
+          lines << "(#{inventory.size} #{inventory.size == 1 ? 'item' : 'items'}) — EXAMINE <item> for details"
+
+          success(lines.join("\n"))
+        end
+
+        def enriched_item_description(item_id, item_def)
+          art = ClassicGame::ItemArt.art_for(item_id, item_def)
+          name = item_def["name"] || item_id
+          description = item_def["description"] || "You see nothing special about the #{name}."
+
+          stats = []
+          stats << "Damage: +#{item_def['weapon_damage']}" if item_def["weapon_damage"]
+          stats << "Defense: +#{item_def['defense_bonus']}" if item_def["defense_bonus"]
+          if item_def["consumable"]
+            stats << "Consumable"
+            stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP" if item_def.dig("combat_effect", "type") == "heal"
+          end
+
+          lines = [art, "--- #{name} ---", description]
+          lines << stats.join(" | ") if stats.any?
 
           success(lines.join("\n"))
         end

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -167,15 +167,23 @@ module ClassicGame
           return success("You are carrying nothing.") if inventory.empty?
 
           lines = ["=== INVENTORY ==="]
+          inventory_data = []
+
           inventory.each do |item_id|
             item_def = world_snapshot.dig("items", item_id)
             item_name = item_def&.dig("name") || item_id
             art_line = ClassicGame::ItemArt.art_for(item_id, item_def).lines.first.chomp
             lines << "  #{art_line}  #{item_name}"
+            inventory_data << {
+              "item_id" => item_id,
+              "name" => item_name,
+              "art_line" => art_line,
+              "category" => ClassicGame::ItemArt.category_for(item_def)
+            }
           end
           lines << "(#{inventory.size} #{inventory.size == 1 ? 'item' : 'items'}) — EXAMINE <item> for details"
 
-          success(lines.join("\n"))
+          success(lines.join("\n"), state_changes: { inventory_data: inventory_data })
         end
 
         def enriched_item_description(item_id, item_def)
@@ -183,6 +191,13 @@ module ClassicGame
           name = item_def["name"] || item_id
           description = item_def["description"] || "You see nothing special about the #{name}."
 
+          stats = build_item_stats(item_def)
+          box_content = build_item_box(art, name, description, stats)
+
+          success(box_content)
+        end
+
+        def build_item_stats(item_def)
           stats = []
           stats << "Damage: +#{item_def['weapon_damage']}" if item_def["weapon_damage"]
           stats << "Defense: +#{item_def['defense_bonus']}" if item_def["defense_bonus"]
@@ -190,11 +205,16 @@ module ClassicGame
             stats << "Consumable"
             stats << "Heals #{item_def.dig('combat_effect', 'amount')} HP" if item_def.dig("combat_effect", "type") == "heal"
           end
+          stats
+        end
 
-          lines = [art, "--- #{name} ---", description]
+        def build_item_box(art, name, description, stats)
+          lines = []
+          lines << art
+          lines << "--- #{name} ---"
+          lines << description
           lines << stats.join(" | ") if stats.any?
-
-          success(lines.join("\n"))
+          lines.join("\n")
         end
 
         def describe_current_room

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -10,10 +10,20 @@ module ClassicGame
       "armor" => " /--\\\n| () |\n \\--/",
       "treasure" => " /\\\n/  \\\n\\**/\n \\/",
       "container" => "+----+\n|    |\n+----+",
+      "tool" => " _\n|_|\n/ \\",
       "default" => "[item]"
     }.freeze
 
-    ITEM_ART = {}.freeze
+    ITEM_ART = {
+      "old_key" => " _\n|_|-\n  |",
+      "health_potion" => "  _\n (R)\n |_|",
+      "enchanted_blade" => "  *|\n / |\n/~~|\n===+",
+      "scroll" => "/~~~\\\n|rune|\n\\---/",
+      "victory_crown" => " VVV\n/ * \\\n\\___/",
+      "lockpick" => "  _\n |_|\n/ |",
+      "gem" => " /\\\n<**>\n \\/",
+      "supply_crate" => "+====+\n|>  <|\n+====+"
+    }.freeze
 
     def self.art_for(item_id, item_def)
       ITEM_ART[item_id] || CATEGORY_ART[category_for(item_def)] || CATEGORY_ART["default"]
@@ -24,10 +34,13 @@ module ClassicGame
       return "weapon" if item_def["weapon_damage"]
       return "armor" if item_def["defense_bonus"]
       return "potion" if item_def["consumable"] && item_def.dig("combat_effect", "type") == "heal"
-      return "key" if (item_def["keywords"] || []).include?("key")
-      return "scroll" if (item_def["keywords"] || []).include?("scroll")
+
+      keywords = item_def["keywords"] || []
+      return "tool" if (keywords & %w[pick lockpick tool]).any?
+      return "key" if keywords.include?("key")
+      return "scroll" if keywords.include?("scroll")
       return "container" if item_def["is_container"]
-      return "treasure" if ((item_def["keywords"] || []) & %w[crown gem]).any?
+      return "treasure" if (keywords & %w[crown gem]).any?
 
       "default"
     end

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -30,17 +30,17 @@ module ClassicGame
     end
 
     def self.category_for(item_def)
-      item_def = item_def || {}
+      item_def ||= {}
       return "weapon" if item_def["weapon_damage"]
       return "armor" if item_def["defense_bonus"]
       return "potion" if item_def["consumable"] && item_def.dig("combat_effect", "type") == "heal"
 
       keywords = item_def["keywords"] || []
-      return "tool" if (keywords & %w[pick lockpick tool]).any?
+      return "tool" if keywords.intersect?(%w[pick lockpick tool])
       return "key" if keywords.include?("key")
       return "scroll" if keywords.include?("scroll")
       return "container" if item_def["is_container"]
-      return "treasure" if (keywords & %w[crown gem]).any?
+      return "treasure" if keywords.intersect?(%w[crown gem])
 
       "default"
     end

--- a/app/lib/classic_game/item_art.rb
+++ b/app/lib/classic_game/item_art.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module ItemArt
+    CATEGORY_ART = {
+      "weapon" => "  /|\n / |\n/  |\n===+",
+      "potion" => "  _\n (*)\n |_|",
+      "key" => "--o\n |\n--",
+      "scroll" => "/-~-\\\n| ~ |\n\\---/",
+      "armor" => " /--\\\n| () |\n \\--/",
+      "treasure" => " /\\\n/  \\\n\\**/\n \\/",
+      "container" => "+----+\n|    |\n+----+",
+      "default" => "[item]"
+    }.freeze
+
+    ITEM_ART = {}.freeze
+
+    def self.art_for(item_id, item_def)
+      ITEM_ART[item_id] || CATEGORY_ART[category_for(item_def)] || CATEGORY_ART["default"]
+    end
+
+    def self.category_for(item_def)
+      item_def = item_def || {}
+      return "weapon" if item_def["weapon_damage"]
+      return "armor" if item_def["defense_bonus"]
+      return "potion" if item_def["consumable"] && item_def.dig("combat_effect", "type") == "heal"
+      return "key" if (item_def["keywords"] || []).include?("key")
+      return "scroll" if (item_def["keywords"] || []).include?("scroll")
+      return "container" if item_def["is_container"]
+      return "treasure" if ((item_def["keywords"] || []) & %w[crown gem]).any?
+
+      "default"
+    end
+  end
+end

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -480,10 +480,16 @@ class FullGameSystemTest < ActiveSupport::TestCase
     # Phase 10: final state verification
     def phase_verification(game, user)
       r = ex(game, user, "inventory")
-      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
+      assert_includes r[:response], "Victory Crown",   "PHASE 10: victory crown should be in inventory"
       assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
       assert_includes r[:response], "Old Key",         "old key should still be in inventory"
       assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+      assert_includes r[:response], "=== INVENTORY ===", "inventory should show formatted header"
+      assert_includes r[:response], "EXAMINE",         "inventory should include examine hint"
+
+      r = ex(game, user, "examine enchanted blade")
+      assert_includes r[:response], "Damage: +3",            "enchanted blade should show weapon stats"
+      assert_includes r[:response], "blade humming with magic", "enchanted blade description should appear"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
       assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -487,6 +487,12 @@ class FullGameSystemTest < ActiveSupport::TestCase
       assert_includes r[:response], "=== INVENTORY ===", "inventory should show formatted header"
       assert_includes r[:response], "EXAMINE",         "inventory should include examine hint"
 
+      # Verify inventory_data is present and contains expected items
+      assert r[:state_changes][:inventory_data].is_a?(Array), "inventory_data should be an Array"
+      inv_names = r[:state_changes][:inventory_data].map { |i| i["name"] }
+      assert_includes inv_names, "Victory Crown",   "inventory_data should include Victory Crown"
+      assert_includes inv_names, "Enchanted Blade", "inventory_data should include Enchanted Blade"
+
       r = ex(game, user, "examine enchanted blade")
       assert_includes r[:response], "Damage: +3",            "enchanted blade should show weapon stats"
       assert_includes r[:response], "blade humming with magic", "enchanted blade description should appear"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -485,16 +485,16 @@ class FullGameSystemTest < ActiveSupport::TestCase
       assert_includes r[:response], "Old Key",         "old key should still be in inventory"
       assert_not_includes r[:response], "Glowing Gem", "gem was given away"
       assert_includes r[:response], "=== INVENTORY ===", "inventory should show formatted header"
-      assert_includes r[:response], "EXAMINE",         "inventory should include examine hint"
+      assert_includes r[:response], "EXAMINE", "inventory should include examine hint"
 
       # Verify inventory_data is present and contains expected items
       assert r[:state_changes][:inventory_data].is_a?(Array), "inventory_data should be an Array"
-      inv_names = r[:state_changes][:inventory_data].map { |i| i["name"] }
+      inv_names = r[:state_changes][:inventory_data].pluck("name")
       assert_includes inv_names, "Victory Crown",   "inventory_data should include Victory Crown"
       assert_includes inv_names, "Enchanted Blade", "inventory_data should include Enchanted Blade"
 
       r = ex(game, user, "examine enchanted blade")
-      assert_includes r[:response], "Damage: +3",            "enchanted blade should show weapon stats"
+      assert_includes r[:response], "Damage: +3", "enchanted blade should show weapon stats"
       assert_includes r[:response], "blade humming with magic", "enchanted blade description should appear"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExamineHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {},
+          "items" => ["sword"]
+        }
+      },
+      items: {
+        "sword" => {
+          "name" => "Iron Sword", "keywords" => %w[sword iron],
+          "takeable" => true, "weapon_damage" => 3,
+          "description" => "A sharp iron sword."
+        },
+        "shield" => {
+          "name" => "Wooden Shield", "keywords" => ["shield"],
+          "takeable" => true, "defense_bonus" => 2,
+          "description" => "A sturdy wooden shield."
+        },
+        "health_potion" => {
+          "name" => "Health Potion", "keywords" => %w[potion health],
+          "takeable" => true, "consumable" => true,
+          "description" => "A red potion.",
+          "combat_effect" => { "type" => "heal", "amount" => 5 }
+        }
+      }
+    )
+    @game = build_game(world_data: @world, player_id: USER_ID)
+  end
+
+  # ─── INVENTORY ───────────────────────────────────────────────────────────────
+
+  test "inventory displays formatted header" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "=== INVENTORY ==="
+    assert_includes result[:response], "Iron Sword"
+  end
+
+  test "inventory shows item count" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: %w[sword shield])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "(2 items)"
+  end
+
+  test "inventory shows singular item count" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "(1 item)"
+  end
+
+  test "inventory includes examine hint" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_includes result[:response], "EXAMINE"
+  end
+
+  test "empty inventory shows carrying nothing" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_includes result[:response], "You are carrying nothing."
+  end
+
+  # ─── EXAMINE INVENTORY ITEMS ─────────────────────────────────────────────────
+
+  test "examining inventory item shows ASCII art" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert result[:response].include?("\n"), "response should be multi-line with ASCII art"
+  end
+
+  test "examining inventory item shows item name header" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert_includes result[:response], "Iron Sword"
+  end
+
+  test "examining inventory item shows weapon stats" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "Damage: +3"
+  end
+
+  test "examining inventory potion shows consumable" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["health_potion"])
+    result = execute("examine potion")
+
+    assert result[:success]
+    assert_includes result[:response], "Consumable"
+  end
+
+  test "examining inventory potion shows heal amount" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["health_potion"])
+    result = execute("examine potion")
+
+    assert result[:success]
+    assert_includes result[:response], "Heals 5 HP"
+  end
+
+  test "examining inventory armor shows defense stats" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["shield"])
+    result = execute("examine shield")
+
+    assert result[:success]
+    assert_includes result[:response], "Defense: +2"
+  end
+
+  # ─── EXAMINE ROOM ITEMS ───────────────────────────────────────────────────────
+
+  test "examining room item does not show stats" do
+    # sword is in room items but NOT in inventory
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "A sharp iron sword."
+    assert_not_includes result[:response], "Damage:"
+  end
+
+  test "examining room item shows plain description" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "A sharp iron sword."
+  end
+
+  private
+
+    def execute(input)
+      command = ClassicGame::CommandParser.parse(input)
+      ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+    end
+end

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -150,6 +150,78 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     assert_includes result[:response], "A sharp iron sword."
   end
 
+  # ─── INVENTORY DATA IN STATE_CHANGES ─────────────────────────────────────────
+
+  test "inventory result includes inventory_data in state_changes" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert result[:state_changes].key?(:inventory_data), "inventory_data should be present in state_changes"
+    assert_equal 1, result[:state_changes][:inventory_data].length
+    assert_equal "Iron Sword", result[:state_changes][:inventory_data][0]["name"]
+  end
+
+  test "inventory_data includes item category" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_equal "weapon", result[:state_changes][:inventory_data][0]["category"]
+  end
+
+  test "inventory_data includes art_line" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert result[:state_changes][:inventory_data][0]["art_line"].present?,
+           "art_line should be a non-empty string"
+  end
+
+  test "inventory_data includes item_id" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("inventory")
+
+    assert_equal "sword", result[:state_changes][:inventory_data][0]["item_id"]
+  end
+
+  test "empty inventory has no inventory_data" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: [])
+    result = execute("inventory")
+
+    assert result[:success]
+    assert_empty result[:state_changes], "state_changes should be empty for empty inventory"
+    assert_not result[:state_changes].key?(:inventory_data)
+  end
+
+  test "examining inventory item shows bordered output" do
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    result = execute("examine sword")
+
+    assert result[:success]
+    assert_includes result[:response], "---", "response should include border characters"
+    assert result[:response].include?("\n"), "response should be multi-line"
+  end
+
+  test "inventory works for different user_ids (multiplayer isolation)" do
+    user2_id = 2
+    @game.game_state["player_states"][USER_ID.to_s] = player_state_in("room1", inventory: ["sword"])
+    @game.game_state["player_states"][user2_id.to_s] = player_state_in("room1", inventory: ["shield"])
+
+    result1 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID)
+                .handle(ClassicGame::CommandParser.parse("inventory"))
+    result2 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: user2_id)
+                .handle(ClassicGame::CommandParser.parse("inventory"))
+
+    items1 = result1[:state_changes][:inventory_data].map { |i| i["name"] }
+    items2 = result2[:state_changes][:inventory_data].map { |i| i["name"] }
+
+    assert_includes items1, "Iron Sword"
+    assert_not_includes items1, "Wooden Shield"
+
+    assert_includes items2, "Wooden Shield"
+    assert_not_includes items2, "Iron Sword"
+  end
+
   private
 
     def execute(input)

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -208,12 +208,12 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     @game.game_state["player_states"][user2_id.to_s] = player_state_in("room1", inventory: ["shield"])
 
     result1 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID)
-                .handle(ClassicGame::CommandParser.parse("inventory"))
+      .handle(ClassicGame::CommandParser.parse("inventory"))
     result2 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: user2_id)
-                .handle(ClassicGame::CommandParser.parse("inventory"))
+      .handle(ClassicGame::CommandParser.parse("inventory"))
 
-    items1 = result1[:state_changes][:inventory_data].map { |i| i["name"] }
-    items2 = result2[:state_changes][:inventory_data].map { |i| i["name"] }
+    items1 = result1[:state_changes][:inventory_data].pluck("name")
+    items2 = result2[:state_changes][:inventory_data].pluck("name")
 
     assert_includes items1, "Iron Sword"
     assert_not_includes items1, "Wooden Shield"

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -208,9 +208,9 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     @game.game_state["player_states"][user2_id.to_s] = player_state_in("room1", inventory: ["shield"])
 
     result1 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID)
-      .handle(ClassicGame::CommandParser.parse("inventory"))
+                                                   .handle(ClassicGame::CommandParser.parse("inventory"))
     result2 = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: user2_id)
-      .handle(ClassicGame::CommandParser.parse("inventory"))
+                                                   .handle(ClassicGame::CommandParser.parse("inventory"))
 
     items1 = result1[:state_changes][:inventory_data].pluck("name")
     items2 = result2[:state_changes][:inventory_data].pluck("name")

--- a/test/lib/classic_game/item_art_test.rb
+++ b/test/lib/classic_game/item_art_test.rb
@@ -67,4 +67,48 @@ class ItemArtTest < ActiveSupport::TestCase
     result = ClassicGame::ItemArt.art_for("unknown", nil)
     assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
   end
+
+  # ─── ITEM_ART per-item entries ────────────────────────────────────────────────
+
+  test "ITEM_ART has entry for old_key" do
+    result = ClassicGame::ItemArt::ITEM_ART["old_key"]
+    assert_not_nil result, "ITEM_ART should have an entry for old_key"
+    assert result.include?("\n"), "old_key art should be multi-line"
+  end
+
+  test "ITEM_ART has entry for health_potion" do
+    assert_not_nil ClassicGame::ItemArt::ITEM_ART["health_potion"]
+  end
+
+  test "ITEM_ART has entry for enchanted_blade" do
+    assert_not_nil ClassicGame::ItemArt::ITEM_ART["enchanted_blade"]
+  end
+
+  test "ITEM_ART has entry for victory_crown" do
+    assert_not_nil ClassicGame::ItemArt::ITEM_ART["victory_crown"]
+  end
+
+  test "art_for prefers ITEM_ART over CATEGORY_ART for old_key" do
+    item_def = { "keywords" => ["key"] }
+    result = ClassicGame::ItemArt.art_for("old_key", item_def)
+    assert_equal ClassicGame::ItemArt::ITEM_ART["old_key"], result,
+                 "art_for should return ITEM_ART entry, not CATEGORY_ART key art"
+  end
+
+  # ─── category_for tool category ───────────────────────────────────────────────
+
+  test "category_for returns tool for lockpick keywords" do
+    item_def = { "keywords" => %w[lockpick pick] }
+    assert_equal "tool", ClassicGame::ItemArt.category_for(item_def)
+  end
+
+  test "category_for returns tool for pick keyword" do
+    item_def = { "keywords" => %w[pick metal] }
+    assert_equal "tool", ClassicGame::ItemArt.category_for(item_def)
+  end
+
+  test "CATEGORY_ART has entry for tool" do
+    assert_not_nil ClassicGame::ItemArt::CATEGORY_ART["tool"],
+                   "CATEGORY_ART should have a tool entry"
+  end
 end

--- a/test/lib/classic_game/item_art_test.rb
+++ b/test/lib/classic_game/item_art_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ItemArtTest < ActiveSupport::TestCase
+  # ─── category_for ────────────────────────────────────────────────────────────
+
+  test "category_for returns weapon for weapon_damage items" do
+    assert_equal "weapon", ClassicGame::ItemArt.category_for("weapon_damage" => 3)
+  end
+
+  test "category_for returns armor for defense_bonus items" do
+    assert_equal "armor", ClassicGame::ItemArt.category_for("defense_bonus" => 2)
+  end
+
+  test "category_for returns potion for consumable heal items" do
+    item_def = { "consumable" => true, "combat_effect" => { "type" => "heal", "amount" => 5 } }
+    assert_equal "potion", ClassicGame::ItemArt.category_for(item_def)
+  end
+
+  test "category_for returns key when keywords include key" do
+    assert_equal "key", ClassicGame::ItemArt.category_for("keywords" => %w[brass key])
+  end
+
+  test "category_for returns scroll when keywords include scroll" do
+    assert_equal "scroll", ClassicGame::ItemArt.category_for("keywords" => %w[ancient scroll])
+  end
+
+  test "category_for returns container for is_container items" do
+    assert_equal "container", ClassicGame::ItemArt.category_for("is_container" => true)
+  end
+
+  test "category_for returns treasure when keywords include crown" do
+    assert_equal "treasure", ClassicGame::ItemArt.category_for("keywords" => %w[crown victory])
+  end
+
+  test "category_for returns treasure when keywords include gem" do
+    assert_equal "treasure", ClassicGame::ItemArt.category_for("keywords" => %w[gem glowing])
+  end
+
+  test "category_for returns default for unknown items" do
+    assert_equal "default", ClassicGame::ItemArt.category_for("name" => "Mystery Box")
+  end
+
+  test "category_for handles nil item_def" do
+    assert_equal "default", ClassicGame::ItemArt.category_for(nil)
+  end
+
+  # ─── art_for ─────────────────────────────────────────────────────────────────
+
+  test "art_for returns non-empty string for weapon item" do
+    result = ClassicGame::ItemArt.art_for("anything", "weapon_damage" => 1)
+    assert result.present?
+  end
+
+  test "art_for returns weapon art for weapon_damage items" do
+    result = ClassicGame::ItemArt.art_for("sword", "weapon_damage" => 3)
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["weapon"], result
+  end
+
+  test "art_for falls back to default for unknown items" do
+    result = ClassicGame::ItemArt.art_for("mystery", "name" => "Mystery")
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
+  end
+
+  test "art_for handles nil item_def" do
+    result = ClassicGame::ItemArt.art_for("unknown", nil)
+    assert_equal ClassicGame::ItemArt::CATEGORY_ART["default"], result
+  end
+end

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -17,7 +17,7 @@ module QaWorld
       find(".terminal-input").click
       find(".terminal-input").send_keys("take key", :return)
       find(".terminal-input").send_keys("inventory", :return)
-      assert_text "EXAMINE"
+      assert_text "Click an item for details"
     end
 
     test "examine inventory key shows description" do

--- a/test/system/qa_world/inventory_test.rb
+++ b/test/system/qa_world/inventory_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class InventoryTest < ApplicationSystemTestCase
+    test "inventory shows formatted header" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "=== INVENTORY ==="
+    end
+
+    test "inventory shows examine hint" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("inventory", :return)
+      assert_text "EXAMINE"
+    end
+
+    test "examine inventory key shows description" do
+      visit dev_game_path
+      find(".terminal-input").click
+      find(".terminal-input").send_keys("take key", :return)
+      find(".terminal-input").send_keys("examine key", :return)
+      assert_text "Rusty Key"
+      assert_text "rusty iron key"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Added `inventory_data` structured payload to the `INVENTORY` command result, enabling the UI to render an interactive inventory panel with clickable item rows
- Created `InventoryMessageComponent` (ViewComponent) that renders a bordered inventory panel where each item can be clicked to auto-send `EXAMINE <item>` into the terminal
- Created `inventory_item_controller.js` (Stimulus) to handle click-to-examine behavior by dispatching a keydown event on the terminal input
- Expanded `ItemArt::ITEM_ART` with unique ASCII art for 8 specific items (`old_key`, `health_potion`, `enchanted_blade`, `scroll`, `victory_crown`, `lockpick`, `gem`, `supply_crate`)
- Added `"tool"` category to `ItemArt::CATEGORY_ART` with corresponding `category_for` detection (keywords: `pick`, `lockpick`, `tool`)
- Updated `ClassicCommandJob` to create an `event_type: "inventory"` message (associated with the requesting game_user) when `inventory_data` is present, enabling Turbo Stream broadcast of the interactive panel
- Wired `EventMessageComponent` to delegate `event_type == "inventory"` to `InventoryMessageComponent`, bypassing the generic bordered wrapper
- Extracted `build_item_stats` and `build_item_box` helpers from `enriched_item_description` to keep methods within RuboCop MethodLength limits
- Added `.inventory-item` CSS class with hover/active states using terminal-green color palette

## Test plan

- [x] `inventory_data` present in `state_changes` with correct `name`, `item_id`, `art_line`, `category` fields
- [x] Empty inventory returns no `inventory_data` in `state_changes`
- [x] Multiplayer isolation: each player's inventory command only returns their own items
- [x] `examine <item>` response includes `---` border separator (bordered box)
- [x] `ITEM_ART` entries exist for `old_key`, `health_potion`, `enchanted_blade`, `victory_crown`
- [x] `art_for("old_key", ...)` returns `ITEM_ART["old_key"]` over `CATEGORY_ART["key"]`
- [x] `category_for` returns `"tool"` for lockpick/pick keywords
- [x] `CATEGORY_ART["tool"]` is defined
- [x] Full game system test: `phase_verification` asserts `inventory_data` is an Array containing Victory Crown and Enchanted Blade

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Fix Notes

**`d198425` — fix: update inventory test to match click-based UI hint**

The system test `QaWorld::InventoryTest#test_inventory_shows_examine_hint` expected to find the text "EXAMINE" in the rendered inventory panel. However, `InventoryMessageComponent` renders the hint as "Click an item for details" (since items are clickable and auto-send the EXAMINE command via Stimulus). Updated the test assertion to match the actual UI text.

**`547df96` — fix: resolve rubocop offenses in inventory feature**

Fixed 12 autocorrectable RuboCop offenses:
- `examine_handler.rb`: Broke long `if`-modifier line into block form to stay within 120-char limit
- `item_art.rb`: Used `||=` self-assignment shorthand; replaced `(array & other).any?` with `Array#intersect?`
- `full_game_system_test.rb`: Removed extra alignment spacing; used `pluck("name")` instead of `map { |i| i["name"] }`
- `examine_handler_test.rb`: Fixed multiline method call indentation; used `pluck("name")`

**`7bd5eb1` — fix: align multiline method call indentation for rubocop**

Aligned `.handle` with `.new` on multiline method chains in `examine_handler_test.rb` (lines 210-213) to satisfy `Layout/MultilineMethodCallIndentation` cop.