### PR TITLE
Improved Visual Inventory System

### DIFF
--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -28,7 +28,7 @@ export default class extends Controller {
       document.getElementById('message-content-wrapper').classList.remove('invisible');
     }, 500)
 
-    // If messages are being loaded from scrolling "up", we want the 
+    // If messages are being loaded from scrolling "up", we want the
     // mutation observer to scroll the view to 0, otherwise all the way down
     document.addEventListener('turbo:before-stream-render', (event) => {
       if(event.detail.newStream.target == 'messages' || event.detail.newStream.target.indexOf("message_") === 0) {
@@ -36,6 +36,7 @@ export default class extends Controller {
           this.scrollPosition = document.getElementById('game-messages').getBoundingClientRect().height
         } else {
           this.scrollPosition = 'last'
+          this.clear_client_messages()
         }
       }
     });
@@ -91,10 +92,11 @@ export default class extends Controller {
 
       if(this.gameTypeValue === "classic" && ["I", "INV", "INVENTORY"].includes(inputText)){
         window.stimulus_controller("terminalInput", "terminal").clear_input()
-        this.show_client_message("Your inventory is shown in the sidebar.")
+        this.show_client_message("Thine inventory is innith thine sidebar!")
         return false
       }
 
+      this.clear_client_messages()
       window.stimulus_controller("terminalInput", "terminal").clear_input()
       this.errorTarget.style.display = "none"
 
@@ -117,12 +119,25 @@ export default class extends Controller {
     const messages = document.getElementById("game-messages")
     if(!messages){ return }
 
+    this.clear_client_messages()
+
     const div = document.createElement("div")
-    div.className = "game-message host-message text-white opacity-70 italic py-2 pl-5"
+    div.className = "game-message host-message client-message text-white opacity-70 italic py-2 pl-5 transition-opacity duration-500"
+    div.dataset.clientMessage = "true"
     div.textContent = text
     messages.appendChild(div)
 
     const container = document.querySelector(".grid-in-message-container")
     if(container){ container.scrollTo(0, container.scrollHeight) }
+
+    setTimeout(() => {
+      if(!div.isConnected){ return }
+      div.classList.add("opacity-0")
+      setTimeout(() => div.remove(), 500)
+    }, 4000)
+  }
+
+  clear_client_messages(){
+    document.querySelectorAll("[data-client-message='true']").forEach((el) => el.remove())
   }
 }

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -88,6 +88,12 @@ export default class extends Controller {
 
       if(inputText === ""){ return false; }
 
+      if(["I", "INV", "INVENTORY"].includes(inputText)){
+        window.stimulus_controller("terminalInput", "terminal").clear_input()
+        this.show_client_message("Your inventory is shown in the sidebar.")
+        return false
+      }
+
       window.stimulus_controller("terminalInput", "terminal").clear_input()
       this.errorTarget.style.display = "none"
 
@@ -104,5 +110,18 @@ export default class extends Controller {
 
   show_error(text, fade){
     window.stimulus_controller("terminalInput", "terminal").show_error(text, fade)
+  }
+
+  show_client_message(text){
+    const messages = document.getElementById("game-messages")
+    if(!messages){ return }
+
+    const div = document.createElement("div")
+    div.className = "game-message host-message text-white opacity-70 italic py-2 pl-5"
+    div.textContent = text
+    messages.appendChild(div)
+
+    const container = document.querySelector(".grid-in-message-container")
+    if(container){ container.scrollTo(0, container.scrollHeight) }
   }
 }

--- a/app/javascript/controllers/game_controller.js
+++ b/app/javascript/controllers/game_controller.js
@@ -6,7 +6,8 @@ export default class extends Controller {
   static outlets = [ "game-user" ]
   static values = {
     id: Number,
-    userId: String
+    userId: String,
+    gameType: String
   }
 
   observer = null
@@ -88,7 +89,7 @@ export default class extends Controller {
 
       if(inputText === ""){ return false; }
 
-      if(["I", "INV", "INVENTORY"].includes(inputText)){
+      if(this.gameTypeValue === "classic" && ["I", "INV", "INVENTORY"].includes(inputText)){
         window.stimulus_controller("terminalInput", "terminal").clear_input()
         this.show_client_message("Your inventory is shown in the sidebar.")
         return false

--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -1,0 +1,13 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle(event){
+    const button = event.currentTarget
+    const description = button.parentElement.querySelector("[data-inventory-target='description']")
+    if(!description){ return }
+
+    const expanded = button.getAttribute("aria-expanded") === "true"
+    button.setAttribute("aria-expanded", (!expanded).toString())
+    description.classList.toggle("hidden")
+  }
+}

--- a/app/javascript/controllers/sidebar_tabs_controller.js
+++ b/app/javascript/controllers/sidebar_tabs_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["tab", "panel"]
+  static values = { active: { type: String, default: "inventory" } }
+
+  connect(){
+    this.render()
+  }
+
+  switch({ params }){
+    if(!params.name){ return }
+    this.activeValue = params.name
+  }
+
+  activeValueChanged(){
+    this.render()
+  }
+
+  render(){
+    this.tabTargets.forEach((tab) => {
+      const active = tab.dataset.sidebarTabsNameParam === this.activeValue
+      tab.classList.toggle("border-terminal-green", active)
+      tab.classList.toggle("border-transparent", !active)
+      tab.classList.toggle("opacity-50", !active)
+      tab.setAttribute("aria-selected", active.toString())
+    })
+
+    this.panelTargets.forEach((panel) => {
+      const active = panel.dataset.sidebarTabsName === this.activeValue
+      panel.classList.toggle("hidden", !active)
+    })
+  }
+}

--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -62,9 +62,13 @@ class ClassicCommandJob
                                                      partial: "/games/player",
                                                      locals: { game_user: game_user, for_host: false })
 
-      # Broadcast updated inventory partial
+      # Broadcast updated inventory partial on both player and host streams — when a
+      # host is also a player (dev mode), they only subscribe to :host_players.
       game_user.broadcast_replace_to(game, :players, target: "player_inventory_#{user.id}",
                                                      partial: "/games/inventory",
                                                      locals: { game: game, user: user })
+      game_user.broadcast_replace_to(game, :host_players, target: "player_inventory_#{user.id}",
+                                                          partial: "/games/inventory",
+                                                          locals: { game: game, user: user })
     end
 end

--- a/app/jobs/classic_command_job.rb
+++ b/app/jobs/classic_command_job.rb
@@ -61,5 +61,10 @@ class ClassicCommandJob
       game_user.broadcast_replace_to(game, :players, target: "game_user_#{game_user.id}",
                                                      partial: "/games/player",
                                                      locals: { game_user: game_user, for_host: false })
+
+      # Broadcast updated inventory partial
+      game_user.broadcast_replace_to(game, :players, target: "player_inventory_#{user.id}",
+                                                     partial: "/games/inventory",
+                                                     locals: { game: game, user: user })
     end
 end

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -159,7 +159,7 @@ module ClassicGame
         end
 
         def handle_inventory
-          success("Your inventory is shown in the sidebar.")
+          success("Thine inventory is innith thine sidebar!")
         end
 
         def describe_current_room

--- a/app/lib/classic_game/handlers/examine_handler.rb
+++ b/app/lib/classic_game/handlers/examine_handler.rb
@@ -159,17 +159,7 @@ module ClassicGame
         end
 
         def handle_inventory
-          inventory = player_state["inventory"] || []
-
-          return success("You are carrying nothing.") if inventory.empty?
-
-          lines = ["You are carrying:"]
-          inventory.each do |item_id|
-            item_name = world_snapshot.dig("items", item_id, "name") || item_id
-            lines << "  - #{item_name}"
-          end
-
-          success(lines.join("\n"))
+          success("Your inventory is shown in the sidebar.")
         end
 
         def describe_current_room

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -1,13 +1,27 @@
 <div id="player_inventory_<%= user.id %>" class="mb-5">
-  <h4 class="text-center mb-0 mt-3">INVENTORY</h4>
   <% inventory = game.player_state(user.id)["inventory"] || [] %>
   <% if inventory.empty? %>
     <p class="text-center opacity-60 italic">(empty)</p>
   <% else %>
-    <ul class="list-none p-0 m-0">
+    <ul class="list-none p-0 m-0" data-controller="inventory">
       <% inventory.each do |item_id| %>
-        <% item_name = game.world_snapshot.dig("items", item_id, "name") || item_id %>
-        <li class="text-center"><%= item_name %></li>
+        <% item_def = game.world_snapshot.dig("items", item_id) || {} %>
+        <% item_name = item_def["name"] || item_id %>
+        <% item_description = item_def["description"] %>
+        <li class="mb-1">
+          <button type="button"
+                  class="w-full text-center py-1 px-2 cursor-pointer bg-transparent border border-transparent hover:border-terminal-green hover:border-dashed text-terminal-green"
+                  aria-expanded="false"
+                  data-inventory-target="toggle"
+                  data-action="click->inventory#toggle">
+            <%= item_name %>
+          </button>
+          <% if item_description.present? %>
+            <p class="hidden text-sm opacity-80 italic px-2 pt-1 pb-2" data-inventory-target="description">
+              <%= item_description %>
+            </p>
+          <% end %>
+        </li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -1,0 +1,14 @@
+<div id="player_inventory_<%= user.id %>" class="mb-5">
+  <h4 class="text-center mb-0 mt-3">INVENTORY</h4>
+  <% inventory = game.player_state(user.id)["inventory"] || [] %>
+  <% if inventory.empty? %>
+    <p class="text-center opacity-60 italic">(empty)</p>
+  <% else %>
+    <ul class="list-none p-0 m-0">
+      <% inventory.each do |item_id| %>
+        <% item_name = game.world_snapshot.dig("items", item_id, "name") || item_id %>
+        <li class="text-center"><%= item_name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <% content_for :text_form do %>
-  <%= render(TerminalInputComponent.new(prompt: "", stimulus_controllers: ["game"], stimulus_values: { "game-id": @game.id, "game-user-id": @game.game_user(current_user)&.id || (@game.host?(current_user) ? :host : nil) })) %>
+  <%= render(TerminalInputComponent.new(prompt: "", stimulus_controllers: ["game"], stimulus_values: { "game-id": @game.id, "game-user-id": @game.game_user(current_user)&.id || (@game.host?(current_user) ? :host : nil), "game-type": @game.game_type })) %>
 <% end %>
 
 <% content_for :sidebar do %>
@@ -32,7 +32,7 @@
     <%= render "current_context", game: @game %>
   </div>
 
-  <% if @game.classic? %>
+  <% if @game.classic? && @game.game_user(current_user).present? %>
     <%= render "/games/inventory", game: @game, user: current_user %>
   <% end %>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -32,24 +32,60 @@
     <%= render "current_context", game: @game %>
   </div>
 
-  <% if @game.classic? && @game.game_user(current_user).present? %>
-    <%= render "/games/inventory", game: @game, user: current_user %>
-  <% end %>
+  <% show_inventory_tab = @game.classic? && @game.game_user(current_user).present? %>
+  <% if show_inventory_tab %>
+    <div data-controller="sidebar-tabs" data-sidebar-tabs-active-value="inventory">
+      <div class="grid grid-cols-2 mb-3 border-b border-dashed border-terminal-green" role="tablist">
+        <button type="button"
+                class="py-2 font-bold uppercase text-terminal-green border-b-2 -mb-px bg-transparent cursor-pointer"
+                role="tab"
+                data-sidebar-tabs-target="tab"
+                data-sidebar-tabs-name-param="inventory"
+                data-action="click->sidebar-tabs#switch">Inventory</button>
+        <button type="button"
+                class="py-2 font-bold uppercase text-terminal-green border-b-2 -mb-px bg-transparent cursor-pointer"
+                role="tab"
+                data-sidebar-tabs-target="tab"
+                data-sidebar-tabs-name-param="players"
+                data-action="click->sidebar-tabs#switch">Players</button>
+      </div>
 
-  <h4 class="text-center mb-0 mt-3">PLAYERS</h4>
-  <% if @game.host?(current_user) %>
-    <div class="grid grid-cols-2 mb-3">
-      <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
-        <%= form.hidden_field :can_message, value: false %>
-        <%= form.submit class: "button w-full text-sm", value: "Mute All" %>
-      <% end %>
-      <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
-        <%= form.hidden_field :can_message, value: true %>
-        <%= form.submit class: "button w-full text-sm", value: "Unmute All" %>
-      <% end %>
+      <div data-sidebar-tabs-target="panel" data-sidebar-tabs-name="inventory" role="tabpanel">
+        <%= render "/games/inventory", game: @game, user: current_user %>
+      </div>
+
+      <div data-sidebar-tabs-target="panel" data-sidebar-tabs-name="players" role="tabpanel" class="hidden">
+        <% if @game.host?(current_user) %>
+          <div class="grid grid-cols-2 mb-3">
+            <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
+              <%= form.hidden_field :can_message, value: false %>
+              <%= form.submit class: "button w-full text-sm", value: "Mute All" %>
+            <% end %>
+            <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
+              <%= form.hidden_field :can_message, value: true %>
+              <%= form.submit class: "button w-full text-sm", value: "Unmute All" %>
+            <% end %>
+          </div>
+        <% end %>
+        <%= render "players", game_users: @game.game_users.order(:id), for_host: @game.host?(current_user) %>
+      </div>
     </div>
+  <% else %>
+    <h4 class="text-center mb-0 mt-3">PLAYERS</h4>
+    <% if @game.host?(current_user) %>
+      <div class="grid grid-cols-2 mb-3">
+        <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
+          <%= form.hidden_field :can_message, value: false %>
+          <%= form.submit class: "button w-full text-sm", value: "Mute All" %>
+        <% end %>
+        <%= form_with(scope: :game_user, url: game_users_mute_or_unmute_path(game_id: @game.id), method: :patch) do |form| %>
+          <%= form.hidden_field :can_message, value: true %>
+          <%= form.submit class: "button w-full text-sm", value: "Unmute All" %>
+        <% end %>
+      </div>
+    <% end %>
+    <%= render "players", game_users: @game.game_users.order(:id), for_host: @game.host?(current_user) %>
   <% end %>
-  <%= render "players", game_users: @game.game_users.order(:id), for_host: @game.host?(current_user) %>
 <% end %>
 
 <% content_for :loading_modal do %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,7 +22,7 @@
 </div>
 
 <% content_for :text_form do %>
-  <%= render(TerminalInputComponent.new(prompt: "", stimulus_controllers: ["game"], stimulus_values: { "game-id": @game.id, "game-user-id": @game.game_user(current_user)&.id || (@game.host?(current_user) ? :host : nil), "game-type": @game.game_type })) %>
+  <%= render(TerminalInputComponent.new(prompt: "", stimulus_controllers: ["game"], stimulus_values: { "game-id": @game.id, "game-user-id": @game.game_user(current_user)&.id || (@game.host?(current_user) ? :host : nil), "game-game-type": @game.game_type })) %>
 <% end %>
 
 <% content_for :sidebar do %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -32,6 +32,10 @@
     <%= render "current_context", game: @game %>
   </div>
 
+  <% if @game.classic? %>
+    <%= render "/games/inventory", game: @game, user: current_user %>
+  <% end %>
+
   <h4 class="text-center mb-0 mt-3">PLAYERS</h4>
   <% if @game.host?(current_user) %>
     <div class="grid grid-cols-2 mb-3">

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -258,8 +258,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
       r = ex(game, user, "help")
       assert_includes r[:response], "Available commands"
 
-      r = ex(game, user, "inventory")
-      assert_includes r[:response], "carrying nothing"
+      assert_empty game.player_state(USER_ID)["inventory"]
 
       r = ex(game, user, "examine guide")
       assert_includes r[:response], "helpful traveler"
@@ -427,8 +426,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
       assert_includes game.player_state(USER_ID)["inventory"], "enchanted_blade"
       assert_not_includes game.player_state(USER_ID)["inventory"], "gem"
 
-      r = ex(game, user, "inventory")
-      assert_includes r[:response], "Enchanted Blade"
+      assert_includes game.player_state(USER_ID)["inventory"], "enchanted_blade"
     end
 
     # Phase 8: traverse the now-revealed hidden exit and pick up the victory crown
@@ -479,11 +477,11 @@ class FullGameSystemTest < ActiveSupport::TestCase
 
     # Phase 10: final state verification
     def phase_verification(game, user)
-      r = ex(game, user, "inventory")
-      assert_includes r[:response], "Victory Crown",   "PHASE 9: victory crown should be in inventory"
-      assert_includes r[:response], "Enchanted Blade", "enchanted blade should be in inventory"
-      assert_includes r[:response], "Old Key",         "old key should still be in inventory"
-      assert_not_includes r[:response], "Glowing Gem", "gem was given away"
+      inv = game.player_state(USER_ID)["inventory"]
+      assert_includes inv, "victory_crown",   "PHASE 9: victory crown should be in inventory"
+      assert_includes inv, "enchanted_blade", "enchanted blade should be in inventory"
+      assert_includes inv, "old_key",         "old key should still be in inventory"
+      assert_not_includes inv, "gem",         "gem was given away"
 
       assert game.get_flag("spoke_to_guide"),  "spoke_to_guide flag should be set"
       assert game.get_flag("tower_unlocked"),  "tower_unlocked flag should be set"

--- a/test/lib/classic_game/full_game_system_test.rb
+++ b/test/lib/classic_game/full_game_system_test.rb
@@ -476,7 +476,7 @@ class FullGameSystemTest < ActiveSupport::TestCase
     end
 
     # Phase 10: final state verification
-    def phase_verification(game, user)
+    def phase_verification(game, _user)
       inv = game.player_state(USER_ID)["inventory"]
       assert_includes inv, "victory_crown",   "PHASE 9: victory crown should be in inventory"
       assert_includes inv, "enchanted_blade", "enchanted blade should be in inventory"

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ExamineHandlerTest < ActiveSupport::TestCase
+  include ClassicGameTestHelper
+
+  USER_ID = 1
+
+  setup do
+    @world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => {
+          "name" => "Test Room",
+          "description" => "A plain room.",
+          "exits" => {}
+        }
+      },
+      items: {
+        "sword" => { "name" => "Iron Sword", "keywords" => ["sword"], "takeable" => true }
+      }
+    )
+    @game = build_game(
+      world_data: @world,
+      player_id: USER_ID,
+      player_state: player_state_in("room1", inventory: ["sword"])
+    )
+  end
+
+  test "inventory command returns sidebar redirect message and does not list items" do
+    command = ClassicGame::CommandParser.parse("inventory")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+    assert_not_includes result[:response], "Iron Sword"
+    assert_not_includes result[:response], "sword"
+  end
+
+  test "inv alias returns sidebar redirect message" do
+    command = ClassicGame::CommandParser.parse("inv")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+  end
+
+  test "i alias returns sidebar redirect message" do
+    command = ClassicGame::CommandParser.parse("i")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+  end
+
+  test "inventory command with empty inventory returns sidebar redirect message" do
+    game = build_game(world_data: @world, player_id: USER_ID)
+    command = ClassicGame::CommandParser.parse("inventory")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: game, user_id: USER_ID).handle(command)
+
+    assert result[:success]
+    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+  end
+end

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -33,7 +33,7 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
 
     assert result[:success]
