### PR TITLE
feature/Crazy Inventory

### DIFF
--- a/app/javascript/controllers/inventory_controller.js
+++ b/app/javascript/controllers/inventory_controller.js
@@ -1,13 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  toggle(event){
+  toggle(event) {
     const button = event.currentTarget
-    const description = button.parentElement.querySelector("[data-inventory-target='description']")
-    if(!description){ return }
+    const li = button.closest("li")
+    if (!li) return
+
+    const detail = li.querySelector("[data-inventory-target='detail']")
+    const caret = li.querySelector("[data-inventory-target='caret']")
+
+    if (!detail) return
 
     const expanded = button.getAttribute("aria-expanded") === "true"
-    button.setAttribute("aria-expanded", (!expanded).toString())
-    description.classList.toggle("hidden")
+    button.setAttribute("aria-expanded", String(!expanded))
+    detail.classList.toggle("hidden")
+    if (caret) caret.classList.toggle("rotate-90")
+    li.classList.toggle("is-open")
   }
 }

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -1,28 +1,22 @@
 <div id="player_inventory_<%= user.id %>" class="mb-5">
-  <% inventory = game.player_state(user.id)["inventory"] || [] %>
-  <% if inventory.empty? %>
-    <p class="text-center opacity-60 italic">(empty)</p>
-  <% else %>
-    <ul class="list-none p-0 m-0" data-controller="inventory">
-      <% inventory.each do |item_id| %>
-        <% item_def = game.world_snapshot.dig("items", item_id) || {} %>
-        <% item_name = item_def["name"] || item_id %>
-        <% item_description = item_def["description"] %>
-        <li class="mb-1">
-          <button type="button"
-                  class="w-full text-center py-1 px-2 cursor-pointer bg-transparent border border-transparent hover:border-terminal-green hover:border-dashed text-terminal-green"
-                  aria-expanded="false"
-                  data-inventory-target="toggle"
-                  data-action="click->inventory#toggle">
-            <%= item_name %>
-          </button>
-          <% if item_description.present? %>
-            <p class="hidden text-sm opacity-80 italic px-2 pt-1 pb-2" data-inventory-target="description">
-              <%= item_description %>
-            </p>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  <% end %>
+  <div class="border-double border-2 border-terminal-green/40 px-2 py-3 bg-stone-900/40">
+    <p class="text-xs uppercase opacity-70 mb-2 text-center tracking-widest">— Inventory —</p>
+    <% inventory = game.player_state(user.id)["inventory"] || [] %>
+    <% if inventory.empty? %>
+      <pre class="text-[0.55rem] md:text-xs leading-tight text-terminal-green text-center opacity-70">  _____
+ /     \
+|       |
+|  ___  |
+ \_____/</pre>
+      <p class="text-center opacity-60 italic">(thine sack lieth empty)</p>
+    <% else %>
+      <ul data-controller="inventory">
+        <% items = game.world_snapshot["items"] || {} %>
+        <% inventory.each do |item_id| %>
+          <% item_def = items[item_id] || {} %>
+          <%= render "inventory_item", item_id: item_id, item_def: item_def %>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
 </div>

--- a/app/views/games/_inventory.html.erb
+++ b/app/views/games/_inventory.html.erb
@@ -14,7 +14,7 @@
         <% items = game.world_snapshot["items"] || {} %>
         <% inventory.each do |item_id| %>
           <% item_def = items[item_id] || {} %>
-          <%= render "inventory_item", item_id: item_id, item_def: item_def %>
+          <%= render "games/inventory_item", item_id: item_id, item_def: item_def %>
         <% end %>
       </ul>
     <% end %>

--- a/app/views/games/_inventory_item.html.erb
+++ b/app/views/games/_inventory_item.html.erb
@@ -1,0 +1,23 @@
+<%
+  item_name = item_def["name"] || item_id
+  ascii_art = item_def["ascii_art"]
+  body = item_def["detailed_description"].presence || item_def["description"].presence || "Naught to tell about this."
+%>
+<li class="mb-2 group">
+  <button
+    class="w-full text-left text-terminal-green hover:border-dashed hover:border hover:border-terminal-green px-2 py-1 flex justify-between items-center"
+    data-inventory-target="toggle"
+    data-action="click->inventory#toggle"
+    aria-expanded="false"
+  >
+    <span><%= item_name %></span>
+    <span class="opacity-60 transition-transform inline-block" data-inventory-target="caret">▶</span>
+  </button>
+  <div class="hidden mt-1 border border-dashed border-terminal-green/60 bg-stone-950/60 px-2 py-3" data-inventory-target="detail">
+    <% if ascii_art %>
+      <pre class="text-[0.55rem] md:text-xs leading-tight text-terminal-green text-center overflow-x-auto whitespace-pre"><%= ascii_art %></pre>
+      <hr class="border-terminal-green/30 my-2">
+    <% end %>
+    <p class="text-sm italic opacity-80 px-1"><%= body %></p>
+  </div>
+</li>

