### PR TITLE
Crazy Inventory

### DIFF
--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -1,13 +1,24 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  toggle(event){
-    const button = event.currentTarget
-    const description = button.parentElement.querySelector("[data-inventory-target='description']")
-    if(!description){ return }
+  toggle(event) {
+    const li = event.currentTarget.closest("li")
+    const wasExpanded = event.currentTarget.getAttribute("aria-expanded") === "true"
 
-    const expanded = button.getAttribute("aria-expanded") === "true"
-    button.setAttribute("aria-expanded", (!expanded).toString())
-    description.classList.toggle("hidden")
+    this.element.querySelectorAll("li[data-item-id]").forEach(otherLi => {
+      if (otherLi === li) return
+      const btn = otherLi.querySelector("[data-inventory-target='toggle']")
+      if (btn) btn.setAttribute("aria-expanded", "false")
+      const art = otherLi.querySelector("[data-inventory-target='art']")
+      if (art) art.classList.add("hidden")
+      const desc = otherLi.querySelector("[data-inventory-target='description']")
+      if (desc) desc.classList.add("hidden")
+    })
+
+    const art = li.querySelector("[data-inventory-target='art']")
+    const desc = li.querySelector("[data-inventory-target='description']")
+    if (art) art.classList.toggle("hidden", wasExpanded)
+    if (desc) desc.classList.toggle("hidden", wasExpanded)
+    event.currentTarget.setAttribute("aria-expanded", (!wasExpanded).toString())
   }
 }

--- a/app/lib/classic_game/inventory_art.rb
+++ b/app/lib/classic_game/inventory_art.rb
@@ -2,75 +2,75 @@
 
 module ClassicGame
   module InventoryArt
-    DEFAULT_ART = <<~ART.freeze
+    DEFAULT_ART = <<~ART
       +--------+
       |  ITEM  |
       +--------+
     ART
 
     CATALOG = {
-      "sword" => <<~ART.freeze,
-           /|
-          / |
-         /  |
-        /===|
-       /    |
-      |_____|
+      "sword" => <<~ART,
+             /|
+            / |
+           /  |
+          /===|
+         /    |
+        |_____|
       ART
-      "key" => <<~ART.freeze,
-         ___
-        /   \
-        \___/
-          |---+
-          |---+
+      "key" => <<~ART,
+           ___
+          /   \
+          ___/
+            |---+
+            |---+
       ART
-      "rusty_key" => <<~ART.freeze,
-         ~~~
-        /~~~\
-        \~~~/
-          |---+
-          |---+
+      "rusty_key" => <<~ART,
+           ~~~
+          /~~~\
+          ~~~/
+            |---+
+            |---+
       ART
-      "potion" => <<~ART.freeze,
+      "potion" => <<~ART,
           .---.
          /     \
         |  o o  |
         |   ~   |
-         \     /
+              /
           `---'
       ART
-      "health_potion" => <<~ART.freeze,
+      "health_potion" => <<~ART,
           .---.
          /  +  \
         |  + +  |
         |   +   |
-         \     /
+              /
           `---'
       ART
-      "scroll" => <<~ART.freeze,
+      "scroll" => <<~ART,
         .======.
         | .... |
         | .... |
         | .... |
         `======'
       ART
-      "chest" => <<~ART.freeze,
+      "chest" => <<~ART,
         .--------.
         |========|
         |  [__]  |
         `--------'
       ART
-      "gold_coin" => <<~ART.freeze
+      "gold_coin" => <<~ART
           .---.
          /  $  \
         |  $ $  |
-         \  $  /
+           $  /
           `---'
       ART
     }.freeze
 
     def self.for(item_id, item_def = nil)
-      item_def = item_def || {}
+      item_def ||= {}
       return item_def["ascii_art"] if item_def["ascii_art"].present?
 
       id_str = item_id.to_s

--- a/app/lib/classic_game/inventory_art.rb
+++ b/app/lib/classic_game/inventory_art.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module InventoryArt
+    DEFAULT_ART = <<~ART.freeze
+      +--------+
+      |  ITEM  |
+      +--------+
+    ART
+
+    CATALOG = {
+      "sword" => <<~ART.freeze,
+           /|
+          / |
+         /  |
+        /===|
+       /    |
+      |_____|
+      ART
+      "key" => <<~ART.freeze,
+         ___
+        /   \
+        \___/
+          |---+
+          |---+
+      ART
+      "rusty_key" => <<~ART.freeze,
+         ~~~
+        /~~~\
+        \~~~/
+          |---+
+          |---+
+      ART
+      "potion" => <<~ART.freeze,
+          .---.
+         /     \
+        |  o o  |
+        |   ~   |
+         \     /
+          `---'
+      ART
+      "health_potion" => <<~ART.freeze,
+          .---.
+         /  +  \
+        |  + +  |
+        |   +   |
+         \     /
+          `---'
+      ART
+      "scroll" => <<~ART.freeze,
+        .======.
+        | .... |
+        | .... |
+        | .... |
+        `======'
+      ART
+      "chest" => <<~ART.freeze,
+        .--------.
+        |========|
+        |  [__]  |
+        `--------'
+      ART
+      "gold_coin" => <<~ART.freeze
+          .---.
+         /  $  \
+        |  $ $  |
+         \  $  /
+          `---'
+      ART
+    }.freeze
+
+    def self.for(item_id, item_def = nil)
+      item_def = item_def || {}
+      return item_def["ascii_art"] if item_def["ascii_art"].present?
+
+      id_str = item_id.to_s
+      return CATALOG[id_str] if CATALOG.key?(id_str)
+
+      keywords = item_def["keywords"] || []
+      keyword_match = keywords.find { |kw| CATALOG.key?(kw.to_s) }
+      return CATALOG[keyword_match.to_s] if keyword_match
+
+      DEFAULT_ART
+    end
+  end
+end

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -1,4 +1,5 @@
 <div id="player_inventory_<%= user.id %>" class="mb-5">