-    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+    assert_equal "Thine inventory is innith thine sidebar!", result[:response]
     assert_not_includes result[:response], "Iron Sword"
     assert_not_includes result[:response], "sword"
   end
@@ -43,7 +43,7 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
 
     assert result[:success]
-    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+    assert_equal "Thine inventory is innith thine sidebar!", result[:response]
   end
 
   test "i alias returns sidebar redirect message" do
@@ -51,7 +51,7 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
 
     assert result[:success]
-    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+    assert_equal "Thine inventory is innith thine sidebar!", result[:response]
   end
 
   test "inventory command with empty inventory returns sidebar redirect message" do
@@ -60,6 +60,6 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     result = ClassicGame::Handlers::ExamineHandler.new(game: game, user_id: USER_ID).handle(command)
 
     assert result[:success]
-    assert_equal "Your inventory is shown in the sidebar.", result[:response]
+    assert_equal "Thine inventory is innith thine sidebar!", result[:response]
   end
 end

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -48,8 +48,8 @@ class ClassicGameTest < ApplicationSystemTestCase
   test "sidebar shows inventory section for classic game" do
     visit dev_game_path
     assert_selector "[id^='player_inventory_']"
+    assert_button "Inventory"
     within("[id^='player_inventory_']") do
-      assert_text "INVENTORY"
       assert_text "(empty)"
     end
   end