--- a/test/integration/inventory_partial_test.rb
+++ b/test/integration/inventory_partial_test.rb
@@ -30,7 +30,7 @@ class InventoryPartialTest < ActionView::TestCase
     )
     user = FakeUser.new(1)
 
-    render template: "games/inventory", locals: { game: game, user: user }
+    render partial: "games/inventory", locals: { game: game, user: user }
 
     assert_includes rendered, "███"
     assert_select "li", 2
@@ -49,7 +49,7 @@ class InventoryPartialTest < ActionView::TestCase
     game = build_game(world_data: world, player_id: 1)
     user = FakeUser.new(1)
 
-    render template: "games/inventory", locals: { game: game, user: user }
+    render partial: "games/inventory", locals: { game: game, user: user }
 
     assert_includes rendered, "thine sack lieth empty"
     assert_match(/<pre[^>]*>/, rendered)

--- a/test/integration/inventory_partial_test.rb
+++ b/test/integration/inventory_partial_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class InventoryPartialTest < ActionView::TestCase
+  include ClassicGameTestHelper
+
+  test "renders ascii art block when item has ascii_art" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Test Room", "description" => "A room.", "exits" => {} }
+      },
+      items: {
+        "shiny" => {
+          "name" => "shiny",
+          "ascii_art" => "███\n░░░",
+          "description" => "A shiny object."
+        },
+        "plain" => {
+          "name" => "plain",
+          "description" => "A plain object."
+        }
+      }
+    )
+    game = build_game(
+      world_data: world,
+      player_id: 1,
+      player_state: player_state_in("room1", inventory: %w[shiny plain])
+    )
+    user = FakeUser.new(1)
+
+    render template: "games/inventory", locals: { game: game, user: user }
+
+    assert_includes rendered, "███"
+    assert_select "li", 2
+    assert_includes rendered, "border-double"
+    assert_includes rendered, "— Inventory —"
+    assert_select "pre", 1
+  end
+
+  test "renders empty-state ascii when inventory is empty" do
+    world = build_world(
+      starting_room: "room1",
+      rooms: {
+        "room1" => { "name" => "Test Room", "description" => "A room.", "exits" => {} }
+      }
+    )
+    game = build_game(world_data: world, player_id: 1)
+    user = FakeUser.new(1)
+
+    render template: "games/inventory", locals: { game: game, user: user }
+
+    assert_includes rendered, "thine sack lieth empty"
+    assert_match(/<pre[^>]*>/, rendered)
+  end
+end

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -2,14 +2,14 @@
 
 module TestSupport
   module QaWorldData # rubocop:disable Metrics/ModuleLength
-    RUSTY_KEY_ART = <<~ART.freeze
+    RUSTY_KEY_ART = <<~ART
       ╔═══╗
       ║ ◉ ╠══╗
       ╚═══╝  ║
          ▓▓▓▓╝
     ART
 
-    GEM_ART = <<~ART.freeze
+    GEM_ART = <<~ART
       ╔══╦══╗
       ║◆◆║◆◆║
       ╠══╬══╣
@@ -17,17 +17,17 @@ module TestSupport
       ╚══╩══╝
     ART
 
-    SWORD_ART = <<~ART.freeze
-          ╔╗
-          ║║
-          ║║
-        ╔═╬╬═╗
-        ╚═╬╬═╝
-          ║║
-          ╚╝
+    SWORD_ART = <<~ART
+        ╔╗
+        ║║
+        ║║
+      ╔═╬╬═╗
+      ╚═╬╬═╝
+        ║║
+        ╚╝
     ART
 
-    SHIELD_ART = <<~ART.freeze
+    SHIELD_ART = <<~ART
       ██████████
       █▓▓▓▓▓▓▓█
       █▓▒▒▒▒▓█