+  <div class="text-terminal-green font-bold text-center tracking-widest mb-2">[[ INVENTORY ]]</div>
   <% inventory = game.player_state(user.id)["inventory"] || [] %>
   <% if inventory.empty? %>
     <p class="text-center opacity-60 italic">(empty)</p>
@@ -7,8 +8,8 @@
       <% inventory.each do |item_id| %>
         <% item_def = game.world_snapshot.dig("items", item_id) || {} %>
         <% item_name = item_def["name"] || item_id %>
-        <% item_description = item_def["description"] %>
-        <li class="mb-1">
+        <% item_description = item_def["detailed_description"] || item_def["description"] %>
+        <li class="mb-2 border border-terminal-green border-dashed rounded p-2" data-item-id="<%= item_id %>">
           <button type="button"
                   class="w-full text-center py-1 px-2 cursor-pointer bg-transparent border border-transparent hover:border-terminal-green hover:border-dashed text-terminal-green"
                   aria-expanded="false"
@@ -16,6 +17,7 @@
                   data-action="click->inventory#toggle">
             <%= item_name %>
           </button>
+          <pre class="hidden text-xs font-mono leading-tight overflow-x-auto mt-2 px-2" data-inventory-target="art"><%= ClassicGame::InventoryArt.for(item_id, item_def) %></pre>
           <% if item_description.present? %>
             <p class="hidden text-sm opacity-80 italic px-2 pt-1 pb-2" data-inventory-target="description">
               <%= item_description %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -15,4 +15,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   Capybara.default_max_wait_time = 10
 
   include SystemTestHelper
+
+  setup do
+    page.driver.resize(1400, 1400)
+  end
 end

--- a/test/lib/classic_game/handlers/examine_handler_test.rb
+++ b/test/lib/classic_game/handlers/examine_handler_test.rb
@@ -62,4 +62,13 @@ class ExamineHandlerTest < ActiveSupport::TestCase
     assert result[:success]
     assert_equal "Thine inventory is innith thine sidebar!", result[:response]
   end
+
+  test "examine handler inventory response never includes ascii art" do
+    command = ClassicGame::CommandParser.parse("inventory")
+    result = ClassicGame::Handlers::ExamineHandler.new(game: @game, user_id: USER_ID).handle(command)
+
+    assert_not_includes result[:response], "|"
+    first_art_line = ClassicGame::InventoryArt::CATALOG["sword"].lines.first.strip
+    assert_not_includes result[:response], first_art_line
+  end
 end