@@ -78,13 +78,13 @@ class ClassicGameTest < ApplicationSystemTestCase
     initial_count = Message.count
 
     find(".terminal-input").send_keys("i", :return)
-    assert_text "Your inventory is shown in the sidebar."
+    assert_text "Thine inventory is innith thine sidebar!"
 
     find(".terminal-input").send_keys("inv", :return)
-    assert_text "Your inventory is shown in the sidebar."
+    assert_text "Thine inventory is innith thine sidebar!"
 
     find(".terminal-input").send_keys("inventory", :return)
-    assert_text "Your inventory is shown in the sidebar."
+    assert_text "Thine inventory is innith thine sidebar!"
 
     assert_equal initial_count, Message.count
   end
@@ -115,5 +115,68 @@ class ClassicGameTest < ApplicationSystemTestCase
       assert_text "Rusty Key"
       assert_text "Health Potion"
     end
+  end
+
+  # AC5 — Sidebar tabs switch between Inventory and Players panels
+  test "sidebar tabs switch between inventory and players panels" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    # Inventory tab is the default — inventory is visible, players list is hidden.
+    assert_selector "[id^='player_inventory_']", visible: :visible
+
+    click_on "Players"
+    assert_selector "[id^='player_inventory_']", visible: :hidden
+    assert_selector "turbo-frame#players", visible: :visible
+
+    click_on "Inventory"
+    assert_selector "[id^='player_inventory_']", visible: :visible
+    assert_selector "turbo-frame#players", visible: :hidden
+  end
+
+  # AC6 — Clicking an inventory item expands/collapses its description
+  test "clicking inventory item toggles its description" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    within("[id^='player_inventory_']") do
+      # Description is hidden until the item is clicked.
+      assert_no_text "rusty iron key"
+
+      click_on "Rusty Key"
+      assert_text "rusty iron key"
+
+      # Clicking again collapses the description.
+      click_on "Rusty Key"
+      assert_no_text "rusty iron key"
+    end
+  end
+
+  # AC7 — Client-side inventory hint clears when a new command is sent
+  test "inventory hint clears when another command is sent" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("i", :return)
+    assert_text "Thine inventory is innith thine sidebar!"
+
+    find(".terminal-input").send_keys("look", :return)
+    assert_text "Town Square"
+    assert_no_text "Thine inventory is innith thine sidebar!"
+  end
+
+  # AC8 — Client-side inventory hint fades out after a few seconds on its own
+  test "inventory hint auto-dismisses after a few seconds" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("i", :return)
+    assert_text "Thine inventory is innith thine sidebar!"
+
+    # Fade kicks in at 4s and finishes at ~4.5s; allow a generous wait.
+    assert_no_text "Thine inventory is innith thine sidebar!", wait: 8
   end
 end

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -94,17 +94,22 @@ class ClassicGameTest < ApplicationSystemTestCase
     visit dev_game_path
     find(".terminal-input").click
 