@@ -39,17 +39,17 @@ module TestSupport
           ██
     ART
 
-    POTION_ART = <<~ART.freeze
-           _____
-          /° ° °\
-         | °   ° |
-         | ° ° ° |
-          \_____/
-            | |
-           =====
+    POTION_ART = <<~ART
+        _____
+       /° ° °\
+      | °   ° |
+      | ° ° ° |
+       _____/
+         | |
+        =====
     ART
 
-    LOCKPICK_ART = <<~ART.freeze
+    LOCKPICK_ART = <<~ART
       ⌐──────────┐
                   │
       ⌐──────────┘

--- a/test/support/qa_world_data.rb
+++ b/test/support/qa_world_data.rb
@@ -2,6 +2,83 @@
 
 module TestSupport
   module QaWorldData # rubocop:disable Metrics/ModuleLength
+    RUSTY_KEY_ART = <<~ART.freeze
+      ╔═══╗
+      ║ ◉ ╠══╗
+      ╚═══╝  ║
+         ▓▓▓▓╝
+    ART
+
+    GEM_ART = <<~ART.freeze
+      ╔══╦══╗
+      ║◆◆║◆◆║
+      ╠══╬══╣
+      ║◊◊║◊◊║
+      ╚══╩══╝
+    ART
+
+    SWORD_ART = <<~ART.freeze
+          ╔╗
+          ║║
+          ║║
+        ╔═╬╬═╗
+        ╚═╬╬═╝
+          ║║
+          ╚╝
+    ART
+
+    SHIELD_ART = <<~ART.freeze
+      ██████████
+      █▓▓▓▓▓▓▓█
+      █▓▒▒▒▒▓█
+      █▓▒░░▒▓█
+      ██████████
+       ████████
+        ██████
+         ████
+          ██
+    ART
+
+    POTION_ART = <<~ART.freeze
+           _____
+          /° ° °\
+         | °   ° |
+         | ° ° ° |
+          \_____/
+            | |
+           =====
+    ART
+
+    LOCKPICK_ART = <<~ART.freeze
+      ⌐──────────┐
+                  │
+      ⌐──────────┘
+    ART
+
+    def self.rusty_key_lore
+      "A tarnished rusty iron key, worn smooth by many hands — what lock does it open?"
+    end
+
+    def self.gem_lore
+      "A faceted jewel that catches even the faintest light, cold and brilliant to the touch."
+    end
+
+    def self.sword_lore
+      "An enchanted blade humming with arcane energy, its edge never dulling."
+    end
+
+    def self.shield_lore
+      "A sturdy shield bearing the crest of a forgotten order, still solid as the day it was forged."
+    end
+
+    def self.potion_lore
+      "A stoppered vial of crimson liquid that seems to pulse with warmth."
+    end
+
+    def self.lockpick_lore
+      "A slender steel pick, its tip bent just so — in the right hands, no lock is a match for it."
+    end
+
     def self.data
       @data ||= {
         "meta" => meta,
@@ -117,7 +194,9 @@ module TestSupport
           "name" => "Rusty Key",
           "keywords" => %w[key rusty],
           "takeable" => true,
-          "description" => "An old rusty iron key."
+          "description" => "An old rusty iron key.",
+          "ascii_art" => RUSTY_KEY_ART,
+          "detailed_description" => rusty_key_lore
         },
         "chest" => chest_item,
         "health_potion" => health_potion_item,
@@ -125,21 +204,27 @@ module TestSupport
           "name" => "Sparkling Gem",
           "keywords" => %w[gem sparkling],
           "takeable" => true,
-          "description" => "A brilliant gemstone that glows faintly."
+          "description" => "A brilliant gemstone that glows faintly.",
+          "ascii_art" => GEM_ART,
+          "detailed_description" => gem_lore
         },
         "enchanted_sword" => {
           "name" => "Enchanted Sword",
           "keywords" => %w[sword enchanted],
           "takeable" => true,
           "weapon_damage" => 8,
-          "description" => "A sword that hums with magical energy."
+          "description" => "A sword that hums with magical energy.",
+          "ascii_art" => SWORD_ART,
+          "detailed_description" => sword_lore
         },
         "shield" => {
           "name" => "Iron Shield",
           "keywords" => %w[shield iron],
           "takeable" => true,
           "defense_bonus" => 3,
-          "description" => "A sturdy iron shield."
+          "description" => "A sturdy iron shield.",
+          "ascii_art" => SHIELD_ART,
+          "detailed_description" => shield_lore
         },
         "lockpick" => lockpick_item
       }