--- a/test/lib/classic_game/inventory_art_test.rb
+++ b/test/lib/classic_game/inventory_art_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryArtTest < ActiveSupport::TestCase
+  test "returns ascii_art from item_def when provided" do
+    result = ClassicGame::InventoryArt.for("x", { "ascii_art" => "CUSTOM" })
+    assert_equal "CUSTOM", result
+  end
+
+  test "falls back to catalog by item_id" do
+    result = ClassicGame::InventoryArt.for("sword", {})
+    assert_includes result, "|"
+    assert_equal ClassicGame::InventoryArt::CATALOG["sword"], result
+  end
+
+  test "falls back to catalog by keyword" do
+    result = ClassicGame::InventoryArt.for("katana", { "keywords" => ["sword"] })
+    assert_equal ClassicGame::InventoryArt::CATALOG["sword"], result
+  end
+
+  test "returns DEFAULT_ART when nothing matches" do
+    result = ClassicGame::InventoryArt.for("zz_unknown", {})
+    assert_equal ClassicGame::InventoryArt::DEFAULT_ART, result
+  end
+
+  test "returns DEFAULT_ART when item_def is nil" do
+    result = ClassicGame::InventoryArt.for("zz_unknown")
+    assert_equal ClassicGame::InventoryArt::DEFAULT_ART, result
+  end
+
+  test "ascii_art from item_def takes precedence over catalog entry" do
+    result = ClassicGame::InventoryArt.for("sword", { "ascii_art" => "MY SWORD ART" })
+    assert_equal "MY SWORD ART", result
+  end
+
+  test "keyword fallback checks all keywords in order" do
+    result = ClassicGame::InventoryArt.for("flask", { "keywords" => %w[flask potion] })
+    assert_equal ClassicGame::InventoryArt::CATALOG["potion"], result
+  end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -117,7 +117,9 @@ module TestSupport
           "name" => "Rusty Key",
           "keywords" => %w[key rusty],
           "takeable" => true,
-          "description" => "An old rusty iron key."
+          "description" => "An old rusty iron key.",
+          "detailed_description" => "An ancient rusty iron key, pitted with corrosion and worn smooth at the bow. The teeth still look sharp enough to turn a lock.",
+          "ascii_art" => " .-.\n|~~~|\n'~~'--->"
         },
         "chest" => chest_item,
         "health_potion" => health_potion_item,
@@ -132,7 +134,8 @@ module TestSupport
           "keywords" => %w[sword enchanted],
           "takeable" => true,
           "weapon_damage" => 8,
-          "description" => "A sword that hums with magical energy."
+          "description" => "A sword that hums with magical energy.",
+          "detailed_description" => "A gleaming sword etched with arcane runes. It hums with magical energy and feels warm to the touch. Weapon damage: 8."
         },
         "shield" => {
           "name" => "Iron Shield",
@@ -192,6 +195,7 @@ module TestSupport
         "takeable" => true,
         "consumable" => true,
         "description" => "A bubbling red potion.",
+        "detailed_description" => "A small vial filled with a bubbling crimson liquid. Drinking it restores 5 HP. Handle with care.",
         "on_use" => { "type" => "heal", "amount" => 5, "text" => "You drink the health potion and feel revitalized!" },
         "combat_effect" => { "type" => "heal", "amount" => 5 }
       }

--- a/test/system/crazy_inventory_test.rb
+++ b/test/system/crazy_inventory_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class CrazyInventoryTest < ApplicationSystemTestCase
+  # AC3 — Visually more appealing
+  test "renders inventory header and dashed card per item" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    within("[id^='player_inventory_']") do
+      assert_text "[[ INVENTORY ]]"
+      assert_selector "li[data-item-id]"
+      assert_selector "pre[data-inventory-target='art']", visible: false
+    end
+  end
+
+  # AC2 — Click/tap reveals ascii art and detailed description
+  test "clicking an inventory item reveals ascii art and detailed description" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    within("[id^='player_inventory_']") do
+      assert_selector "pre[data-inventory-target='art']", visible: :hidden
+
+      click_on "Rusty Key"
+
+      assert_selector "pre[data-inventory-target='art']", visible: :visible
+      assert_selector "p[data-inventory-target='description']", visible: :visible
+    end
+  end
+
+  # AC2 — Clicking again collapses the item
+  test "clicking an expanded item collapses it" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    within("[id^='player_inventory_']") do
+      click_on "Rusty Key"
+      assert_selector "pre[data-inventory-target='art']", visible: :visible
+
+      click_on "Rusty Key"
+      assert_selector "pre[data-inventory-target='art']", visible: :hidden
+    end
+  end
+
+  # AC2 — Opening a second item collapses the first
+  test "opening a second item collapses the first" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    find(".terminal-input").send_keys("go east", :return)
+    assert_text "The Tavern"
+
+    find(".terminal-input").send_keys("take lockpick", :return)
+    within("[id^='player_inventory_']") { assert_text "Lockpick" }
+
+    within("[id^='player_inventory_']") do
+      key_li = find("li[data-item-id='rusty_key']")
+      pick_li = find("li[data-item-id='lockpick']")
+
+      key_li.click_on "Rusty Key"
+      assert_selector "li[data-item-id='rusty_key'] pre[data-inventory-target='art']", visible: :visible
+
+      pick_li.click_on "Lockpick"
+      assert_selector "li[data-item-id='lockpick'] pre[data-inventory-target='art']", visible: :visible
+      assert_selector "li[data-item-id='rusty_key'] pre[data-inventory-target='art']", visible: :hidden
+    end
+  end
+
+  # AC4 — Works in single + multiplayer (scoped wrapper per user)
+  test "partial renders per-user scoped wrapper" do
+    visit dev_game_path
+    assert_selector "[id^='player_inventory_']"
+  end
+end

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -89,7 +89,7 @@ module QaWorld
           assert_text "Rusty Key"
           # Clicking the item in the sidebar expands its description inline.
           click_on "Rusty Key"
