### PR TITLE
feature/Crazy Inventory

### DIFF
--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -3,11 +3,13 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   toggle(event){
     const button = event.currentTarget
-    const description = button.parentElement.querySelector("[data-inventory-target='description']")
-    if(!description){ return }
-
     const expanded = button.getAttribute("aria-expanded") === "true"
     button.setAttribute("aria-expanded", (!expanded).toString())
-    description.classList.toggle("hidden")
+
+    const description = button.parentElement.querySelector("[data-inventory-target='description']")
+    if(description){ description.classList.toggle("hidden") }
+
+    const li = button.closest("li")
+    if(li){ li.classList.toggle("inventory-item--expanded") }
   }
 }

--- a/app/lib/classic_game/item_ascii_art.rb
+++ b/app/lib/classic_game/item_ascii_art.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module ClassicGame
+  module ItemAsciiArt
+    FALLBACK_ART = {
+      "key" => "  ___\n /   |\n \\___|-o",
+      "sword" => "   /\\\n  /  \\\n /----\\\n|__||__|\n   ||\n  _||_",
+      "potion" => "  ___\n /   \\\n|     |\n|     |\n \\___/\n  | |",
+      "scroll" => " _____\n|     |\n| --- |\n| --- |\n|_____|\n(_____)",
+      "gem" => "  /\\\n /  \\\n\\    /\n >--<\n/    \\\n \\  /",
+      "book" => " _____\n/     \\\n|=====|\n|     |\n|=====|\n\\_____/",
+      "coin" => "  ___\n / $ \\\n|     |\n \\___/",
+      "torch" => "  )\n )((\n  )(\n  ||\n  ||\n  ||",
+      "shield" => " _____\n/     \\\n| ( ) |\n|     |\n \\   /\n  \\_/",
+      "bottle" => "  ___\n |   |\n  \\ /\n  | |\n  | |\n  |_|",
+      "ring" => "  ___\n /   \\\n(     )\n \\___/",
+      "map" => " _____\n|  .  |\n| .X. |\n|  .  |\n|_____|\n[_____]",
+      "gold" => "  $$$\n $$$$$\n$ $$$ $\n $$$$$\n  $$$",
+      "helmet" => " _____\n/     \\\n| o o |\n|     |\n|_____|",
+      "axe" => " ___\n/   \\\n| * |\\\n\\___/ \\\n      ||\n     _||_",
+      "bow" => "  |\n  |\\\n  | \\\n  |  >\n  | /\n  |/",
+      "food" => "  ___\n /   \\\n( ~~~ )\n \\___/",
+      "chest" => " _____\n|=====|\n|     |\n|  $  |\n|_____|",
+      "box" => " _____\n|     |\n|     |\n|     |\n|_____|",
+      "default" => ".-----.\n|  ?  |\n'-----'"
+    }.freeze
+
+    def self.for(item_def, item_id)
+      art = item_def.is_a?(Hash) ? item_def["ascii_art"] : nil
+      return art if art.present?
+
+      keywords = (item_def.is_a?(Hash) ? item_def["keywords"] : nil) || []
+      fallback_for(item_id, keywords)
+    end
+
+    def self.fallback_for(item_id, keywords)
+      candidates = [item_id.to_s, *keywords].compact.map { |s| s.to_s.downcase }
+      FALLBACK_ART.each do |key, art|
+        next if key == "default"
+        return art if candidates.any? { |c| c.include?(key) }
+      end
+      FALLBACK_ART["default"]
+    end
+  end
+end

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -3,25 +3,11 @@
   <% if inventory.empty? %>
     <p class="text-center opacity-60 italic">(empty)</p>
   <% else %>
-    <ul class="list-none p-0 m-0" data-controller="inventory">
+    <ul class="list-none p-0 m-0 space-y-2" data-controller="inventory">
       <% inventory.each do |item_id| %>
         <% item_def = game.world_snapshot.dig("items", item_id) || {} %>
-        <% item_name = item_def["name"] || item_id %>
-        <% item_description = item_def["description"] %>
-        <li class="mb-1">
-          <button type="button"
-                  class="w-full text-center py-1 px-2 cursor-pointer bg-transparent border border-transparent hover:border-terminal-green hover:border-dashed text-terminal-green"
-                  aria-expanded="false"
-                  data-inventory-target="toggle"
-                  data-action="click->inventory#toggle">
-            <%= item_name %>
-          </button>
-          <% if item_description.present? %>
-            <p class="hidden text-sm opacity-80 italic px-2 pt-1 pb-2" data-inventory-target="description">
-              <%= item_description %>
-            </p>
-          <% end %>
-        </li>
+        <% ascii_art = ClassicGame::ItemAsciiArt.for(item_def, item_id) %>
+        <%= render "/games/inventory_item", item_id: item_id, item_def: item_def, ascii_art: ascii_art %>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/games/_inventory_item.html.erb
+++ b/app/views/games/_inventory_item.html.erb
@@ -8,7 +8,7 @@
           aria-expanded="false"
           data-inventory-target="toggle"
           data-action="click->inventory#toggle"