@@ -151,6 +236,8 @@ module TestSupport
         "keywords" => %w[lockpick pick],
         "takeable" => true,
         "description" => "A thin metal pick for opening locks.",
+        "ascii_art" => LOCKPICK_ART,
+        "detailed_description" => lockpick_lore,
         "dice_roll" => {
           "dc" => 12,
           "stat" => "dexterity",
@@ -192,6 +279,8 @@ module TestSupport
         "takeable" => true,
         "consumable" => true,
         "description" => "A bubbling red potion.",
+        "ascii_art" => POTION_ART,
+        "detailed_description" => potion_lore,
         "on_use" => { "type" => "heal", "amount" => 5, "text" => "You drink the health potion and feel revitalized!" },
         "combat_effect" => { "type" => "heal", "amount" => 5 }
       }

--- a/test/system/classic_game_test.rb
+++ b/test/system/classic_game_test.rb
@@ -50,7 +50,7 @@ class ClassicGameTest < ApplicationSystemTestCase
     assert_selector "[id^='player_inventory_']"
     assert_button "Inventory"
     within("[id^='player_inventory_']") do
-      assert_text "(empty)"
+      assert_text "thine sack lieth empty"
     end
   end
 
@@ -66,7 +66,7 @@ class ClassicGameTest < ApplicationSystemTestCase
 
     find(".terminal-input").send_keys("drop key", :return)
     within("[id^='player_inventory_']") do
-      assert_text "(empty)"
+      assert_text "thine sack lieth empty"
       assert_no_text "Rusty Key"
     end
   end
@@ -145,13 +145,16 @@ class ClassicGameTest < ApplicationSystemTestCase
     within("[id^='player_inventory_']") do
       # Description is hidden until the item is clicked.
       assert_no_text "rusty iron key"
+      assert_no_text "▓"
 
       click_on "Rusty Key"
       assert_text "rusty iron key"
+      assert_text "▓"
 
       # Clicking again collapses the description.
       click_on "Rusty Key"
       assert_no_text "rusty iron key"
+      assert_no_text "▓"
     end
   end
 

--- a/test/system/qa_world/crazy_inventory_test.rb
+++ b/test/system/qa_world/crazy_inventory_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+module QaWorld
+  class CrazyInventoryTest < ApplicationSystemTestCase
+    test "inventory items render ASCII art only after click" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("take key", :return)
+      within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+      within("[id^='player_inventory_']") do
+        assert_no_text "▓"
+        click_on "Rusty Key"
+        assert_text "▓"
+      end
+    end
+
+    test "clicking second inventory item reveals its own art" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("take key", :return)
+      assert_text "Rusty Key"
+
+      find(".terminal-input").send_keys("go east", :return)
+      assert_text "The Tavern"
+
+      find(".terminal-input").send_keys("open chest", :return)
+      assert_text "unlock the chest"
+
+      find(".terminal-input").send_keys("take potion", :return)
+      assert_text "Health Potion"
+
+      within("[id^='player_inventory_']") do
+        click_on "Health Potion"
+        assert_text "°"
+        assert_no_text "▓"
+      end
+    end
+
+    test "ASCII art renders inside sidebar, not chat output" do
+      visit dev_game_path
+      find(".terminal-input").click
+
+      find(".terminal-input").send_keys("take key", :return)
+      within("[id^='player_inventory_']") { assert_text "Rusty Key" }
+
+      within("[id^='player_inventory_']") do
+        click_on "Rusty Key"
+        assert_text "▓"
+      end
+
+      within("#message-content-wrapper") do
+        assert_no_text "▓"
+      end
+    end
+
+    test "empty inventory shows decorative empty-state art" do
+      visit dev_game_path
+
+      within("[id^='player_inventory_']") do
+        assert_text "thine sack lieth empty"
+        assert_selector "pre"
+      end
+    end
+  end
+end

--- a/test/system/qa_world/full_playthrough_test.rb
+++ b/test/system/qa_world/full_playthrough_test.rb
@@ -60,7 +60,7 @@ module QaWorld
         # Sidebar defaults to the Inventory tab and the empty inventory is visible.
         assert_button "Inventory"
         assert_button "Players"