-          assert_text "An old rusty iron key"
+          assert_text "An ancient rusty iron key"
         end
 
         # Clicking the sidebar button moves focus; refocus the terminal so the


### PR DESCRIPTION
## Summary

- **`ClassicGame::InventoryArt` module** (`app/lib/classic_game/inventory_art.rb`) — ASCII art catalog with entries for sword, key, rusty_key, potion, health_potion, scroll, chest, and gold_coin. `InventoryArt.for(item_id, item_def)` resolves art via a four-step fallback: item-def `ascii_art` field → catalog by item ID → catalog by keyword → `DEFAULT_ART`.
- **Inventory partial** (`app/views/games/_inventory.html.erb`) — Added `[[ INVENTORY ]]` section header; each item is now a dashed-border card (`border-terminal-green border-dashed`). Each card contains a toggle button, a hidden `<pre>` with ASCII art (`data-inventory-target="art"`), and an optional description `<p>` sourced from `detailed_description || description`.
- **Stimulus controller** (`app/javascript/controllers/inventory_controller.js`) — Rewrote `toggle()` so that expanding an item first collapses all sibling items, then toggles the clicked item's art and description. Null-checks both targets for items without a description.
- **QA world data** (`test/support/qa_world_data.rb`) — Added `ascii_art` and `detailed_description` to `rusty_key` (world-supplied art), `enchanted_sword`, and `health_potion` (catalog fallback via keywords).

## Test plan

- [x] `test/lib/classic_game/inventory_art_test.rb` — unit tests for all four fallback paths in `InventoryArt.for`
- [x] `test/lib/classic_game/handlers/examine_handler_test.rb` — added assertion that `inventory` command response never contains ASCII art characters
- [x] `test/system/crazy_inventory_test.rb` — Capybara system tests covering: header/card rendering (AC3), click-to-reveal art+description (AC2), click-to-collapse (AC2), sibling collapse when second item opened (AC2), per-user wrapper existence (AC4)
- [x] Existing `classic_game_test.rb` AC6 test preserved — `rusty_key` `detailed_description` retains the "rusty iron key" phrase

## Constraints respected

- `handle_inventory` response unchanged: `"Thine inventory is innith thine sidebar!"`
- Turbo broadcast target `id="player_inventory_<user.id>"` and partial name `_inventory.html.erb` unchanged
- No new partial locals required — art resolved inside partial via `game.world_snapshot` and `InventoryArt`
- Expanded-item state is purely client-side; never persisted to `game_state`
- Stimulus controller scoped to `this.element` so multiple sidebars don't cross-collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix notes (round 1)

- QA world system test expected the short inventory description ("An old rusty iron key") when clicking an item in the sidebar, but the Crazy Inventory feature now surfaces the `detailed_description` ("An ancient rusty iron key..."). Updated `test/system/qa_world/full_playthrough_test.rb` to assert against the new detailed text.



## Fix notes (round 2)

- Every failing test was looking for an element inside `#sidebar-panel`, which has `hidden md:block` in the layout. The errors were "element exists but not visible" — meaning the viewport had fallen below the `md` breakpoint.
- Root cause: Cuprite reuses one browser session across test classes, so when `MobileSystemTestCase` resizes the window to 375x667, any `ApplicationSystemTestCase` test that runs afterwards inherits that size. Different test seeds expose the ordering in different ways, which is why main was green but this branch's seed failed across onboarding, lobby, host, classic_game, crazy_inventory, and qa_world tests alike.
- Fix: added `page.driver.resize(1400, 1400)` to the `ApplicationSystemTestCase` setup block so every desktop-sized test starts from a known viewport.


---
### Recovery fix (round 3)
- Fixed 16 rubocop offenses in `app/lib/classic_game/inventory_art.rb`: removed redundant `.freeze` on heredocs, removed redundant string escapes (`\_`, `\~`, `\ `), switched `item_def = item_def || {}` to `||=`, and adjusted sword heredoc indentation to satisfy `Layout/HeredocIndentation`.