-          class="w-full py-1 px-2 bg-transparent border-0 border-t border-dashed border-terminal-green/30 text-terminal-green font-bold uppercase tracking-wide cursor-pointer hover:bg-terminal-green hover:text-stone-900 transition-colors">
+          class="w-full py-1 px-2 bg-transparent border-0 border-t border-dashed border-terminal-green/30 text-terminal-green font-bold tracking-wide cursor-pointer hover:bg-terminal-green hover:text-stone-900 transition-colors">
     <%= item_name %>
   </button>
   <% if item_description.present? %>

--- a/app/views/games/_inventory_item.html.erb
+++ b/app/views/games/_inventory_item.html.erb
@@ -1,0 +1,20 @@
+<% item_name = item_def["name"].presence || item_id %>
+<% item_description = item_def["description"] %>
+<li class="mb-3 border border-dashed border-terminal-green/40 rounded-sm overflow-hidden">
+  <% if ascii_art.present? %>
+    <pre class="m-0 px-2 py-1 text-[10px] leading-tight text-terminal-green text-center whitespace-pre font-mono select-none"><%= ascii_art %></pre>
+  <% end %>
+  <button type="button"
+          aria-expanded="false"
+          data-inventory-target="toggle"
+          data-action="click->inventory#toggle"
+          class="w-full py-1 px-2 bg-transparent border-0 border-t border-dashed border-terminal-green/30 text-terminal-green font-bold uppercase tracking-wide cursor-pointer hover:bg-terminal-green hover:text-stone-900 transition-colors">
+    <%= item_name %>
+  </button>
+  <% if item_description.present? %>
+    <div class="hidden px-3 py-2 text-sm opacity-90 italic border-t border-dashed border-terminal-green/30"
+         data-inventory-target="description">
+      <p class="m-0"><%= item_description %></p>
+    </div>
+  <% end %>
+</li>

--- a/test/lib/classic_game/item_ascii_art_test.rb
+++ b/test/lib/classic_game/item_ascii_art_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ItemAsciiArtTest < ActiveSupport::TestCase
+  test "returns explicit ascii_art when present" do
+    item_def = { "ascii_art" => "  X\n /|\\\n / \\", "name" => "Custom" }
+    result = ClassicGame::ItemAsciiArt.for(item_def, "custom_thing")
+    assert_equal "  X\n /|\\\n / \\", result
+  end
+
+  test "treats empty string ascii_art as absent and falls back" do
+    item_def = { "ascii_art" => "", "name" => "Key", "keywords" => ["key"] }
+    result = ClassicGame::ItemAsciiArt.for(item_def, "empty_art_key")
+    assert_includes result, "___"
+  end
+
+  test "falls back by item_id substring" do
+    item_def = { "name" => "Rusty Key", "keywords" => ["rusty"] }
+    result = ClassicGame::ItemAsciiArt.for(item_def, "rusty_key")
+    assert_includes result, "___"
+  end
+
+  test "falls back by keyword" do
+    item_def = { "name" => "Excalibur", "keywords" => %w[sword blade] }
+    result = ClassicGame::ItemAsciiArt.for(item_def, "excalibur")
+    assert_includes result, "__||__"
+  end
+
+  test "returns default when no match" do
+    item_def = { "name" => "Whatsit", "keywords" => ["whatsit"] }
+    result = ClassicGame::ItemAsciiArt.for(item_def, "whatsit")
+    assert_includes result, "?"
+  end
+
+  test "handles nil item_def gracefully" do
+    result = ClassicGame::ItemAsciiArt.for({}, "unknown_thing")
+    assert_includes result, "?"
+  end
+
+  test "fallback_for returns default when no candidates match" do
+    result = ClassicGame::ItemAsciiArt.fallback_for("zork_artifact", [])
+    assert_equal ClassicGame::ItemAsciiArt::FALLBACK_ART["default"], result
+  end
+
+  test "fallback_for matches partial item_id" do
+    result = ClassicGame::ItemAsciiArt.fallback_for("old_sword_of_doom", [])
+    assert_includes result, "__||__"
+  end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -125,7 +125,8 @@ module TestSupport
           "name" => "Sparkling Gem",
           "keywords" => %w[gem sparkling],
           "takeable" => true,