-        within("[id^='player_inventory_']") { assert_text "(empty)" }
+        within("[id^='player_inventory_']") { assert_text "thine sack lieth empty" }
 
         # Inventory shortcut shows the client-only hint and clears on next command.
         cmd "i"
@@ -89,7 +89,7 @@ module QaWorld
           assert_text "Rusty Key"
           # Clicking the item in the sidebar expands its description inline.
           click_on "Rusty Key"
-          assert_text "An old rusty iron key"
+          assert_text "rusty iron key"
         end
 
         # Clicking the sidebar button moves focus; refocus the terminal so the


### PR DESCRIPTION
## Crazy Inventory

Upgrades the sidebar inventory from a plain list to a visually rich, expandable panel with ASCII art and lore descriptions for every item.

## What changed

- **`app/views/games/_inventory.html.erb`** — Fully refactored. Adds a decorative border-double frame with a centered "— Inventory —" header. Empty state shows an ASCII art sack with the flavour text "thine sack lieth empty". Non-empty state moves the `data-controller="inventory"` to the `<ul>` and delegates per-item rendering to the new partial.
- **`app/views/games/_inventory_item.html.erb`** — New partial. Each item renders as an expandable `<li>`: clicking the button reveals an optional ASCII art `<pre>` block (separated by a dashed `<hr>`) followed by the item's `detailed_description` (falls back to `description`, then a default string).
- **`app/javascript/controllers/inventory_controller.js`** — Rewritten toggle method. Uses `button.closest("li")` to scope toggle targets, rotates the caret glyph via `rotate-90`, and adds `is-open` to the `<li>` for styling hooks.
- **`test/support/qa_world_data.rb`** — Six ASCII art constants (`RUSTY_KEY_ART`, `GEM_ART`, `SWORD_ART`, `SHIELD_ART`, `POTION_ART`, `LOCKPICK_ART`) and matching lore helper methods added. All items in `self.items` now carry `ascii_art` and `detailed_description`.
- **`test/integration/inventory_partial_test.rb`** — New ActionView::TestCase exercising the partial in isolation: one test verifies ASCII art renders for items that have it (and only one `<pre>` for the one art-bearing item), the other verifies the empty-state `<pre>` and flavour text.
- **`test/system/qa_world/crazy_inventory_test.rb`** — New system test suite covering: art only appears after click, second item shows its own art, art stays in sidebar not chat, empty state renders decoratively.
- **`test/system/classic_game_test.rb`** — AC6 toggle test extended with `▓` sentinel assertions (before/after/after-collapse). AC1 and AC2 empty-state assertions updated to new text.
- **`test/system/qa_world/full_playthrough_test.rb`** — Empty-state and item-description assertions updated to match new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix notes (CI recovery round 1)

- **`test/integration/inventory_partial_test.rb`** — Switched `render template: "games/inventory"` to `render partial: "games/inventory"` in both tests. The view is `_inventory.html.erb` (a partial), so `template:` resolution couldn't find it and CI failed with `ActionView::MissingTemplate`. Using `partial:` correctly resolves the underscore-prefixed filename.

## Fix notes (CI recovery round 2)

- **`app/views/games/_inventory.html.erb`** — Changed `render "inventory_item", ...` to `render "games/inventory_item", ...`. Inside `ActionView::TestCase`, partial lookups are relative to the test case context (`action_view/test_case/test/`), not the `games/` folder, so the bare name failed with `Missing partial /_inventory_item` when `InventoryPartialTest` rendered `games/inventory`. Fully qualifying the path resolves it correctly in both the live request path and the isolated view test.

## Fix notes (CI recovery round 3)

- **`test/support/qa_world_data.rb`** — Cleared 9 rubocop offenses on the new ASCII-art constants:
  - **Style/RedundantFreeze** ×6 — Dropped `.freeze` from each `<<~ART.freeze` declaration. Frozen-string-literal magic comment already freezes string literals, so the explicit call was redundant.
  - **Layout/HeredocIndentation** ×2 — Dedented the bodies of `SWORD_ART` and `POTION_ART` so their minimum-indent line is exactly 2 spaces past the closing `ART` (the cop's default width). Visual layout of each glyph is preserved relative to the others.
  - **Style/RedundantStringEscape** ×1 — Replaced `\_____/` with `_____/` in `POTION_ART`. In a `<<~ART` heredoc the leading `\` was a no-op escape — Ruby strips unknown escapes — so the rendered art is unchanged.