-    find(".terminal-input").send_keys("take key", :return)
+    # Each command waits for its specific response text before the next one is
+    # sent — commands are processed async and sending without a wait races the
+    # job queue against the broadcast that updates the sidebar.
     assert_selector "[id^='player_inventory_']", visible: :visible
+
+    find(".terminal-input").send_keys("take key", :return)
+    assert_text "Rusty Key"
 
     find(".terminal-input").send_keys("go east", :return)
-    assert_selector "[id^='player_inventory_']", visible: :visible
+    assert_text "The Tavern"
 
     find(".terminal-input").send_keys("open chest", :return)
-    assert_selector "[id^='player_inventory_']", visible: :visible
+    assert_text "unlock the chest"
 
     find(".terminal-input").send_keys("take potion", :return)
-    assert_selector "[id^='player_inventory_']", visible: :visible
+    assert_text "Health Potion"
 
     within("[id^='player_inventory_']") do
       assert_text "Rusty Key"

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -43,4 +43,72 @@ class ClassicGameTest < ApplicationSystemTestCase
     assert_current_path(%r{/games/})
     assert_text "Town Square"
   end
+
+  # AC1 — Inventory section appears in sidebar on load
+  test "sidebar shows inventory section for classic game" do
+    visit dev_game_path
+    assert_selector "[id^='player_inventory_']"
+    within("[id^='player_inventory_']") do
+      assert_text "INVENTORY"
+      assert_text "(empty)"
+    end
+  end
+
+  # AC2 — Sidebar inventory updates in real-time as items are added/removed
+  test "sidebar inventory updates when player takes and drops items" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") do
+      assert_text "Rusty Key"
+    end
+
+    find(".terminal-input").send_keys("drop key", :return)
+    within("[id^='player_inventory_']") do
+      assert_text "(empty)"
+      assert_no_text "Rusty Key"
+    end
+  end
+
+  # AC3 — Inventory shortcuts show client-only hint and do not create game messages
+  test "inventory shortcuts show client-only hint and do not create game messages" do
+    visit dev_game_path
+    find(".terminal-input").click
+    initial_count = Message.count
+
+    find(".terminal-input").send_keys("i", :return)
+    assert_text "Your inventory is shown in the sidebar."
+
+    find(".terminal-input").send_keys("inv", :return)
+    assert_text "Your inventory is shown in the sidebar."
+
+    find(".terminal-input").send_keys("inventory", :return)
+    assert_text "Your inventory is shown in the sidebar."
+
+    assert_equal initial_count, Message.count
+  end
+
+  # AC4 — Sidebar inventory is visible across commands and room changes
+  test "sidebar inventory is visible across commands and room changes" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    assert_selector "[id^='player_inventory_']", visible: :visible
+
+    find(".terminal-input").send_keys("go east", :return)
+    assert_selector "[id^='player_inventory_']", visible: :visible
+
+    find(".terminal-input").send_keys("open chest", :return)
+    assert_selector "[id^='player_inventory_']", visible: :visible
+
+    find(".terminal-input").send_keys("take potion", :return)
+    assert_selector "[id^='player_inventory_']", visible: :visible
+
+    within("[id^='player_inventory_']") do
+      assert_text "Rusty Key"
+      assert_text "Health Potion"
+    end
+  end
 end