-          "description" => "A brilliant gemstone that glows faintly."
+          "description" => "A brilliant gemstone that glows faintly.",
+          "ascii_art" => "  * *\n *   *\n  * *\n   *"
         },
         "enchanted_sword" => {
           "name" => "Enchanted Sword",

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -134,6 +134,21 @@ class ClassicGameTest < ApplicationSystemTestCase
     assert_selector "turbo-frame#players", visible: :hidden
   end
 
+  # AC4 — Inventory item shows ASCII art card and reveals description on click
+  test "inventory item shows ASCII art card and reveals description on click" do
+    visit dev_game_path
+    find(".terminal-input").click
+
+    find(".terminal-input").send_keys("take key", :return)
+    within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+    within("[id^='player_inventory_']") do
+      assert_selector "pre"
+      click_on "Rusty Key"
+      assert_text "rusty iron key"
+    end
+  end
+
   # AC6 — Clicking an inventory item expands/collapses its description
   test "clicking inventory item toggles its description" do
     visit dev_game_path

--- a/test/views/games/inventory_partial_test.rb
+++ b/test/views/games/inventory_partial_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryPartialTest < ActionView::TestCase
+  include ClassicGameTestHelper
+
+  def setup
+    @world = build_world(
+      starting_room: "start",
+      rooms: {
+        "start" => { "name" => "Start Room", "description" => "A room.", "exits" => {} }
+      },
+      items: {
+        "rusty_key" => {
+          "name" => "Rusty Key",
+          "description" => "A cold iron key.",
+          "keywords" => %w[key rusty],
+          "takeable" => true
+        }
+      }
+    )
+    @user = FakeUser.new(1)
+    @game = build_game(
+      world_data: @world,
+      player_id: 1,
+      player_state: player_state_in("start", inventory: ["rusty_key"])
+    )
+  end
+
+  test "renders toggle button and hidden description" do
+    render partial: "games/inventory", locals: { game: @game, user: @user }
+
+    assert_match "click->inventory#toggle", rendered
+    assert_match "aria-expanded=\"false\"", rendered
+    assert_match "A cold iron key.", rendered
+    assert_match(/class="hidden[^"]*"/, rendered)
+  end
+
+  test "renders ascii art block for items" do
+    render partial: "games/inventory", locals: { game: @game, user: @user }
+
+    assert_match "<pre", rendered
+    assert_match "___", rendered
+  end
+
+  test "inventory card has visual border classes" do
+    render partial: "games/inventory", locals: { game: @game, user: @user }
+
+    assert_match(/class="[^"]*\bborder\b[^"]*"/, rendered)
+    assert_match(/class="[^"]*\bborder-dashed\b[^"]*"/, rendered)
+  end
+
+  test "renders empty state when inventory is empty" do
+    game = build_game(world_data: @world, player_id: 1, player_state: player_state_in("start", inventory: []))
+    render partial: "games/inventory", locals: { game: game, user: @user }
+
+    assert_match "(empty)", rendered
+    assert_no_match "border-dashed", rendered
+  end
+
+  test "falls back to item_id when item has no name" do
+    world = build_world(
+      starting_room: "start",
+      rooms: { "start" => { "name" => "Room", "description" => ".", "exits" => {} } },
+      items: {}
+    )
+    game = build_game(
+      world_data: world,
+      player_id: 1,
+      player_state: player_state_in("start", inventory: ["mystery_box"])
+    )
+    render partial: "games/inventory", locals: { game: game, user: @user }
+
+    assert_match "mystery_box", rendered
+  end
+end


### PR DESCRIPTION
## Summary

- Added `ClassicGame::ItemAsciiArt` module with a 20-entry fallback registry (keyed by item name substrings like `"key"`, `"sword"`, `"potion"`, etc.) plus custom per-item art via `item_def["ascii_art"]`
- New `_inventory_item` partial renders each inventory item as a styled card: ASCII art in a `<pre>` block, a clickable uppercase button, and a hidden description panel that toggles on click
- Updated `_inventory.html.erb` to render the new partial per item; preserved the `player_inventory_<user_id>` wrapper id so multiplayer Turbo broadcasts remain unbroken
- Updated `inventory_controller.js` toggle to also flip an `inventory-item--expanded` class on the parent `<li>` (and no longer early-returns when no description exists, so `aria-expanded` and the expanded class always update)
- QA world: added an `ascii_art` field to the `gem` item as an example of custom art overriding the fallback

## Test plan

- [ ] `test/lib/classic_game/item_ascii_art_test.rb` — unit tests for lookup priority (explicit art, item_id fallback, keyword fallback, default)
- [ ] `test/views/games/inventory_partial_test.rb` — view tests asserting `<pre>` block, toggle button, hidden description, border classes, and empty state
- [ ] `test/system/classic_game_test.rb` — new system test: take key → assert `<pre>` in sidebar → click item → assert description text visible
- [ ] Existing system tests for toggle, multiplayer broadcast, and inventory shortcuts all continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Fix notes (recovery round 1)

6 system tests failed because the inventory item button used Tailwind `uppercase`, so Capybara saw "RUSTY KEY" / "HEALTH POTION" while tests asserted "Rusty Key" / "Health Potion". Removed the `uppercase` class from `app/views/games/_inventory_item.html.erb` so the displayed casing matches the underlying item names (and the tests).