--- a/test/system/host_test.rb
+++ b/test/system/host_test.rb
@@ -43,6 +43,7 @@ class HostTest < ApplicationSystemTestCase
 
   test "mute all players" do
     visit game_url(id: games(:classic_open).uuid)
+    click_on "Players"
     click_on "Mute All"
     assert_selector "input[value='Mute All']"
   end

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -57,8 +57,7 @@ module QaWorld
         cmd "help"
         assert_text "Available commands"
 
-        cmd "inventory"
-        assert_text "carrying nothing"
+        within("[id^='player_inventory_']") { assert_text "(empty)" }
 
         cmd "examine crier"
         assert_text "loud man"
@@ -78,8 +77,7 @@ module QaWorld
 
         cmd_and_wait "take key"
 
-        cmd "inventory"
-        assert_text "You are carrying"
+        within("[id^='player_inventory_']") { assert_text "Rusty Key" }
       end
 
       # ─── Phase 3: Dialogue ────────────────────────────────────────
@@ -238,9 +236,10 @@ module QaWorld
       def phase_final_verification
         cmd_and_wait "go north" # return to Town Square
 
-        cmd "inventory"
-        assert_text "Enchanted Sword"
-        assert_text "Iron Shield"
+        within("[id^='player_inventory_']") do
+          assert_text "Enchanted Sword"
+          assert_text "Iron Shield"
+        end
       end
   end
 end

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -57,10 +57,18 @@ module QaWorld
         cmd "help"
         assert_text "Available commands"
 
+        # Sidebar defaults to the Inventory tab and the empty inventory is visible.
+        assert_button "Inventory"
+        assert_button "Players"
         within("[id^='player_inventory_']") { assert_text "(empty)" }
+
+        # Inventory shortcut shows the client-only hint and clears on next command.
+        cmd "i"
+        assert_text "Thine inventory is innith thine sidebar!"
 
         cmd "examine crier"
         assert_text "loud man"
+        assert_no_text "Thine inventory is innith thine sidebar!"
       end
 
       # ─── Phase 2: Item Basics ─────────────────────────────────────
@@ -77,7 +85,16 @@ module QaWorld
 
         cmd_and_wait "take key"
 
-        within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+        within("[id^='player_inventory_']") do
+          assert_text "Rusty Key"
+          # Clicking the item in the sidebar expands its description inline.
+          click_on "Rusty Key"
+          assert_text "An old rusty iron key"
+        end
+
+        # Clicking the sidebar button moves focus; refocus the terminal so the
+        # next cmd's keystrokes land on the contenteditable input.
+        find(".terminal-input").click
       end
 
       # ─── Phase 3: Dialogue ────────────────────────────────────────
@@ -240,6 +257,14 @@ module QaWorld
           assert_text "Enchanted Sword"
           assert_text "Iron Shield"
         end
+
+        # Tabs toggle the Players panel into view and swap back to Inventory.
+        click_on "Players"
+        assert_selector "turbo-frame#players", visible: :visible
+        assert_selector "[id^='player_inventory_']", visible: :hidden
+
+        click_on "Inventory"
+        assert_selector "[id^='player_inventory_']", visible: :visible
       end
   end
 end

--- a/test/system/qa_world/items_test.rb
+++ b/test/system/qa_world/items_test.rb
@@ -10,8 +10,7 @@ module QaWorld
       find(".terminal-input").send_keys("take key", :return)
       assert_text "Rusty Key"
 
-      find(".terminal-input").send_keys("inventory", :return)
-      assert_text "Rusty Key"
+      within("[id^='player_inventory_']") { assert_text "Rusty Key" }
     end
 
     test "drop item shows it in room" do


### PR DESCRIPTION
## Summary

The inventory system in classic-mode games previously relied on the player typing `inventory`, `inv`, or `i` as a text command — cluttering the message stream with a list of items every time they wanted to check what they were carrying. This feature moves inventory display into the sidebar, where it lives persistently and updates in real-time as items are taken, dropped, used, or traded.

Key changes:
- A dedicated **Inventory** tab appears in the sidebar for classic games, rendering the player's current items by name.
- A second **Players** tab contains the player list and host controls (Mute All / Unmute All). Inventory is the default active tab.
- Each inventory item is a clickable button — clicking expands an inline description inside the sidebar; clicking again collapses it.
- The sidebar refreshes automatically after every player command via Turbo Streams, so inventory always reflects current state without requiring a page reload.
- Typing `I`, `INV`, or `INVENTORY` is intercepted client-side before hitting the server — a transient hint message ("Thine inventory is innith thine sidebar!") appears in the terminal, auto-dismisses after ~4s, and also clears the moment another command is sent or received. No `Message` record is created and no server round-trip occurs.
- The server-side `handle_inventory` handler is simplified to a one-line fallback for cases where the JS intercept is bypassed (e.g., combat delegation, API access, or server-side tests).

## Implementation Details

### Tabs — `app/views/games/show.html.erb` + `app/javascript/controllers/sidebar_tabs_controller.js` (new)
The sidebar's Inventory and Players sections are wrapped in a tabbed container driven by a new `sidebar-tabs` Stimulus controller. Two tab buttons use Stimulus action parameters (`data-sidebar-tabs-name-param`) to set an `activeValue`, and a value callback toggles `.hidden` on the matching panel targets. Inventory is the default active tab; when neither applies (non-classic games or non-playing host), the view falls back to the prior Players-only layout to avoid a degenerate single-tab UI.

### Inventory partial — `app/views/games/_inventory.html.erb` + `app/javascript/controllers/inventory_controller.js` (new)
Each inventory item is now a full-width `<button>` followed by a hidden `<p>` containing `item_def["description"]`. A small `inventory` Stimulus controller toggles the `.hidden` class on the description and flips `aria-expanded`. The old `<h4>INVENTORY</h4>` header is gone because the tab label carries that role now.

### Transient hint — `app/javascript/controllers/game_controller.js`
`show_client_message` now tags the message with `data-client-message="true"`, adds a `transition-opacity duration-500` class, and schedules a two-stage dismissal (fade to `opacity-0` at 4s, `div.remove()` at 4.5s). Three new call sites clear any lingering client messages:
- Before sending any non-inventory command in `capture_input`.
- Before showing a new hint (so repeated `i` presses don't stack).
- On `turbo:before-stream-render` for message targets, so inbound server messages also clear stale hints.

### Olde-tongue flair
`examine_handler.rb` and the client-side intercept both now emit "Thine inventory is innith thine sidebar!" — tests updated accordingly.

### Tests
- **`test/system/classic_game_test.rb`** — 4 new AC tests (AC5–AC8):
  - `AC5`: Clicking Players/Inventory tabs swaps panel visibility.
  - `AC6`: Clicking an inventory item expands, then collapses, its description.
  - `AC7`: The hint clears when the next command is sent.
  - `AC8`: The hint auto-dismisses after ~4s on its own.
- **`test/system/qa_world/full_playthrough_test.rb`** — woven into the end-to-end playthrough:
  - `phase_orientation`: Verifies Inventory/Players tab buttons render and the `i` hint shows + disappears after the next command.
  - `phase_item_basics`: Takes the Rusty Key, clicks it in the sidebar, asserts the description expands. Refocuses the terminal after the click because `click_on` moves focus off the contenteditable input and subsequent `send_keys` would otherwise drop the keystrokes.
  - `phase_final_verification`: Toggles to Players tab, verifies the panel swap, toggles back.
- **`test/system/host_test.rb`** — `mute all players` now clicks "Players" before "Mute All" since the host controls live inside the Players tab.

## Testing Plan

- [x] `bin/rails test test/lib/classic_game/handlers/examine_handler_test.rb` — unit tests for updated handler
- [x] `bin/rails test test/lib/classic_game/full_game_system_test.rb` — full engine system test
- [x] `bin/rails test test/system/classic_game_test.rb` — sidebar visibility, tabs, expand/collapse, hint behavior
- [x] `bin/rails test test/system/qa_world/items_test.rb` — sidebar inventory after take
- [x] `bin/rails test test/system/qa_world/full_playthrough_test.rb` — end-to-end playthrough with tabs and expand
- [x] `bin/rails test test/system/host_test.rb` — host controls accessible via Players tab
- [x] `bin/rails test:system` — full system suite (86 runs, 368 assertions passing)

## Notes

- **Multi-user safety**: The `player_inventory_#{user.id}` DOM id means a broadcast targeting one user's inventory element only patches pages where that specific user's id matches — safe for multi-player sessions on shared game pages.
- **Host-as-player (dev mode)**: In dev mode the dev user is simultaneously the host and the sole game_user. Because the host view subscribes to `:host_players` rather than `:players`, the inventory broadcast is sent on both streams so the dev user's sidebar updates in real time.
- **Non-playing host exclusion**: The tabbed sidebar is only rendered when `@game.game_user(current_user).present?` — a pure-observer host in production falls back to the old Players-only layout and does not see a misleading empty inventory section.
- **Chat-mode safety**: The JS shortcut intercept is gated on `gameTypeValue === "classic"` so chat-game users who type "i", "inv", or "inventory" still have their messages delivered as normal chat.
- **Tab state persistence**: Active tab is held in a Stimulus value, not in URL or storage. A full page reload resets to Inventory. Turbo Stream broadcasts only replace the inventory/players inner partials, not the tab wrapper, so active tab survives live updates.
- **Focus handling in tests**: Clicking a sidebar button steals focus from the contenteditable terminal input. Tests that click the sidebar mid-flow must `find(".terminal-input").click` before the next `send_keys`.
- **Combat delegation**: `CombatHandler#delegate_to_original_handler` routes `:inventory` to `ExamineHandler`. The one-line sidebar response is correct in combat context; the job's broadcast still fires after the command completes.

## Review fixes (post-initial-implementation)

1. **Chat-mode regression** — the JS intercept fired on all games, silently dropping legitimate chat messages containing just "i", "inv", or "inventory". Intercept now scoped to classic games via a `gameType` stimulus value.
2. **Misleading empty inventory for non-playing hosts** — `game.player_state(host_id)` lazily returns a default empty state, so a pure-observer host saw "INVENTORY (empty)" persistently. Sidebar now only renders when the current user has a `game_user`.
3. **Dev-mode sidebar not updating (CI failure)** — the inventory broadcast went only to `:players`, but a host-who-is-also-a-player subscribes only to `:host_players`. Sidebar updates now broadcast to both streams.

## Polish pass (tabs + expandable descriptions + hint UX)

After initial review, the sidebar was redesigned based on UX feedback:

1. **Tabbed layout** — replaced the stacked Inventory-then-Players sections with a proper tab UI; Inventory is default, Players is secondary. The old layout felt cramped and made the inventory feel like an afterthought.
2. **Expandable item descriptions** — clicking an inventory item expands its description inline, so players can inspect items without cluttering the message stream with `examine` commands.
3. **Hint auto-dismiss** — the "your inventory is in the sidebar" hint previously lingered forever; it now fades after ~4s and clears immediately when another command is sent or received.
4. **Olde-tongue flair** — hint text updated to "Thine inventory is innith thine sidebar!" to match the game's tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)